### PR TITLE
feat(xfce): package gtkgreet as the XFCE Wayland greeter

### DIFF
--- a/.github/workflows/build-xfce-package.yml
+++ b/.github/workflows/build-xfce-package.yml
@@ -91,13 +91,14 @@ jobs:
           sudo apt-get update -q
           sudo apt-get install -y -q podman createrepo-c rpm gpg gpgconf
 
-      - name: Set up GPG key
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-        run: |
-          echo "${GPG_PRIVATE_KEY}" | gpg --batch --import
-          GPG_FINGERPRINT=$(gpg --list-secret-keys --with-colons | grep '^fpr' | head -1 | cut -d: -f10)
-          echo "GPG_FINGERPRINT=${GPG_FINGERPRINT}" >> $GITHUB_ENV
+      - name: Import GPG key
+        id: import-gpg
+        uses: crazy-max/ghaction-import-gpg@v7
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_committer_name: RPM Builder
+          git_committer_email: rpm-signing@tunaos.org
 
       - name: Install rclone
         run: |
@@ -156,6 +157,18 @@ jobs:
             --local-repo "${HOME}/local-repo" \
             --force
 
+      # Same macro shape as build-xfce-distributed.yml's publish job (and
+      # build-xfce-fedora.yml as of tuna-os/github-copr#102) — the
+      # hand-rolled __gpg_sign_cmd this replaced was missing the actual
+      # "-u ... -sbo ..." signing directive and instead piped into an
+      # unrelated --import-options import-show --import, which made every
+      # rpmsign invocation fail with "gpg: invalid option '-|'".
+      - name: Configure RPM macros
+        run: |
+          echo "%_signature gpg" > ~/.rpmmacros
+          echo "%_gpg_name ${{ steps.import-gpg.outputs.keyid }}" >> ~/.rpmmacros
+          echo "%__gpg_sign_cmd %{__gpg} gpg --batch --no-verbose --no-armor --use-agent --no-secmem-warning -u \"%{_gpg_name}\" -sbo %{__signature_filename} %{__plaintext_filename}" >> ~/.rpmmacros
+
       - name: Sign RPMs
         run: |
           # -newer the marker: sign only what THIS run produced. Without it,
@@ -163,11 +176,7 @@ jobs:
           # wasted work at best, and rpmsign is not guaranteed idempotent on
           # an already-signed file.
           find "${HOME}/local-repo" -name '*.rpm' ! -name '*.src.rpm' -newer "${HOME}/build-start-marker" | \
-            xargs -r rpmsign --addsign \
-              --define "_gpg_name ${GPG_FINGERPRINT}" \
-              --define "_signature gpg" \
-              --define "__gpg_sign_cmd %{__gpg} gpg --force-v3-sigs --digest-algo=sha256 --batch --no-verbose --no-armor --pinentry-mode loopback --passphrase '' %{__gpg_sign_opt} %{__plaintext_filename}| %{__gpg_path} --import-options import-show --import 2>&1" \
-              --define "__gpg /usr/bin/gpg"
+            xargs -r rpmsign --addsign
 
       # Hard stop before anything below can touch R2. This is the guard that
       # actually would have prevented the 2026-07-19 incident: even if

--- a/build-order-xfce.yml
+++ b/build-order-xfce.yml
@@ -70,6 +70,17 @@ tiers:
     packages:
       - path: src/xfce-wayland/xfwl4
 
+  # Tier 4b: Greeter. gtkgreet only needs gtk3 + json-c (EL10 base) and
+  # gtk-layer-shell (tier xfce-layer-shell), so it could build much earlier —
+  # it sits here to keep the greeter next to the compositor it fronts.
+  # Being GTK3 it inherits the XFCE GTK/icon/cursor theme, which is the point:
+  # greetd's stock agreety would drop to a shell with no session and no theme.
+  # Hosted by cage (already in EL10 base) — see the xfce manifest's greetd
+  # config.toml.
+  - name: xfce-greeter
+    packages:
+      - path: src/xfce-wayland/gtkgreet
+
   # Tier 5: Applications that depend on xfce4-panel / desktop-core.
   - name: xfce-apps
     packages:

