### PR TITLE
fix(gnome-shell): pin runtime mutter to the exact build EVR (#27)

### DIFF
--- a/src/gnome-49/gnome-shell/gnome-shell.spec
+++ b/src/gnome-49/gnome-shell/gnome-shell.spec
@@ -77,6 +77,14 @@ Patch: 0001-el10-stub-gnome-qr.patch
 %define gtk4_version 4.0.0
 %define adwaita_version 1.5.0
 %define mutter_version 49.0
+# Lock the runtime mutter to the exact build the shell was compiled against.
+# mutter ships GObject-Introspection typelibs whose API can change behind a stable
+# version and SONAME (the el10 keymap backport in mutter-49.4-6 did exactly this),
+# so a ">= floor" does not stop a newer mutter drifting in under an unrebuilt shell
+# and crashing it at the introspection boundary. Capture the buildroot EVR instead
+# (mutter-devel pulls the exact mutter), with a ">= floor" fallback when mutter is
+# not installed, e.g. when the spec is parsed outside a buildroot. See issue #27.
+%global mutter_dep %(rpm -q --qf '= %%{version}-%%{release}' mutter 2>/dev/null | grep -q '^= ' && rpm -q --qf '= %%{version}-%%{release}' mutter || echo '>= %{mutter_version}')
 %define polkit_version 0.100
 %define gsettings_desktop_schemas_version 47~alpha
 %define ibus_version 1.5.2
@@ -139,7 +147,7 @@ Requires:       libadwaita%{_isa} >= %{adwaita_version}
 Requires:       libnma-gtk4%{?_isa}
 # needed for loading SVG's via gdk-pixbuf
 Requires:       librsvg2%{?_isa}
-Requires:       mutter%{?_isa} >= %{mutter_version}
+Requires:       mutter%{?_isa} %{mutter_dep}
 Requires:       upower%{?_isa}
 Requires:       polkit%{?_isa} >= %{polkit_version}
 Requires:       gnome-desktop4%{?_isa} >= %{gnome_desktop_version}

--- a/src/gnome-50/gnome-shell/gnome-shell.spec
+++ b/src/gnome-50/gnome-shell/gnome-shell.spec
@@ -31,6 +31,14 @@ Patch: 0001-gdm-Work-around-failing-fingerprint-auth.patch
 %define gtk4_version 4.0.0
 %define adwaita_version 1.5.0
 %define mutter_version 50.0
+# Lock the runtime mutter to the exact build the shell was compiled against.
+# mutter ships GObject-Introspection typelibs whose API can change behind a stable
+# version and SONAME (the el10 keymap backport in mutter-49.4-6 did exactly this on
+# gnome-49), so a ">= floor" does not stop a newer mutter drifting in under an
+# unrebuilt shell and crashing it at the introspection boundary. Capture the buildroot
+# EVR instead (mutter-devel pulls the exact mutter), with a ">= floor" fallback when
+# mutter is not installed, e.g. when the spec is parsed outside a buildroot. See issue #27.
+%global mutter_dep %(rpm -q --qf '= %%{version}-%%{release}' mutter 2>/dev/null | grep -q '^= ' && rpm -q --qf '= %%{version}-%%{release}' mutter || echo '>= %{mutter_version}')
 %define polkit_version 0.100
 %define gsettings_desktop_schemas_version 50~alpha
 %define ibus_version 1.5.2
@@ -91,7 +99,7 @@ Requires:       libadwaita%{_isa} >= %{adwaita_version}
 Requires:       libnma-gtk4%{?_isa}
 # needed for loading SVG's via gdk-pixbuf
 Requires:       librsvg2%{?_isa}
-Requires:       mutter%{?_isa} >= %{mutter_version}
+Requires:       mutter%{?_isa} %{mutter_dep}
 Requires:       upower%{?_isa}
 Requires:       polkit%{?_isa} >= %{polkit_version}
 Requires:       gnome-desktop4%{?_isa} >= %{gnome_desktop_version}


### PR DESCRIPTION
Fixes the class of bug in #27: gnome-shell drifting out of lockstep with mutter behind a stable version + SONAME, then crashing at the GObject-Introspection boundary.

## The problem, briefly

gnome-shell is JS, so it binds mutter's introspection typelib at runtime, not just the C ABI. mutter can change that typelib's API while keeping the same version and SONAME. The el10 keymap backport in `mutter-49.4-6` did exactly that (`set_keymap_async`: 6 args + string to 4 args + `MetaKeymapDescription`, still `libmutter-17.so.0`, still `49.4`). The shell's `Requires: mutter%{?_isa} >= 49.0` can't see it, so CS10's newer mutter installs under the unrebuilt COPR shell and the shell SIGSEGVs on boot. GDM crash-loops to a black screen.

A lower bound can't fix this by construction. The break is forward drift behind a version that already satisfies the floor, so any `>=` (even `>= 49.4-1`) is still satisfied by `49.4-6`. The RPM-native way to express a private/introspection ABI lockstep is an exact match against the mutter the shell was actually compiled against.

## The change

Capture the buildroot mutter EVR at build time and require exactly that:

```
%global mutter_dep %(rpm -q --qf '= %%{version}-%%{release}' mutter 2>/dev/null | grep -q '^= ' && rpm -q --qf '= %%{version}-%%{release}' mutter || echo '>= %{mutter_version}')
...
Requires:       mutter%{?_isa} %{mutter_dep}
```

`mutter-devel` (already a BuildRequires) pulls the exact mutter into the buildroot, so `rpm -q mutter` sees it. The macro stays unexpanded in the SRPM and re-evaluates in mock, so it picks up the real buildroot EVR, not whatever is (or isn't) on the SRPM builder. When mutter isn't installed (spec parsed outside a buildroot) it falls back to the old `>= %{mutter_version}` floor, so the SRPM/source path is unchanged.

Applied to both `gnome-49` and `gnome-50`. gnome-shell is the only package in the repo with a runtime mutter dep, so this covers the whole manifested class.

## What this does and doesn't do

- Stops the silent forward-drift: a published shell now requires the exact mutter it was built against, so dnf either keeps that matching mutter or fails loudly (the verify workflow's `dnf install gnome-shell mutter` would error) instead of shipping a shell that crashes at runtime.
- Does NOT repair an already-broken install. The immediate remedy from #27 (rebuild gnome-shell against current mutter) is still needed. This prevents recurrence.

## What I validated, and what I didn't

Validated locally with `rpmspec` (4.19.1) on the actual specs:
- Both parse clean (`rpmspec -P`), NVRs unchanged (`49.5-100.el10gnomeqr`, `50.0-3`).
- mutter installed -> `Requires: mutter(x86-64) = <EVR>` (RPMSENSE_EQUAL).
- mutter absent -> falls back to `Requires: mutter(x86-64) >= 49.0` / `>= 50.0` (RPMSENSE_GREATER|EQUAL), matching prior behavior.
- Extracted the spec from a test SRPM and confirmed the `%(rpm -q ...)` macro ships unexpanded, i.e. it evaluates in mock at build time, not on the SRPM builder.
- The `.copr/Makefile` source query (`rpmspec -q --qf %{SOURCE0}...`) is unaffected.

NOT validated: a real COPR build. I can't run one. The mock-buildroot evaluation is inferred from the unexpanded-macro behavior, not observed end to end.

## Trade-off / open question for maintainers

Exact-EVR means the shell holds the matching mutter and won't pick up a newer CS10 mutter z-stream (security/bugfix) until gnome-shell is rebuilt against it. For a bootc base image that wants a consistent GNOME this seems acceptable and arguably the intent, but it is a real constraint, so flagging it. If you'd rather not hold z-streams, the alternative is a CI trigger that rebuilds gnome-shell whenever mutter advances; that's a bigger change and out of scope here, and this pin would still be the backstop.

Also worth confirming: that the next gnome-shell build resolves CS10's current mutter in its buildroot (so it builds against and pins to the new API), which is the expected outcome on `epel-10-x86_64` but I haven't watched a build do it.