### PR TITLE
fix(gnome-shell): pin runtime mutter to exact build EVR + CI verification (#27)

### DIFF
--- a/.github/workflows/build-gnome49-verify.yml
+++ b/.github/workflows/build-gnome49-verify.yml
@@ -311,25 +311,47 @@ jobs:
                 #!/bin/bash
                 set -euxo pipefail
                 dnf -y install dnf-plugins-core python3-dnf-plugin-copr
-                # Enable COPR (which has the current gnome-shell/mutter pairing)
-                dnf copr enable -y jreilly1821/c10s-gnome-49
-                dnf -y install \
-                  gnome-shell \
-                  gnome-control-center \
-                  mutter \
-                  gdm \
-                  gnome-session-wayland-session \
-                  glib2
-                glib-compile-schemas /usr/share/glib-2.0/schemas/
                 printf '[daemon]\nWaylandEnable=true\n' > /etc/gdm/custom.conf
-                systemctl enable gdm
-                systemctl set-default graphical.target
           EOF
 
       - name: Start Lima VM
         run: |
           limactl start --name=gnome49-verify-copr /tmp/gnome49-verify-copr.yaml --timeout=25m
           echo "VM started"
+
+      - name: Enable COPR and install GNOME packages
+        run: |
+          echo "Enabling COPR..."
+          limactl shell gnome49-verify-copr -- sudo dnf copr enable -y jreilly1821/c10s-gnome-49
+          echo "Installing GNOME packages from COPR..."
+          limactl shell gnome49-verify-copr -- sudo dnf -y install \
+            gnome-shell \
+            gnome-control-center \
+            mutter \
+            gdm \
+            gnome-session-wayland-session \
+            glib2
+          echo "Post-install setup..."
+          limactl shell gnome49-verify-copr -- sudo glib-compile-schemas /usr/share/glib-2.0/schemas/
+          limactl shell gnome49-verify-copr -- sudo systemctl enable gdm
+          limactl shell gnome49-verify-copr -- sudo systemctl set-default graphical.target
+          echo "Packages installed:"
+          limactl shell gnome49-verify-copr -- rpm -q gdm gnome-shell mutter glib2
+
+      - name: Reboot VM to start GDM
+        run: |
+          echo "Rebooting VM to start GDM in graphical target..."
+          limactl shell gnome49-verify-copr -- sudo reboot || true
+          sleep 30
+          echo "Waiting for VM to come back after reboot..."
+          for i in $(seq 1 18); do
+            if limactl shell gnome49-verify-copr -- true 2>/dev/null; then
+              echo "VM is back after reboot"
+              break
+            fi
+            echo "Attempt $i/18: waiting for VM SSH..."
+            sleep 10
+          done
 
       - name: Wait for GDM to become active
         run: |

--- a/.github/workflows/build-gnome49-verify.yml
+++ b/.github/workflows/build-gnome49-verify.yml
@@ -249,3 +249,211 @@ jobs:
       - name: Stop Lima VM
         if: always()
         run: limactl stop gnome49-verify --force || true
+
+  verify-gdm-copr:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      issues: write
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+          ls -la /dev/kvm
+
+      - name: Install QEMU and Lima
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q qemu-system-x86 qemu-utils ovmf
+          LIMA_ASSET_URL=$(curl -s https://api.github.com/repos/lima-vm/lima/releases/latest | python3 -c "
+          import sys, json
+          data = json.load(sys.stdin)
+          for a in data['assets']:
+              if 'Linux-x86_64' in a['name'] and a['name'].endswith('.tar.gz'):
+                  print(a['browser_download_url'])
+                  break
+          ")
+          echo "Downloading Lima from ${LIMA_ASSET_URL}"
+          curl -fsSL "${LIMA_ASSET_URL}" | sudo tar xz -C /usr/local
+          limactl --version
+
+      - name: Install vncdotool
+        run: pip install vncdotool
+
+      - name: Create Lima VM config
+        run: |
+          cat > /tmp/gnome49-verify-copr.yaml << 'EOF'
+          vmType: qemu
+          arch: x86_64
+          cpus: 2
+          memory: 4GiB
+          disk: 20GiB
+
+          video:
+            display: "vnc"
+
+          images:
+            - location: "https://cloud.centos.org/centos/10-stream/x86_64/images/CentOS-Stream-GenericCloud-x86_64-10-latest.x86_64.qcow2"
+              arch: x86_64
+
+          mounts: []
+
+          ssh:
+            localPort: 0
+            loadDotSSHPubKeys: false
+
+          provision:
+            - mode: system
+              script: |
+                #!/bin/bash
+                set -euxo pipefail
+                dnf -y install dnf-plugins-core python3-dnf-plugin-copr
+                # Enable COPR (which has the current gnome-shell/mutter pairing)
+                dnf copr enable -y jreilly1821/c10s-gnome-49
+                dnf -y install \
+                  gnome-shell \
+                  gnome-control-center \
+                  mutter \
+                  gdm \
+                  gnome-session-wayland-session \
+                  glib2
+                glib-compile-schemas /usr/share/glib-2.0/schemas/
+                printf '[daemon]\nWaylandEnable=true\n' > /etc/gdm/custom.conf
+                systemctl enable gdm
+                systemctl set-default graphical.target
+          EOF
+
+      - name: Start Lima VM
+        run: |
+          limactl start --name=gnome49-verify-copr /tmp/gnome49-verify-copr.yaml --timeout=25m
+          echo "VM started"
+
+      - name: Wait for GDM to become active
+        run: |
+          echo "Waiting for GDM to start (up to 5 minutes)..."
+          for i in $(seq 1 30); do
+            STATUS=$(limactl shell gnome49-verify-copr -- systemctl is-active gdm 2>/dev/null || echo "inactive")
+            echo "Attempt $i/30: gdm is ${STATUS}"
+            [[ "${STATUS}" == "active" ]] && break
+            sleep 10
+          done
+          if [[ "${STATUS}" != "active" ]]; then
+            echo "ERROR: GDM failed to become active"
+            limactl shell gnome49-verify-copr -- sudo journalctl -u gdm --no-pager -n 50 || true
+            exit 1
+          fi
+
+      - name: Wait for gnome-shell greeter to be stable
+        run: |
+          echo "Waiting for gnome-shell greeter to start and stabilize (no crash-loop)..."
+          # GDM may be active while gnome-shell crash-loops behind it (#27).
+          # Poll for a gnome-shell PID; once found, wait 10s and confirm the PID
+          # hasn't changed. A changing PID means the greeter is crash-restart cycling.
+          STABLE=false
+          for i in $(seq 1 30); do
+            SHELL_PID=$(limactl shell gnome49-verify-copr -- pgrep -f 'gnome-shell.*gdm' 2>/dev/null | head -1 || true)
+            if [[ -z "${SHELL_PID}" ]]; then
+              echo "Attempt $i/30: gnome-shell not running yet"
+              sleep 10
+              continue
+            fi
+            echo "Attempt $i/30: gnome-shell PID=${SHELL_PID}, waiting 10s for stability check..."
+            sleep 10
+            SHELL_PID2=$(limactl shell gnome49-verify-copr -- pgrep -f 'gnome-shell.*gdm' 2>/dev/null | head -1 || true)
+            if [[ "${SHELL_PID}" == "${SHELL_PID2}" ]]; then
+              echo "gnome-shell PID stable at ${SHELL_PID} (survived 10s)"
+              STABLE=true
+              break
+            fi
+            echo "PID changed: ${SHELL_PID} -> ${SHELL_PID2} (crash-restart detected)"
+          done
+          if [[ "${STABLE}" != "true" ]]; then
+            echo "ERROR: gnome-shell greeter did not stabilize (crash-loop detected)"
+            limactl shell gnome49-verify-copr -- sudo journalctl -u gdm --no-pager -n 60 || true
+            exit 1
+          fi
+          echo "gnome-shell greeter is stable"
+
+      - name: Check GDM and GNOME Shell status
+        run: |
+          limactl shell gnome49-verify-copr -- systemctl status gdm --no-pager
+          limactl shell gnome49-verify-copr -- rpm -q gdm gnome-shell mutter glib2
+          limactl shell gnome49-verify-copr -- gdm --version
+
+      - name: Scan journal for gnome-shell crash signatures
+        id: crash-scan-copr
+        run: |
+          echo "Scanning journal for gnome-shell crash patterns..."
+          PATTERNS='SIGSEGV|SIGABRT|signal 11|Too many arguments|Expected an object of type.*MetaKeymapDescription'
+          limactl shell gnome49-verify-copr -- sudo journalctl -u gdm --no-pager | grep -E "${PATTERNS}" > /tmp/crash-matches.txt || true
+          CRASHES=$(wc -l < /tmp/crash-matches.txt)
+          echo "crash_matches=${CRASHES}" >> "${GITHUB_OUTPUT}"
+          echo "Crash-pattern matches: ${CRASHES}"
+          if [[ "${CRASHES}" -gt 0 ]]; then
+            echo "=== CRASH SIGNATURES FOUND ==="
+            cat /tmp/crash-matches.txt
+          else
+            echo "No gnome-shell crash patterns detected."
+          fi
+
+      - name: File regression issue from crash signatures
+        if: ${{ steps.crash-scan-copr.outputs.crash_matches != '0' }}
+        run: |
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          cat > /tmp/issue-body.md << BODYEOF
+          ## gnome-shell crash-loop regression detected (COPR)
+
+          The verify-gdm-copr VM test found **${{ steps.crash-scan-copr.outputs.crash_matches }}** gnome-shell crash signature(s) in the GDM journal.
+
+          **COPR project**: jreilly1821/c10s-gnome-49
+          **Workflow run**: ${RUN_URL}
+
+          ### Crash signatures
+
+          \`\`\`
+          $(cat /tmp/crash-matches.txt)
+          \`\`\`
+
+          ### What this means
+
+          gnome-shell is out of lockstep with mutter's GObject-Introspection typelib —
+          the same class of bug as #27. The COPR's gnome-shell was built against a
+          different mutter than the one installed at runtime.
+          BODYEOF
+          gh issue create \
+            --title "gnome-shell crash-loop regression (COPR CI catch)" \
+            --body-file /tmp/issue-body.md \
+            --label "bug" \
+            --label "ci-caught"
+          echo "Regression issue filed."
+          exit 1
+
+      - name: Take login screen screenshot via VNC
+        run: |
+          VNC_DISPLAY=$(cat /proc/$(pgrep -f 'qemu.*gnome49-verify-copr' | head -1)/cmdline \
+            | tr '\0' '\n' | grep -oP '(?<=vnc=127\.0\.0\.1:)\d+' || echo "0")
+          VNC_PORT=$((5900 + ${VNC_DISPLAY:-0}))
+          echo "VNC port: ${VNC_PORT}"
+          sleep 5
+          python3 - <<PYEOF
+          from vncdotool import api
+          client = api.connect('127.0.0.1', password='', port=${VNC_PORT})
+          client.captureScreen('gdm-login-screen-copr.png')
+          client.disconnect()
+          print("Screenshot captured")
+          PYEOF
+
+      - name: Upload login screen screenshot
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: gdm-login-screen-gnome49-copr
+          path: gdm-login-screen-copr.png
+          retention-days: 7
+
+      - name: Stop Lima VM
+        if: always()
+        run: limactl stop gnome49-verify-copr --force || true

--- a/.github/workflows/build-gnome49-verify.yml
+++ b/.github/workflows/build-gnome49-verify.yml
@@ -112,6 +112,21 @@ jobs:
           limactl start --name=gnome49-verify /tmp/gnome49-verify.yaml --timeout=25m
           echo "VM started"
 
+      - name: Reboot VM to start GDM
+        run: |
+          echo "Rebooting VM to start GDM in graphical target..."
+          limactl shell gnome49-verify -- sudo reboot || true
+          sleep 30
+          echo "Waiting for VM to come back after reboot..."
+          for i in $(seq 1 18); do
+            if limactl shell gnome49-verify -- true 2>/dev/null; then
+              echo "VM is back after reboot"
+              break
+            fi
+            echo "Attempt $i/18: waiting for VM SSH..."
+            sleep 10
+          done
+
       - name: Wait for GDM to become active
         run: |
           echo "Waiting for GDM to start (up to 5 minutes)..."

--- a/.github/workflows/build-gnome49-verify.yml
+++ b/.github/workflows/build-gnome49-verify.yml
@@ -50,13 +50,13 @@ jobs:
           sudo apt-get update -q
           sudo apt-get install -y -q qemu-system-x86 qemu-utils ovmf
           LIMA_ASSET_URL=$(curl -s https://api.github.com/repos/lima-vm/lima/releases/latest | python3 -c "
-import sys, json
-data = json.load(sys.stdin)
-for a in data['assets']:
-    if 'Linux-x86_64' in a['name'] and a['name'].endswith('.tar.gz'):
-        print(a['browser_download_url'])
-        break
-")
+          import sys, json
+          data = json.load(sys.stdin)
+          for a in data['assets']:
+              if 'Linux-x86_64' in a['name'] and a['name'].endswith('.tar.gz'):
+                  print(a['browser_download_url'])
+                  break
+          ")
           echo "Downloading Lima from ${LIMA_ASSET_URL}"
           curl -fsSL "${LIMA_ASSET_URL}" | sudo tar xz -C /usr/local
           limactl --version

--- a/.github/workflows/build-gnome49-verify.yml
+++ b/.github/workflows/build-gnome49-verify.yml
@@ -5,6 +5,8 @@ on:
     workflows: ["GNOME 49 Distributed Build and Publish"]
     types: [completed]
   workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize]
 
 jobs:
   verify-repo:
@@ -142,12 +144,10 @@ jobs:
             exit 1
           fi
 
-      - name: Wait for gnome-shell greeter to be stable
+      - name: Check gnome-shell greeter stability
+        id: greeter-check
         run: |
-          echo "Waiting for gnome-shell greeter to start and stabilize (no crash-loop)..."
-          # GDM may be active while gnome-shell crash-loops behind it (#27).
-          # Poll for a gnome-shell PID; once found, wait 10s and confirm the PID
-          # hasn't changed. A changing PID means the greeter is crash-restart cycling.
+          echo "Checking gnome-shell greeter stability (no crash-loop)..."
           STABLE=false
           for i in $(seq 1 30); do
             SHELL_PID=$(limactl shell gnome49-verify -- pgrep -f 'gnome-shell.*gdm' 2>/dev/null | head -1 || true)
@@ -166,29 +166,23 @@ jobs:
             fi
             echo "PID changed: ${SHELL_PID} -> ${SHELL_PID2} (crash-restart detected)"
           done
-          if [[ "${STABLE}" != "true" ]]; then
-            echo "ERROR: gnome-shell greeter did not stabilize (crash-loop detected)"
-            limactl shell gnome49-verify -- sudo journalctl -u gdm --no-pager -n 60 || true
-            exit 1
+          echo "greeter_stable=${STABLE}" >> "${GITHUB_OUTPUT}"
+          if [[ "${STABLE}" == "true" ]]; then
+            echo "gnome-shell greeter is stable"
+          else
+            echo "CRASH-LOOP DETECTED: gnome-shell greeter did not stabilize"
           fi
-          echo "gnome-shell greeter is stable"
 
       - name: Check GDM and GNOME Shell status
         run: |
-          limactl shell gnome49-verify -- systemctl status gdm --no-pager
+          limactl shell gnome49-verify -- systemctl status gdm --no-pager || true
           limactl shell gnome49-verify -- rpm -q gdm gnome-shell mutter glib2
-          limactl shell gnome49-verify -- gdm --version
 
       - name: Scan journal for gnome-shell crash signatures
         id: crash-scan
         run: |
           echo "Scanning journal for gnome-shell crash patterns..."
-          # Patterns that indicate the #27 class of bug (gnome-shell/mutter
-          # GObject-Introspection ABI mismatch behind a stable SONAME):
-          # - SIGSEGV / SIGABRT / signal 11: hard crashes
-          # - "Too many arguments": GJS introspection argument count mismatch
-          # - "Expected an object of type MetaKeymapDescription": type coercion failure
-          PATTERNS='SIGSEGV|SIGABRT|signal 11|Too many arguments|Expected an object of type.*MetaKeymapDescription'
+          PATTERNS='SIGSEGV|SIGABRT|signal 11|Too many arguments|Expected an object of type.*MetaKeymapDescription|Session never registered|Child process.*already dead|maximum number of.*display failures'
           limactl shell gnome49-verify -- sudo journalctl -u gdm --no-pager | grep -E "${PATTERNS}" > /tmp/crash-matches.txt || true
           CRASHES=$(wc -l < /tmp/crash-matches.txt)
           echo "crash_matches=${CRASHES}" >> "${GITHUB_OUTPUT}"
@@ -200,38 +194,36 @@ jobs:
             echo "No gnome-shell crash patterns detected."
           fi
 
-      - name: File regression issue from crash signatures
-        if: ${{ steps.crash-scan.outputs.crash_matches != '0' }}
+      - name: Check results and file issue if broken
         run: |
+          STABLE="${{ steps.greeter-check.outputs.greeter_stable }}"
+          CRASHES="${{ steps.crash-scan.outputs.crash_matches }}"
+          if [[ "${STABLE}" == "true" && "${CRASHES}" == "0" ]]; then
+            echo "PASSED: gnome-shell greeter stable, no crash patterns"
+            exit 0
+          fi
+          echo "FAILED: gnome-shell login broken"
+          echo "  greeter stable: ${STABLE}"
+          echo "  crash patterns: ${CRASHES}"
           RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           cat > /tmp/issue-body.md << BODYEOF
-          ## gnome-shell crash-loop regression detected
-
-          The verify-gdm VM test found **${{ steps.crash-scan.outputs.crash_matches }}** gnome-shell crash signature(s) in the GDM journal.
+          ## gnome-shell crash-loop detected (dev-repo CI)
 
           **Workflow run**: ${RUN_URL}
 
-          ### Crash signatures
+          ### Findings
+
+          - Greeter PID stable: ${STABLE}
+          - Crash pattern matches: ${CRASHES}
+
+          ### Journal evidence
 
           \`\`\`
-          $(cat /tmp/crash-matches.txt)
+          $(limactl shell gnome49-verify -- sudo journalctl -u gdm --no-pager -n 30 2>/dev/null || echo "(journal unavailable)")
           \`\`\`
-
-          ### What this means
-
-          gnome-shell is likely out of lockstep with mutter's GObject-Introspection typelib —
-          the same class of bug as #27. The shell was built against a different mutter
-          than the one installed at runtime, and the typelib API changed behind a stable
-          version/SONAME.
-
-          ### Action
-
-          Rebuild gnome-shell against the current mutter in the buildroot. The
-          exact-EVR pin from the spec should prevent this from reaching users, but
-          if this fired from CI, the pin may not have been enough.
           BODYEOF
           gh issue create \
-            --title "gnome-shell crash-loop regression (verify-gdm CI catch)" \
+            --title "gnome-shell crash-loop regression (dev-repo CI catch)" \
             --body-file /tmp/issue-body.md \
             --label "bug" \
             --label "ci-caught"

--- a/.github/workflows/build-gnome49-verify.yml
+++ b/.github/workflows/build-gnome49-verify.yml
@@ -49,9 +49,16 @@ jobs:
         run: |
           sudo apt-get update -q
           sudo apt-get install -y -q qemu-system-x86 qemu-utils ovmf
-          LIMA_VERSION=$(curl -s https://api.github.com/repos/lima-vm/lima/releases/latest | python3 -c "import sys,json; print(json.load(sys.stdin)['tag_name'])")
-          echo "Installing Lima ${LIMA_VERSION}"
-          curl -fsSL "https://github.com/lima-vm/lima/releases/download/${LIMA_VERSION}/lima-${LIMA_VERSION#v}-linux-amd64.tar.gz" | sudo tar xz -C /usr/local
+          LIMA_ASSET_URL=$(curl -s https://api.github.com/repos/lima-vm/lima/releases/latest | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for a in data['assets']:
+    if 'Linux-x86_64' in a['name'] and a['name'].endswith('.tar.gz'):
+        print(a['browser_download_url'])
+        break
+")
+          echo "Downloading Lima from ${LIMA_ASSET_URL}"
+          curl -fsSL "${LIMA_ASSET_URL}" | sudo tar xz -C /usr/local
           limactl --version
 
       - name: Install vncdotool

--- a/.github/workflows/build-gnome49-verify.yml
+++ b/.github/workflows/build-gnome49-verify.yml
@@ -75,7 +75,6 @@ jobs:
 
           video:
             display: "vnc"
-            vga: "std"
 
           images:
             - location: "https://cloud.centos.org/centos/10-stream/x86_64/images/CentOS-Stream-GenericCloud-x86_64-10-latest.x86_64.qcow2"
@@ -124,7 +123,7 @@ jobs:
           done
           if [[ "${STATUS}" != "active" ]]; then
             echo "ERROR: GDM failed to become active"
-            limactl shell gnome49-verify -- journalctl -u gdm --no-pager -n 50 || true
+            limactl shell gnome49-verify -- sudo journalctl -u gdm --no-pager -n 50 || true
             exit 1
           fi
 
@@ -154,7 +153,7 @@ jobs:
           done
           if [[ "${STABLE}" != "true" ]]; then
             echo "ERROR: gnome-shell greeter did not stabilize (crash-loop detected)"
-            limactl shell gnome49-verify -- journalctl -u gdm --no-pager -n 60 || true
+            limactl shell gnome49-verify -- sudo journalctl -u gdm --no-pager -n 60 || true
             exit 1
           fi
           echo "gnome-shell greeter is stable"
@@ -175,7 +174,7 @@ jobs:
           # - "Too many arguments": GJS introspection argument count mismatch
           # - "Expected an object of type MetaKeymapDescription": type coercion failure
           PATTERNS='SIGSEGV|SIGABRT|signal 11|Too many arguments|Expected an object of type.*MetaKeymapDescription'
-          limactl shell gnome49-verify -- journalctl -u gdm --no-pager | grep -E "${PATTERNS}" > /tmp/crash-matches.txt || true
+          limactl shell gnome49-verify -- sudo journalctl -u gdm --no-pager | grep -E "${PATTERNS}" > /tmp/crash-matches.txt || true
           CRASHES=$(wc -l < /tmp/crash-matches.txt)
           echo "crash_matches=${CRASHES}" >> "${GITHUB_OUTPUT}"
           echo "Crash-pattern matches: ${CRASHES}"

--- a/.github/workflows/build-gnome49-verify.yml
+++ b/.github/workflows/build-gnome49-verify.yml
@@ -34,6 +34,8 @@ jobs:
   verify-gdm:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      issues: write
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Enable KVM
@@ -119,11 +121,101 @@ jobs:
             exit 1
           fi
 
+      - name: Wait for gnome-shell greeter to be stable
+        run: |
+          echo "Waiting for gnome-shell greeter to start and stabilize (no crash-loop)..."
+          # GDM may be active while gnome-shell crash-loops behind it (#27).
+          # Poll for a gnome-shell PID; once found, wait 10s and confirm the PID
+          # hasn't changed. A changing PID means the greeter is crash-restart cycling.
+          STABLE=false
+          for i in $(seq 1 30); do
+            SHELL_PID=$(limactl shell gnome49-verify -- pgrep -f 'gnome-shell.*gdm' 2>/dev/null | head -1 || true)
+            if [[ -z "${SHELL_PID}" ]]; then
+              echo "Attempt $i/30: gnome-shell not running yet"
+              sleep 10
+              continue
+            fi
+            echo "Attempt $i/30: gnome-shell PID=${SHELL_PID}, waiting 10s for stability check..."
+            sleep 10
+            SHELL_PID2=$(limactl shell gnome49-verify -- pgrep -f 'gnome-shell.*gdm' 2>/dev/null | head -1 || true)
+            if [[ "${SHELL_PID}" == "${SHELL_PID2}" ]]; then
+              echo "gnome-shell PID stable at ${SHELL_PID} (survived 10s)"
+              STABLE=true
+              break
+            fi
+            echo "PID changed: ${SHELL_PID} -> ${SHELL_PID2} (crash-restart detected)"
+          done
+          if [[ "${STABLE}" != "true" ]]; then
+            echo "ERROR: gnome-shell greeter did not stabilize (crash-loop detected)"
+            limactl shell gnome49-verify -- journalctl -u gdm --no-pager -n 60 || true
+            exit 1
+          fi
+          echo "gnome-shell greeter is stable"
+
       - name: Check GDM and GNOME Shell status
         run: |
           limactl shell gnome49-verify -- systemctl status gdm --no-pager
           limactl shell gnome49-verify -- rpm -q gdm gnome-shell mutter glib2
           limactl shell gnome49-verify -- gdm --version
+
+      - name: Scan journal for gnome-shell crash signatures
+        id: crash-scan
+        run: |
+          echo "Scanning journal for gnome-shell crash patterns..."
+          # Patterns that indicate the #27 class of bug (gnome-shell/mutter
+          # GObject-Introspection ABI mismatch behind a stable SONAME):
+          # - SIGSEGV / SIGABRT / signal 11: hard crashes
+          # - "Too many arguments": GJS introspection argument count mismatch
+          # - "Expected an object of type MetaKeymapDescription": type coercion failure
+          PATTERNS='SIGSEGV|SIGABRT|signal 11|Too many arguments|Expected an object of type.*MetaKeymapDescription'
+          limactl shell gnome49-verify -- journalctl -u gdm --no-pager | grep -E "${PATTERNS}" > /tmp/crash-matches.txt || true
+          CRASHES=$(wc -l < /tmp/crash-matches.txt)
+          echo "crash_matches=${CRASHES}" >> "${GITHUB_OUTPUT}"
+          echo "Crash-pattern matches: ${CRASHES}"
+          if [[ "${CRASHES}" -gt 0 ]]; then
+            echo "=== CRASH SIGNATURES FOUND ==="
+            cat /tmp/crash-matches.txt
+          else
+            echo "No gnome-shell crash patterns detected."
+          fi
+
+      - name: File regression issue from crash signatures
+        if: ${{ steps.crash-scan.outputs.crash_matches != '0' }}
+        run: |
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          cat > /tmp/issue-body.md << BODYEOF
+          ## gnome-shell crash-loop regression detected
+
+          The verify-gdm VM test found **${{ steps.crash-scan.outputs.crash_matches }}** gnome-shell crash signature(s) in the GDM journal.
+
+          **Workflow run**: ${RUN_URL}
+
+          ### Crash signatures
+
+          \`\`\`
+          $(cat /tmp/crash-matches.txt)
+          \`\`\`
+
+          ### What this means
+
+          gnome-shell is likely out of lockstep with mutter's GObject-Introspection typelib —
+          the same class of bug as #27. The shell was built against a different mutter
+          than the one installed at runtime, and the typelib API changed behind a stable
+          version/SONAME.
+
+          ### Action
+
+          Rebuild gnome-shell against the current mutter in the buildroot. The
+          exact-EVR pin from the spec should prevent this from reaching users, but
+          if this fired from CI, the pin may not have been enough.
+          BODYEOF
+          gh issue create \
+            --title "gnome-shell crash-loop regression (verify-gdm CI catch)" \
+            --body-file /tmp/issue-body.md \
+            --label "bug" \
+            --label "ci-caught"
+          echo "Regression issue filed."
+          exit 1
 
       - name: Take login screen screenshot via VNC
         run: |

--- a/.github/workflows/build-gnome49-verify.yml
+++ b/.github/workflows/build-gnome49-verify.yml
@@ -383,12 +383,12 @@ jobs:
             exit 1
           fi
 
-      - name: Wait for gnome-shell greeter to be stable
+      - name: Check gnome-shell greeter stability
+        id: greeter-check
         run: |
-          echo "Waiting for gnome-shell greeter to start and stabilize (no crash-loop)..."
+          echo "Checking gnome-shell greeter stability (no crash-loop)..."
           # GDM may be active while gnome-shell crash-loops behind it (#27).
-          # Poll for a gnome-shell PID; once found, wait 10s and confirm the PID
-          # hasn't changed. A changing PID means the greeter is crash-restart cycling.
+          # Poll for a gnome-shell PID; once found, wait 10s and confirm it survives.
           STABLE=false
           for i in $(seq 1 30); do
             SHELL_PID=$(limactl shell gnome49-verify-copr -- pgrep -f 'gnome-shell.*gdm' 2>/dev/null | head -1 || true)
@@ -407,24 +407,24 @@ jobs:
             fi
             echo "PID changed: ${SHELL_PID} -> ${SHELL_PID2} (crash-restart detected)"
           done
-          if [[ "${STABLE}" != "true" ]]; then
-            echo "ERROR: gnome-shell greeter did not stabilize (crash-loop detected)"
-            limactl shell gnome49-verify-copr -- sudo journalctl -u gdm --no-pager -n 60 || true
-            exit 1
+          echo "greeter_stable=${STABLE}" >> "${GITHUB_OUTPUT}"
+          if [[ "${STABLE}" == "true" ]]; then
+            echo "gnome-shell greeter is stable"
+          else
+            echo "CRASH-LOOP DETECTED: gnome-shell greeter did not stabilize"
           fi
-          echo "gnome-shell greeter is stable"
 
       - name: Check GDM and GNOME Shell status
         run: |
-          limactl shell gnome49-verify-copr -- systemctl status gdm --no-pager
+          limactl shell gnome49-verify-copr -- systemctl status gdm --no-pager || true
           limactl shell gnome49-verify-copr -- rpm -q gdm gnome-shell mutter glib2
-          limactl shell gnome49-verify-copr -- gdm --version
 
       - name: Scan journal for gnome-shell crash signatures
         id: crash-scan-copr
         run: |
           echo "Scanning journal for gnome-shell crash patterns..."
-          PATTERNS='SIGSEGV|SIGABRT|signal 11|Too many arguments|Expected an object of type.*MetaKeymapDescription'
+          # Include GDM's own messages about failed session starts
+          PATTERNS='SIGSEGV|SIGABRT|signal 11|Too many arguments|Expected an object of type.*MetaKeymapDescription|Session never registered|Child process.*already dead|maximum number of.*display failures'
           limactl shell gnome49-verify-copr -- sudo journalctl -u gdm --no-pager | grep -E "${PATTERNS}" > /tmp/crash-matches.txt || true
           CRASHES=$(wc -l < /tmp/crash-matches.txt)
           echo "crash_matches=${CRASHES}" >> "${GITHUB_OUTPUT}"
@@ -436,29 +436,35 @@ jobs:
             echo "No gnome-shell crash patterns detected."
           fi
 
-      - name: File regression issue from crash signatures
-        if: ${{ steps.crash-scan-copr.outputs.crash_matches != '0' }}
+      - name: Check results and file issue if broken
         run: |
+          STABLE="${{ steps.greeter-check.outputs.greeter_stable }}"
+          CRASHES="${{ steps.crash-scan-copr.outputs.crash_matches }}"
+          if [[ "${STABLE}" == "true" && "${CRASHES}" == "0" ]]; then
+            echo "PASSED: gnome-shell greeter stable, no crash patterns"
+            exit 0
+          fi
+          echo "FAILED: gnome-shell login broken"
+          echo "  greeter stable: ${STABLE}"
+          echo "  crash patterns: ${CRASHES}"
+          # File an issue with the evidence
           RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           cat > /tmp/issue-body.md << BODYEOF
-          ## gnome-shell crash-loop regression detected (COPR)
-
-          The verify-gdm-copr VM test found **${{ steps.crash-scan-copr.outputs.crash_matches }}** gnome-shell crash signature(s) in the GDM journal.
+          ## gnome-shell crash-loop detected (COPR CI)
 
           **COPR project**: jreilly1821/c10s-gnome-49
           **Workflow run**: ${RUN_URL}
 
-          ### Crash signatures
+          ### Findings
+
+          - Greeter PID stable: ${STABLE}
+          - Crash pattern matches: ${CRASHES}
+
+          ### Journal evidence
 
           \`\`\`
-          $(cat /tmp/crash-matches.txt)
+          $(limactl shell gnome49-verify-copr -- sudo journalctl -u gdm --no-pager -n 30 2>/dev/null || echo "(journal unavailable)")
           \`\`\`
-
-          ### What this means
-
-          gnome-shell is out of lockstep with mutter's GObject-Introspection typelib —
-          the same class of bug as #27. The COPR's gnome-shell was built against a
-          different mutter than the one installed at runtime.
           BODYEOF
           gh issue create \
             --title "gnome-shell crash-loop regression (COPR CI catch)" \

--- a/.github/workflows/build-gnome50-verify.yml
+++ b/.github/workflows/build-gnome50-verify.yml
@@ -34,6 +34,8 @@ jobs:
   verify-gdm:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      issues: write
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Enable KVM
@@ -119,11 +121,101 @@ jobs:
             exit 1
           fi
 
+      - name: Wait for gnome-shell greeter to be stable
+        run: |
+          echo "Waiting for gnome-shell greeter to start and stabilize (no crash-loop)..."
+          # GDM may be active while gnome-shell crash-loops behind it (#27).
+          # Poll for a gnome-shell PID; once found, wait 10s and confirm the PID
+          # hasn't changed. A changing PID means the greeter is crash-restart cycling.
+          STABLE=false
+          for i in $(seq 1 30); do
+            SHELL_PID=$(limactl shell gnome50-verify -- pgrep -f 'gnome-shell.*gdm' 2>/dev/null | head -1 || true)
+            if [[ -z "${SHELL_PID}" ]]; then
+              echo "Attempt $i/30: gnome-shell not running yet"
+              sleep 10
+              continue
+            fi
+            echo "Attempt $i/30: gnome-shell PID=${SHELL_PID}, waiting 10s for stability check..."
+            sleep 10
+            SHELL_PID2=$(limactl shell gnome50-verify -- pgrep -f 'gnome-shell.*gdm' 2>/dev/null | head -1 || true)
+            if [[ "${SHELL_PID}" == "${SHELL_PID2}" ]]; then
+              echo "gnome-shell PID stable at ${SHELL_PID} (survived 10s)"
+              STABLE=true
+              break
+            fi
+            echo "PID changed: ${SHELL_PID} -> ${SHELL_PID2} (crash-restart detected)"
+          done
+          if [[ "${STABLE}" != "true" ]]; then
+            echo "ERROR: gnome-shell greeter did not stabilize (crash-loop detected)"
+            limactl shell gnome50-verify -- journalctl -u gdm --no-pager -n 60 || true
+            exit 1
+          fi
+          echo "gnome-shell greeter is stable"
+
       - name: Check GDM and GNOME Shell status
         run: |
           limactl shell gnome50-verify -- systemctl status gdm --no-pager
           limactl shell gnome50-verify -- rpm -q gdm gnome-shell mutter glib2
           limactl shell gnome50-verify -- gdm --version
+
+      - name: Scan journal for gnome-shell crash signatures
+        id: crash-scan
+        run: |
+          echo "Scanning journal for gnome-shell crash patterns..."
+          # Patterns that indicate the #27 class of bug (gnome-shell/mutter
+          # GObject-Introspection ABI mismatch behind a stable SONAME):
+          # - SIGSEGV / SIGABRT / signal 11: hard crashes
+          # - "Too many arguments": GJS introspection argument count mismatch
+          # - "Expected an object of type MetaKeymapDescription": type coercion failure
+          PATTERNS='SIGSEGV|SIGABRT|signal 11|Too many arguments|Expected an object of type.*MetaKeymapDescription'
+          limactl shell gnome50-verify -- journalctl -u gdm --no-pager | grep -E "${PATTERNS}" > /tmp/crash-matches.txt || true
+          CRASHES=$(wc -l < /tmp/crash-matches.txt)
+          echo "crash_matches=${CRASHES}" >> "${GITHUB_OUTPUT}"
+          echo "Crash-pattern matches: ${CRASHES}"
+          if [[ "${CRASHES}" -gt 0 ]]; then
+            echo "=== CRASH SIGNATURES FOUND ==="
+            cat /tmp/crash-matches.txt
+          else
+            echo "No gnome-shell crash patterns detected."
+          fi
+
+      - name: File regression issue from crash signatures
+        if: ${{ steps.crash-scan.outputs.crash_matches != '0' }}
+        run: |
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          cat > /tmp/issue-body.md << BODYEOF
+          ## gnome-shell crash-loop regression detected
+
+          The verify-gdm VM test found **${{ steps.crash-scan.outputs.crash_matches }}** gnome-shell crash signature(s) in the GDM journal.
+
+          **Workflow run**: ${RUN_URL}
+
+          ### Crash signatures
+
+          \`\`\`
+          $(cat /tmp/crash-matches.txt)
+          \`\`\`
+
+          ### What this means
+
+          gnome-shell is likely out of lockstep with mutter's GObject-Introspection typelib —
+          the same class of bug as #27. The shell was built against a different mutter
+          than the one installed at runtime, and the typelib API changed behind a stable
+          version/SONAME.
+
+          ### Action
+
+          Rebuild gnome-shell against the current mutter in the buildroot. The
+          exact-EVR pin from the spec should prevent this from reaching users, but
+          if this fired from CI, the pin may not have been enough.
+          BODYEOF
+          gh issue create \
+            --title "gnome-shell crash-loop regression (verify-gdm CI catch)" \
+            --body-file /tmp/issue-body.md \
+            --label "bug" \
+            --label "ci-caught"
+          echo "Regression issue filed."
+          exit 1
 
       - name: Take login screen screenshot via VNC
         run: |

--- a/.github/workflows/build-gnome50-verify.yml
+++ b/.github/workflows/build-gnome50-verify.yml
@@ -75,7 +75,6 @@ jobs:
 
           video:
             display: "vnc"
-            vga: "std"
 
           images:
             - location: "https://cloud.centos.org/centos/10-stream/x86_64/images/CentOS-Stream-GenericCloud-x86_64-10-latest.x86_64.qcow2"
@@ -124,7 +123,7 @@ jobs:
           done
           if [[ "${STATUS}" != "active" ]]; then
             echo "ERROR: GDM failed to become active"
-            limactl shell gnome50-verify -- journalctl -u gdm --no-pager -n 50 || true
+            limactl shell gnome50-verify -- sudo journalctl -u gdm --no-pager -n 50 || true
             exit 1
           fi
 
@@ -154,7 +153,7 @@ jobs:
           done
           if [[ "${STABLE}" != "true" ]]; then
             echo "ERROR: gnome-shell greeter did not stabilize (crash-loop detected)"
-            limactl shell gnome50-verify -- journalctl -u gdm --no-pager -n 60 || true
+            limactl shell gnome50-verify -- sudo journalctl -u gdm --no-pager -n 60 || true
             exit 1
           fi
           echo "gnome-shell greeter is stable"
@@ -175,7 +174,7 @@ jobs:
           # - "Too many arguments": GJS introspection argument count mismatch
           # - "Expected an object of type MetaKeymapDescription": type coercion failure
           PATTERNS='SIGSEGV|SIGABRT|signal 11|Too many arguments|Expected an object of type.*MetaKeymapDescription'
-          limactl shell gnome50-verify -- journalctl -u gdm --no-pager | grep -E "${PATTERNS}" > /tmp/crash-matches.txt || true
+          limactl shell gnome50-verify -- sudo journalctl -u gdm --no-pager | grep -E "${PATTERNS}" > /tmp/crash-matches.txt || true
           CRASHES=$(wc -l < /tmp/crash-matches.txt)
           echo "crash_matches=${CRASHES}" >> "${GITHUB_OUTPUT}"
           echo "Crash-pattern matches: ${CRASHES}"

--- a/.github/workflows/build-gnome50-verify.yml
+++ b/.github/workflows/build-gnome50-verify.yml
@@ -50,13 +50,13 @@ jobs:
           sudo apt-get update -q
           sudo apt-get install -y -q qemu-system-x86 qemu-utils ovmf
           LIMA_ASSET_URL=$(curl -s https://api.github.com/repos/lima-vm/lima/releases/latest | python3 -c "
-import sys, json
-data = json.load(sys.stdin)
-for a in data['assets']:
-    if 'Linux-x86_64' in a['name'] and a['name'].endswith('.tar.gz'):
-        print(a['browser_download_url'])
-        break
-")
+          import sys, json
+          data = json.load(sys.stdin)
+          for a in data['assets']:
+              if 'Linux-x86_64' in a['name'] and a['name'].endswith('.tar.gz'):
+                  print(a['browser_download_url'])
+                  break
+          ")
           echo "Downloading Lima from ${LIMA_ASSET_URL}"
           curl -fsSL "${LIMA_ASSET_URL}" | sudo tar xz -C /usr/local
           limactl --version

--- a/.github/workflows/build-gnome50-verify.yml
+++ b/.github/workflows/build-gnome50-verify.yml
@@ -5,6 +5,8 @@ on:
     workflows: ["GNOME 50 Distributed Build and Publish"]
     types: [completed]
   workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize]
 
 jobs:
   verify-repo:
@@ -127,12 +129,10 @@ jobs:
             exit 1
           fi
 
-      - name: Wait for gnome-shell greeter to be stable
+      - name: Check gnome-shell greeter stability
+        id: greeter-check
         run: |
-          echo "Waiting for gnome-shell greeter to start and stabilize (no crash-loop)..."
-          # GDM may be active while gnome-shell crash-loops behind it (#27).
-          # Poll for a gnome-shell PID; once found, wait 10s and confirm the PID
-          # hasn't changed. A changing PID means the greeter is crash-restart cycling.
+          echo "Checking gnome-shell greeter stability (no crash-loop)..."
           STABLE=false
           for i in $(seq 1 30); do
             SHELL_PID=$(limactl shell gnome50-verify -- pgrep -f 'gnome-shell.*gdm' 2>/dev/null | head -1 || true)
@@ -151,29 +151,23 @@ jobs:
             fi
             echo "PID changed: ${SHELL_PID} -> ${SHELL_PID2} (crash-restart detected)"
           done
-          if [[ "${STABLE}" != "true" ]]; then
-            echo "ERROR: gnome-shell greeter did not stabilize (crash-loop detected)"
-            limactl shell gnome50-verify -- sudo journalctl -u gdm --no-pager -n 60 || true
-            exit 1
+          echo "greeter_stable=${STABLE}" >> "${GITHUB_OUTPUT}"
+          if [[ "${STABLE}" == "true" ]]; then
+            echo "gnome-shell greeter is stable"
+          else
+            echo "CRASH-LOOP DETECTED: gnome-shell greeter did not stabilize"
           fi
-          echo "gnome-shell greeter is stable"
 
       - name: Check GDM and GNOME Shell status
         run: |
-          limactl shell gnome50-verify -- systemctl status gdm --no-pager
+          limactl shell gnome50-verify -- systemctl status gdm --no-pager || true
           limactl shell gnome50-verify -- rpm -q gdm gnome-shell mutter glib2
-          limactl shell gnome50-verify -- gdm --version
 
       - name: Scan journal for gnome-shell crash signatures
         id: crash-scan
         run: |
           echo "Scanning journal for gnome-shell crash patterns..."
-          # Patterns that indicate the #27 class of bug (gnome-shell/mutter
-          # GObject-Introspection ABI mismatch behind a stable SONAME):
-          # - SIGSEGV / SIGABRT / signal 11: hard crashes
-          # - "Too many arguments": GJS introspection argument count mismatch
-          # - "Expected an object of type MetaKeymapDescription": type coercion failure
-          PATTERNS='SIGSEGV|SIGABRT|signal 11|Too many arguments|Expected an object of type.*MetaKeymapDescription'
+          PATTERNS='SIGSEGV|SIGABRT|signal 11|Too many arguments|Expected an object of type.*MetaKeymapDescription|Session never registered|Child process.*already dead|maximum number of.*display failures'
           limactl shell gnome50-verify -- sudo journalctl -u gdm --no-pager | grep -E "${PATTERNS}" > /tmp/crash-matches.txt || true
           CRASHES=$(wc -l < /tmp/crash-matches.txt)
           echo "crash_matches=${CRASHES}" >> "${GITHUB_OUTPUT}"
@@ -185,38 +179,36 @@ jobs:
             echo "No gnome-shell crash patterns detected."
           fi
 
-      - name: File regression issue from crash signatures
-        if: ${{ steps.crash-scan.outputs.crash_matches != '0' }}
+      - name: Check results and file issue if broken
         run: |
+          STABLE="${{ steps.greeter-check.outputs.greeter_stable }}"
+          CRASHES="${{ steps.crash-scan.outputs.crash_matches }}"
+          if [[ "${STABLE}" == "true" && "${CRASHES}" == "0" ]]; then
+            echo "PASSED: gnome-shell greeter stable, no crash patterns"
+            exit 0
+          fi
+          echo "FAILED: gnome-shell login broken"
+          echo "  greeter stable: ${STABLE}"
+          echo "  crash patterns: ${CRASHES}"
           RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           cat > /tmp/issue-body.md << BODYEOF
-          ## gnome-shell crash-loop regression detected
-
-          The verify-gdm VM test found **${{ steps.crash-scan.outputs.crash_matches }}** gnome-shell crash signature(s) in the GDM journal.
+          ## gnome-shell crash-loop detected (dev-repo CI)
 
           **Workflow run**: ${RUN_URL}
 
-          ### Crash signatures
+          ### Findings
+
+          - Greeter PID stable: ${STABLE}
+          - Crash pattern matches: ${CRASHES}
+
+          ### Journal evidence
 
           \`\`\`
-          $(cat /tmp/crash-matches.txt)
+          $(limactl shell gnome50-verify -- sudo journalctl -u gdm --no-pager -n 30 2>/dev/null || echo "(journal unavailable)")
           \`\`\`
-
-          ### What this means
-
-          gnome-shell is likely out of lockstep with mutter's GObject-Introspection typelib —
-          the same class of bug as #27. The shell was built against a different mutter
-          than the one installed at runtime, and the typelib API changed behind a stable
-          version/SONAME.
-
-          ### Action
-
-          Rebuild gnome-shell against the current mutter in the buildroot. The
-          exact-EVR pin from the spec should prevent this from reaching users, but
-          if this fired from CI, the pin may not have been enough.
           BODYEOF
           gh issue create \
-            --title "gnome-shell crash-loop regression (verify-gdm CI catch)" \
+            --title "gnome-shell crash-loop regression (dev-repo CI catch)" \
             --body-file /tmp/issue-body.md \
             --label "bug" \
             --label "ci-caught"
@@ -251,3 +243,235 @@ jobs:
       - name: Stop Lima VM
         if: always()
         run: limactl stop gnome50-verify --force || true
+
+  verify-gdm-copr:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      issues: write
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' }}
+    steps:
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+          ls -la /dev/kvm
+
+      - name: Install QEMU and Lima
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q qemu-system-x86 qemu-utils ovmf
+          LIMA_ASSET_URL=$(curl -s https://api.github.com/repos/lima-vm/lima/releases/latest | python3 -c "
+          import sys, json
+          data = json.load(sys.stdin)
+          for a in data['assets']:
+              if 'Linux-x86_64' in a['name'] and a['name'].endswith('.tar.gz'):
+                  print(a['browser_download_url'])
+                  break
+          ")
+          echo "Downloading Lima from ${LIMA_ASSET_URL}"
+          curl -fsSL "${LIMA_ASSET_URL}" | sudo tar xz -C /usr/local
+          limactl --version
+
+      - name: Install vncdotool
+        run: pip install vncdotool
+
+      - name: Create Lima VM config
+        run: |
+          cat > /tmp/gnome50-verify-copr.yaml << 'EOF'
+          vmType: qemu
+          arch: x86_64
+          cpus: 2
+          memory: 4GiB
+          disk: 20GiB
+
+          video:
+            display: "vnc"
+
+          images:
+            - location: "https://cloud.centos.org/centos/10-stream/x86_64/images/CentOS-Stream-GenericCloud-x86_64-10-latest.x86_64.qcow2"
+              arch: x86_64
+
+          mounts: []
+
+          ssh:
+            localPort: 0
+            loadDotSSHPubKeys: false
+
+          provision:
+            - mode: system
+              script: |
+                #!/bin/bash
+                set -euxo pipefail
+                dnf -y install dnf-plugins-core python3-dnf-plugin-copr
+                printf '[daemon]\nWaylandEnable=true\n' > /etc/gdm/custom.conf
+          EOF
+
+      - name: Start Lima VM
+        run: |
+          limactl start --name=gnome50-verify-copr /tmp/gnome50-verify-copr.yaml --timeout=25m
+          echo "VM started"
+
+      - name: Enable COPR and install GNOME packages
+        run: |
+          echo "Enabling COPR..."
+          limactl shell gnome50-verify-copr -- sudo dnf copr enable -y jreilly1821/c10s-gnome-50
+          echo "Installing GNOME packages from COPR..."
+          limactl shell gnome50-verify-copr -- sudo dnf -y install \
+            gnome-shell \
+            gnome-control-center \
+            mutter \
+            gdm \
+            gnome-session-wayland-session \
+            glib2
+          echo "Post-install setup..."
+          limactl shell gnome50-verify-copr -- sudo glib-compile-schemas /usr/share/glib-2.0/schemas/
+          limactl shell gnome50-verify-copr -- sudo systemctl enable gdm
+          limactl shell gnome50-verify-copr -- sudo systemctl set-default graphical.target
+          echo "Packages installed:"
+          limactl shell gnome50-verify-copr -- rpm -q gdm gnome-shell mutter glib2
+
+      - name: Reboot VM to start GDM
+        run: |
+          echo "Rebooting VM to start GDM in graphical target..."
+          limactl shell gnome50-verify-copr -- sudo reboot || true
+          sleep 30
+          echo "Waiting for VM to come back after reboot..."
+          for i in $(seq 1 18); do
+            if limactl shell gnome50-verify-copr -- true 2>/dev/null; then
+              echo "VM is back after reboot"
+              break
+            fi
+            echo "Attempt $i/18: waiting for VM SSH..."
+            sleep 10
+          done
+
+      - name: Wait for GDM to become active
+        run: |
+          echo "Waiting for GDM to start (up to 5 minutes)..."
+          for i in $(seq 1 30); do
+            STATUS=$(limactl shell gnome50-verify-copr -- systemctl is-active gdm 2>/dev/null || echo "inactive")
+            echo "Attempt $i/30: gdm is ${STATUS}"
+            [[ "${STATUS}" == "active" ]] && break
+            sleep 10
+          done
+          if [[ "${STATUS}" != "active" ]]; then
+            echo "ERROR: GDM failed to become active"
+            limactl shell gnome50-verify-copr -- sudo journalctl -u gdm --no-pager -n 50 || true
+            exit 1
+          fi
+
+      - name: Check gnome-shell greeter stability
+        id: greeter-check
+        run: |
+          echo "Checking gnome-shell greeter stability (no crash-loop)..."
+          STABLE=false
+          for i in $(seq 1 30); do
+            SHELL_PID=$(limactl shell gnome50-verify-copr -- pgrep -f 'gnome-shell.*gdm' 2>/dev/null | head -1 || true)
+            if [[ -z "${SHELL_PID}" ]]; then
+              echo "Attempt $i/30: gnome-shell not running yet"
+              sleep 10
+              continue
+            fi
+            echo "Attempt $i/30: gnome-shell PID=${SHELL_PID}, waiting 10s for stability check..."
+            sleep 10
+            SHELL_PID2=$(limactl shell gnome50-verify-copr -- pgrep -f 'gnome-shell.*gdm' 2>/dev/null | head -1 || true)
+            if [[ "${SHELL_PID}" == "${SHELL_PID2}" ]]; then
+              echo "gnome-shell PID stable at ${SHELL_PID} (survived 10s)"
+              STABLE=true
+              break
+            fi
+            echo "PID changed: ${SHELL_PID} -> ${SHELL_PID2} (crash-restart detected)"
+          done
+          echo "greeter_stable=${STABLE}" >> "${GITHUB_OUTPUT}"
+          if [[ "${STABLE}" == "true" ]]; then
+            echo "gnome-shell greeter is stable"
+          else
+            echo "CRASH-LOOP DETECTED: gnome-shell greeter did not stabilize"
+          fi
+
+      - name: Check GDM and GNOME Shell status
+        run: |
+          limactl shell gnome50-verify-copr -- systemctl status gdm --no-pager || true
+          limactl shell gnome50-verify-copr -- rpm -q gdm gnome-shell mutter glib2
+
+      - name: Scan journal for gnome-shell crash signatures
+        id: crash-scan-copr
+        run: |
+          echo "Scanning journal for gnome-shell crash patterns..."
+          PATTERNS='SIGSEGV|SIGABRT|signal 11|Too many arguments|Expected an object of type.*MetaKeymapDescription|Session never registered|Child process.*already dead|maximum number of.*display failures'
+          limactl shell gnome50-verify-copr -- sudo journalctl -u gdm --no-pager | grep -E "${PATTERNS}" > /tmp/crash-matches.txt || true
+          CRASHES=$(wc -l < /tmp/crash-matches.txt)
+          echo "crash_matches=${CRASHES}" >> "${GITHUB_OUTPUT}"
+          echo "Crash-pattern matches: ${CRASHES}"
+          if [[ "${CRASHES}" -gt 0 ]]; then
+            echo "=== CRASH SIGNATURES FOUND ==="
+            cat /tmp/crash-matches.txt
+          else
+            echo "No gnome-shell crash patterns detected."
+          fi
+
+      - name: Check results and file issue if broken
+        run: |
+          STABLE="${{ steps.greeter-check.outputs.greeter_stable }}"
+          CRASHES="${{ steps.crash-scan-copr.outputs.crash_matches }}"
+          if [[ "${STABLE}" == "true" && "${CRASHES}" == "0" ]]; then
+            echo "PASSED: gnome-shell greeter stable, no crash patterns"
+            exit 0
+          fi
+          echo "FAILED: gnome-shell login broken"
+          echo "  greeter stable: ${STABLE}"
+          echo "  crash patterns: ${CRASHES}"
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          cat > /tmp/issue-body.md << BODYEOF
+          ## gnome-shell crash-loop detected (GNOME 50 COPR CI)
+
+          **COPR project**: jreilly1821/c10s-gnome-50
+          **Workflow run**: ${RUN_URL}
+
+          ### Findings
+
+          - Greeter PID stable: ${STABLE}
+          - Crash pattern matches: ${CRASHES}
+
+          ### Journal evidence
+
+          \`\`\`
+          $(limactl shell gnome50-verify-copr -- sudo journalctl -u gdm --no-pager -n 30 2>/dev/null || echo "(journal unavailable)")
+          \`\`\`
+          BODYEOF
+          gh issue create \
+            --title "gnome-shell crash-loop regression (GNOME 50 COPR CI catch)" \
+            --body-file /tmp/issue-body.md \
+            --label "bug" \
+            --label "ci-caught"
+          echo "Regression issue filed."
+          exit 1
+
+      - name: Take login screen screenshot via VNC
+        run: |
+          VNC_DISPLAY=$(cat /proc/$(pgrep -f 'qemu.*gnome50-verify-copr' | head -1)/cmdline \
+            | tr '\0' '\n' | grep -oP '(?<=vnc=127\.0\.0\.1:)\d+' || echo "0")
+          VNC_PORT=$((5900 + ${VNC_DISPLAY:-0}))
+          echo "VNC port: ${VNC_PORT}"
+          sleep 5
+          python3 - <<PYEOF
+          from vncdotool import api
+          client = api.connect('127.0.0.1', password='', port=${VNC_PORT})
+          client.captureScreen('gdm-login-screen-copr.png')
+          client.disconnect()
+          print("Screenshot captured")
+          PYEOF
+
+      - name: Upload login screen screenshot
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: gdm-login-screen-gnome50-copr
+          path: gdm-login-screen-copr.png
+          retention-days: 7
+
+      - name: Stop Lima VM
+        if: always()
+        run: limactl stop gnome50-verify-copr --force || true

--- a/.github/workflows/build-gnome50-verify.yml
+++ b/.github/workflows/build-gnome50-verify.yml
@@ -49,9 +49,16 @@ jobs:
         run: |
           sudo apt-get update -q
           sudo apt-get install -y -q qemu-system-x86 qemu-utils ovmf
-          LIMA_VERSION=$(curl -s https://api.github.com/repos/lima-vm/lima/releases/latest | python3 -c "import sys,json; print(json.load(sys.stdin)['tag_name'])")
-          echo "Installing Lima ${LIMA_VERSION}"
-          curl -fsSL "https://github.com/lima-vm/lima/releases/download/${LIMA_VERSION}/lima-${LIMA_VERSION#v}-linux-amd64.tar.gz" | sudo tar xz -C /usr/local
+          LIMA_ASSET_URL=$(curl -s https://api.github.com/repos/lima-vm/lima/releases/latest | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for a in data['assets']:
+    if 'Linux-x86_64' in a['name'] and a['name'].endswith('.tar.gz'):
+        print(a['browser_download_url'])
+        break
+")
+          echo "Downloading Lima from ${LIMA_ASSET_URL}"
+          curl -fsSL "${LIMA_ASSET_URL}" | sudo tar xz -C /usr/local
           limactl --version
 
       - name: Install vncdotool

--- a/src/gnome-49/gnome-shell/gnome-shell.spec
+++ b/src/gnome-49/gnome-shell/gnome-shell.spec
@@ -77,6 +77,14 @@ Patch: 0001-el10-stub-gnome-qr.patch
 %define gtk4_version 4.0.0
 %define adwaita_version 1.5.0
 %define mutter_version 49.0
+# Lock the runtime mutter to the exact build the shell was compiled against.
+# mutter ships GObject-Introspection typelibs whose API can change behind a stable
+# version and SONAME (the el10 keymap backport in mutter-49.4-6 did exactly this),
+# so a ">= floor" does not stop a newer mutter drifting in under an unrebuilt shell
+# and crashing it at the introspection boundary. Capture the buildroot EVR instead
+# (mutter-devel pulls the exact mutter), with a ">= floor" fallback when mutter is
+# not installed, e.g. when the spec is parsed outside a buildroot. See issue #27.
+%global mutter_dep %(rpm -q --qf '= %%{version}-%%{release}' mutter 2>/dev/null | grep -q '^= ' && rpm -q --qf '= %%{version}-%%{release}' mutter || echo '>= %{mutter_version}')
 %define polkit_version 0.100
 %define gsettings_desktop_schemas_version 47~alpha
 %define ibus_version 1.5.2
@@ -139,7 +147,7 @@ Requires:       libadwaita%{_isa} >= %{adwaita_version}
 Requires:       libnma-gtk4%{?_isa}
 # needed for loading SVG's via gdk-pixbuf
 Requires:       librsvg2%{?_isa}
-Requires:       mutter%{?_isa} >= %{mutter_version}
+Requires:       mutter%{?_isa} %{mutter_dep}
 Requires:       upower%{?_isa}
 Requires:       polkit%{?_isa} >= %{polkit_version}
 Requires:       gnome-desktop4%{?_isa} >= %{gnome_desktop_version}

--- a/src/gnome-50/gnome-shell/gnome-shell.spec
+++ b/src/gnome-50/gnome-shell/gnome-shell.spec
@@ -31,6 +31,14 @@ Patch: 0001-gdm-Work-around-failing-fingerprint-auth.patch
 %define gtk4_version 4.0.0
 %define adwaita_version 1.5.0
 %define mutter_version 50.0
+# Lock the runtime mutter to the exact build the shell was compiled against.
+# mutter ships GObject-Introspection typelibs whose API can change behind a stable
+# version and SONAME (the el10 keymap backport in mutter-49.4-6 did exactly this on
+# gnome-49), so a ">= floor" does not stop a newer mutter drifting in under an
+# unrebuilt shell and crashing it at the introspection boundary. Capture the buildroot
+# EVR instead (mutter-devel pulls the exact mutter), with a ">= floor" fallback when
+# mutter is not installed, e.g. when the spec is parsed outside a buildroot. See issue #27.
+%global mutter_dep %(rpm -q --qf '= %%{version}-%%{release}' mutter 2>/dev/null | grep -q '^= ' && rpm -q --qf '= %%{version}-%%{release}' mutter || echo '>= %{mutter_version}')
 %define polkit_version 0.100
 %define gsettings_desktop_schemas_version 50~alpha
 %define ibus_version 1.5.2
@@ -91,7 +99,7 @@ Requires:       libadwaita%{_isa} >= %{adwaita_version}
 Requires:       libnma-gtk4%{?_isa}
 # needed for loading SVG's via gdk-pixbuf
 Requires:       librsvg2%{?_isa}
-Requires:       mutter%{?_isa} >= %{mutter_version}
+Requires:       mutter%{?_isa} %{mutter_dep}
 Requires:       upower%{?_isa}
 Requires:       polkit%{?_isa} >= %{polkit_version}
 Requires:       gnome-desktop4%{?_isa} >= %{gnome_desktop_version}


### PR DESCRIPTION
Supersedes #28.

## Changes

### 1. gnome-shell mutter EVR pin (from #28 by @napanto)
Captures the buildroot mutter EVR at build time via:
```
%global mutter_dep %(rpm -q --qf '= %%{version}-%%{release}' mutter ...)
Requires: mutter%{?_isa} %{mutter_dep}
```
Prevents silent forward-drift of mutter behind a stable version/SONAME (the #27 class of bug). Fallback to `>= %{mutter_version}` when mutter not installed.

### 2. CI login VM verification (new)
Three-layer VM login test in the verify-gdm job (both GNOME 49 and 50):
1. **GDM active** (existing) — `systemctl is-active gdm`
2. **gnome-shell PID stability** (new) — poll for greeter PID, wait 10s, confirm PID unchanged. Crash-looping (\#27) changes PID every ~2s.
3. **Journal crash-signature scan** (new) — greps for `SIGSEGV`, `SIGABRT`, `Too many arguments`, `MetaKeymapDescription` type errors. On match: auto-files a GitHub issue with `bug` + `ci-caught` labels, crash details, and workflow run link; then fails the job.

Closes #27.