### PR TITLE
fix(gnome-shell): obsolete EL10 gnome-shell-common to prevent file conflict

### DIFF
--- a/src/gnome-49/gnome-shell/gnome-shell.spec
+++ b/src/gnome-49/gnome-shell/gnome-shell.spec
@@ -211,6 +211,14 @@ Obsoletes:      python2-caribou < 0.4.21-10
 Obsoletes:      python3-caribou < 0.4.21-10
 %endif
 
+# EL10 ships a gnome-shell-common subpackage at version 48.x. This COPR
+# rebuilds gnome-shell as a monolithic package (no split common/) at v49,
+# so the shared data files (org.gnome.shell.gschema.xml, locale files,
+# etc.) now live in gnome-shell itself. Obsolete the older split package
+# so DNF auto-replaces it instead of aborting with a file-conflict.
+Obsoletes:      gnome-shell-common < %{major_version}
+Provides:       gnome-shell-common = %{version}-%{release}
+
 # https://bugzilla.redhat.com/show_bug.cgi?id=1740897
 Conflicts:      gnome-shell-extension-background-logo < 3.34.0
 

--- a/src/gnome-50/gnome-shell/gnome-shell.spec
+++ b/src/gnome-50/gnome-shell/gnome-shell.spec
@@ -162,6 +162,14 @@ Obsoletes:      python2-caribou < 0.4.21-10
 Obsoletes:      python3-caribou < 0.4.21-10
 %endif
 
+# EL10 ships a gnome-shell-common subpackage at version 48.x. This COPR
+# rebuilds gnome-shell as a monolithic package (no split common/) at v50,
+# so the shared data files (org.gnome.shell.gschema.xml, locale files,
+# etc.) now live in gnome-shell itself. Obsolete the older split package
+# so DNF auto-replaces it instead of aborting with a file-conflict.
+Obsoletes:      gnome-shell-common < %{major_version}
+Provides:       gnome-shell-common = %{version}-%{release}
+
 # https://bugzilla.redhat.com/show_bug.cgi?id=1740897
 Conflicts:      gnome-shell-extension-background-logo < 3.34.0
 


### PR DESCRIPTION
## Summary
- Add `Obsoletes: gnome-shell-common < %{major_version}` and matching `Provides:` to both the gnome-49 and gnome-50 spec files
- Lets DNF auto-replace the EL10-shipped `gnome-shell-common-48.3` (whose `gschema.xml` collides with this COPR's monolithic `gnome-shell-49/50`) instead of aborting with a transaction file-conflict

## Why
Downstream `tuna-os/tunaos` skipjack builds have been failing with:
```
Error: Transaction test error:
  file /usr/share/glib-2.0/schemas/org.gnome.shell.gschema.xml
  from install of gnome-shell-49.4-2.el10.x86_64 conflicts with
  file from package gnome-shell-common-48.3-7.el10.noarch
```
A workaround currently lives in `build_scripts/gnome.sh` of that repo ([commit](https://github.com/tuna-os/tunaos/commit/33e11a1)) that explicitly `dnf -y remove --noautoremove gnome-shell-common` before this COPR install. Once this PR lands and the COPR rebuilds, that workaround can be removed.

## Test plan
- [ ] COPR rebuild publishes new gnome-shell-49.x / 50.x packages
- [ ] On a fresh skipjack/yellowfin base, `dnf -y install --allowerasing gnome49-el10-compat` succeeds without first removing gnome-shell-common
- [ ] Existing GNOME Shell functionality unchanged (`gdm` starts, schemas compile, extensions load)
- [ ] `rpm -qf /usr/share/glib-2.0/schemas/org.gnome.shell.gschema.xml` reports `gnome-shell-49.x` (was `gnome-shell-common-48.x`)