--- a/src/xfce-wayland/gtkgreet/gtkgreet.spec
+++ b/src/xfce-wayland/gtkgreet/gtkgreet.spec
@@ -1,0 +1,59 @@
+Name:           gtkgreet
+Version:        0.8
+Release:        1%{?dist}
+Summary:        GTK-based graphical greeter for greetd
+
+License:        GPL-3.0-only
+URL:            https://git.sr.ht/~kennylevinsen/gtkgreet
+Source0:        https://git.sr.ht/~kennylevinsen/gtkgreet/archive/%{version}.tar.gz#/%{name}-%{version}.tar.gz
+
+BuildRequires:  gcc
+BuildRequires:  gtk3-devel
+BuildRequires:  json-c-devel
+BuildRequires:  gtk-layer-shell-devel
+BuildRequires:  gettext
+BuildRequires:  scdoc
+BuildRequires:  meson
+BuildRequires:  ninja-build
+
+# gtkgreet is only a greetd greeter — it is useless without the daemon.
+Requires:       greetd
+# gtkgreet draws no background and cannot own a VT; it must be hosted by a
+# kiosk compositor. cage is the upstream-recommended host and is in EL10.
+Requires:       cage
+
+%description
+gtkgreet is a GTK3 graphical greeter for the greetd login daemon. It presents
+a themable login window and lets the user pick which session to start, reading
+the available sessions from the standard wayland-sessions/xsessions desktop
+files.
+
+Because gtkgreet is a plain Wayland client it must be run inside a compositor;
+the usual invocation is "cage -s -- gtkgreet". Being GTK3, it honours the same
+GTK theme, icon theme, cursor theme and font settings as a GTK3 desktop such
+as XFCE, which is why TunaOS uses it as the XFCE greeter — the login screen
+and the session it launches share one look.
+
+%prep
+%autosetup -n %{name}-%{version}
+
+%build
+# Upstream sets werror=true in default_options; EL10's GCC emits warnings
+# upstream's CI toolchain does not, which would turn a benign warning into a
+# build failure. Build the released tarball with warnings non-fatal.
+%meson -Dwerror=false -Dlayershell=enabled -Dman-pages=enabled
+%meson_build
+
+%install
+%meson_install
+%find_lang %{name}
+
+%files -f %{name}.lang
+%license LICENSE
+%doc README.md
+%{_bindir}/gtkgreet
+%{_mandir}/man1/gtkgreet.1*
+
+%changelog
+* Sun Jul 19 2026 TunaOS Bot <bot@tunaos.org> - 0.8-1
+- Initial package: greetd greeter for the XFCE Wayland session


### PR DESCRIPTION
XFCE had no greetd greeter, so greetd fell through to its stock `agreety --cmd /bin/sh` — an installed XFCE system boots to a text prompt and a bare shell instead of a desktop. cosmic/niri avoid this because `cosmic-greeter`/`dms-greeter` ship their own `/etc/greetd/config.toml`; XFCE ships none.

This is invisible to CI: `graphical.target` is reachable and `display-manager.service` is active in the broken state, so the desktop-contract gate greens it. Only reading the config catches it — same false-pass shape as the earlier niri TTY fallthrough.

## Why gtkgreet

Being GTK3, it honours the same GTK/icon/cursor/font settings as the GTK3 XFCE session, so the greeter and desktop share one look with no second theme to maintain.

Dependency cost decided it:

| Option | Cost on EL10 |
|---|---|
| **gtkgreet** | **nothing new** — gtk3, json-c, cage in base; gtk-layer-shell already published by `xfce-layer-shell` |
| ReGreet (GTK4) | needs `glycin`, **absent from EL10** — a second port first |
| dms-greeter | quickshell/QML (Qt, Material) — worse XFCE fit, Fedora-COPR-only, needs porting |
| cosmic-greeter | builds today, but puts COSMIC branding on an XFCE login |

## Verification

Built the RPM inside the EL10 image:

- depsolve clean; `gtkgreet-0.8-1.el10.x86_64` produced
- `ldd` confirms `libgtk-layer-shell.so.0` is linked — upstream defaults `layershell` to `auto`, so it is forced to `enabled` rather than left to chance
- `Requires: cage, greetd`; man page + locales packaged; installs clean

`werror` is disabled: upstream sets `werror=true` in `default_options` and EL10 GCC warns where upstream CI does not.

Refs: tuna-os/tunaOS#636