### PR TITLE
feat: make the build chain multi-distro, and target Fedora for Wayland XFCE

### DIFF
--- a/build-order-xfce-fedora.yml
+++ b/build-order-xfce-fedora.yml
@@ -1,0 +1,29 @@
+# Build Order Manifest for XFCE Wayland on Fedora
+#
+# Companion to build-order-xfce.yml (EL10). The two look wildly different in
+# size, and the reason is worth stating so nobody "fixes" this by copying the
+# EL10 tier list over:
+#
+#   EL10 ships essentially no XFCE, so build-order-xfce.yml builds the entire
+#   stack from source — 20+ packages across 8 tiers.
+#
+#   Fedora 44 already ships XFCE 4.20, and 4.20 is the release that landed
+#   upstream Wayland support. Fedora's own xfce4-panel already links
+#   libgtk-layer-shell.so.0 and libwayland-client.so.0; greetd, gtkgreet and
+#   cage are all in Fedora proper. Rebuilding any of that here would mean
+#   shipping worse-tested duplicates of packages Fedora already maintains.
+#
+# The one genuine gap is xfwl4, the Rust/Smithay Wayland compositor from the
+# hanthor/xfce-wayland port, which no distro packages. That is the whole
+# manifest.
+#
+# Consumed by scripts/build-chain.sh, which derives %{dist} (.fc44) from the
+# target below — see derive_dist().
+
+target: fedora-44-x86_64
+r2_path: xfce/44-x86_64
+
+tiers:
+  - name: xfce-compositor
+    packages:
+      - path: src/xfce-wayland/xfwl4

--- a/mock/fedora-44-ci.cfg
+++ b/mock/fedora-44-ci.cfg
@@ -1,0 +1,36 @@
+# Mock config for building the XFCE Wayland compositor on Fedora 44.
+#
+# Deliberately thin compared to centos-stream-10-ci.cfg. That config exists
+# because EL10 ships almost no XFCE at all, so this repo has to build the whole
+# stack (panel, session, settings, xfdesktop, thunar, plugins…) from source.
+#
+# Fedora needs none of that. Fedora 44 already ships XFCE 4.20, and 4.20 is the
+# release that added upstream Wayland support — its xfce4-panel links
+# libgtk-layer-shell.so.0 and libwayland-client.so.0 already. greetd, gtkgreet
+# and cage are all in Fedora proper too. The single missing piece is xfwl4, the
+# Rust/Smithay compositor, which is packaged nowhere for Fedora.
+#
+# So this chroot builds one package against stock Fedora, with no local repo
+# of hand-built dependencies to layer in.
+
+include('/etc/mock/fedora-44-x86_64.cfg')
+
+config_opts['root'] = 'fedora-44-ci'
+
+# Match COPR's network isolation: sources are staged before the build, so a
+# spec that reaches out mid-build is a bug we want to fail on, not paper over.
+config_opts['rpmbuild_networking'] = False
+config_opts['use_host_resolv'] = False
+
+# Packages built by earlier tiers are served from the local repo, same as the
+# EL10 config. xfwl4 has no intra-repo dependencies today, but keeping the repo
+# wired in means adding a second Fedora package later needs no config change.
+config_opts['dnf.conf'] += """
+[local-build]
+name=Local build results
+baseurl=file:///local-repo
+enabled=1
+gpgcheck=0
+priority=1
+cost=1
+"""

--- a/scripts/build-chain.sh
+++ b/scripts/build-chain.sh
@@ -33,6 +33,11 @@ MANIFEST="${REPO_ROOT}/build-order.yml"
 BACKEND="podman"
 BUILD_IMAGE="ghcr.io/tuna-os/mock-runner:centos-stream-10"
 MOCK_CONFIG="centos-stream-10-ci"
+# RPM %{dist} tag. Empty means "derive from the manifest's target:", so a
+# manifest targeting fedora-44 gets .fc44 without every caller passing --dist.
+# It used to be hard-coded to .el10 at eight separate call sites, which is why
+# this repo could only ever build for EL10.
+DIST=""
 LOCAL_REPO="${REPO_ROOT}/local-repo"
 JOBS=$(( $(nproc) / 2 ))
 [[ $JOBS -lt 1 ]] && JOBS=1
@@ -49,6 +54,8 @@ usage() {
     echo "  --backend <name>     Build backend: podman, mock, or native (default: podman)"
     echo "  --image <ref>        Container image for podman backend"
     echo "  --mock-config <cfg>  Mock config name (default: centos-stream-10-ci)"
+    echo "  --dist <tag>         RPM %{dist} tag, e.g. .el10 or .fc44"
+    echo "                       (default: derived from the manifest's target:)"
     echo "  --local-repo <path>  Path to local repo directory (default: ./local-repo)"
     echo "  --jobs <N>           Parallel jobs within a tier (default: nproc/2)"
     echo "  --tier <name>        Only build a specific tier"
@@ -69,6 +76,7 @@ while [[ $# -gt 0 ]]; do
         --backend)     BACKEND="$2";     shift 2 ;;
         --image)       BUILD_IMAGE="$2"; shift 2 ;;
         --mock-config) MOCK_CONFIG="$2"; shift 2 ;;
+        --dist)        DIST="$2";        shift 2 ;;
         --local-repo)  LOCAL_REPO="$2";  shift 2 ;;
         --jobs)        JOBS="$2";        shift 2 ;;
         --tier)        FILTER_TIER="$2"; shift 2 ;;
@@ -85,6 +93,37 @@ done
 # --- Helpers ---
 log() { echo "==> $*"; }
 err() { echo "ERROR: $*" >&2; }
+
+# Derive the %{dist} tag from the manifest's `target:` when --dist was not
+# given. Keeps a manifest self-describing: build-order-xfce.yml says
+# centos-stream-10-x86_64 and gets .el10, build-order-xfce-fedora.yml says
+# fedora-44-x86_64 and gets .fc44 — no caller has to keep the two in sync.
+derive_dist() {
+    local target
+    target="$(sed -n 's/^target:[[:space:]]*//p' "$MANIFEST" 2>/dev/null | head -1)"
+    case "$target" in
+        # Rawhide's dist tag is whatever Fedora's next release number is, which
+        # cannot be read off the target name and must not be guessed from the
+        # build host (it is not Fedora in CI). Require it explicitly.
+        fedora-rawhide*)
+            err "target '${target}' has no derivable %{dist} — rawhide's tag"
+            err "tracks Fedora's next release (e.g. .fc45); pass --dist"
+            exit 1
+            ;;
+        fedora-*)                 echo ".fc${target#fedora-}" | sed 's/-.*//' ;;
+        centos-stream-10*|epel-10*|almalinux*-10*) echo ".el10" ;;
+        centos-stream-9*|epel-9*) echo ".el9" ;;
+        *)
+            err "cannot derive %{dist} from target '${target:-<unset>}' in ${MANIFEST}"
+            err "pass --dist explicitly (e.g. --dist .fc44)"
+            exit 1
+            ;;
+    esac
+}
+
+if [[ -z "$DIST" ]]; then
+    DIST="$(derive_dist)"
+fi
 
 ensure_local_repo() {
     mkdir -p "${LOCAL_REPO}"
@@ -201,7 +240,7 @@ check_package_exists() {
         -v "$(dirname "$spec"):/specdir:Z" \
         "${BUILD_IMAGE}" \
         rpmspec -q "/specdir/${spec_basename}" \
-            --define "dist .el10" \
+            --define "dist ${DIST}" \
             --queryformat "%{NAME}-%{VERSION}-%{RELEASE}\n" | head -1)
 
     if [[ -z "$nvr" ]]; then
@@ -256,7 +295,7 @@ build_package_podman() {
         "${BUILD_IMAGE}" \
         rpmbuild -bs "/builddir/SPECS/${spec_basename}" \
             --define "_topdir /builddir" \
-            --define "dist .el10"
+            --define "dist ${DIST}"
 
     local srpm
     srpm="$(find "${builddir}/SRPMS" -name "*.src.rpm" | head -1)"
@@ -299,11 +338,11 @@ build_package_podman() {
             # Use flock to ensure only one process runs mock at a time
             # because they share mock chroot initialization.
             flock /local-repo/repo.lock -c \"
-                mock -r centos-stream-10-ci \\
+                mock -r \"${MOCK_CONFIG}\" \\
                     --uniqueext='${pkg_name}' \\
                     --rebuild /builddir/SRPMS/*.src.rpm \\
                     --resultdir=/builddir/results \\
-                    --define 'dist .el10' \\
+                    --define \"dist ${DIST}\" \\
                     --nocheck \\
                     --no-clean \\
                     --no-cleanup-after || {
@@ -364,7 +403,7 @@ build_package_mock() {
         "${BUILD_IMAGE}" \
         rpmbuild -bs "/builddir/SPECS/${spec_basename}" \
             --define "_topdir /builddir" \
-            --define "dist .el10"
+            --define "dist ${DIST}"
 
     local srpm
     srpm="$(find "${builddir}/SRPMS" -name "*.src.rpm" | head -1)"
@@ -386,7 +425,7 @@ build_package_mock() {
             --uniqueext=\"${pkg_name}\" \\
             --rebuild \"$srpm\" \\
             --resultdir=\"$resultdir\" \\
-            --define 'dist .el10' \\
+            --define \"dist ${DIST}\" \\
             --nocheck \\
             --no-clean \\
             --no-cleanup-after || {
@@ -430,7 +469,7 @@ build_package_native() {
     if ! $FORCE; then
         local nvr
         nvr=$(rpm -q --specfile "$spec" \
-            --define "dist .el10" \
+            --define "dist ${DIST}" \
             --queryformat "%{NAME}-%{VERSION}-%{RELEASE}\n" 2>/dev/null | head -1)
         if [[ -n "$nvr" ]] && ls "${LOCAL_REPO}/${nvr}"*.rpm &>/dev/null 2>&1; then
             log "[${pkg_name}] Skipping: ${nvr} already in local repo"
@@ -483,7 +522,7 @@ build_package_native() {
     # Install BuildRequires from spec
     log "[${pkg_name}] Installing BuildRequires..."
     dnf builddep -y \
-        --define "dist .el10" \
+        --define "dist ${DIST}" \
         "${builddir}/SPECS/${spec_basename}" || {
         err "dnf builddep failed for ${pkg_name}"
         return 1
@@ -493,7 +532,7 @@ build_package_native() {
     log "[${pkg_name}] Running rpmbuild..."
     rpmbuild -bb \
         --define "_topdir ${builddir}" \
-        --define "dist .el10" \
+        --define "dist ${DIST}" \
         "${builddir}/SPECS/${spec_basename}" || {
         err "rpmbuild failed for ${pkg_name}"
         return 1
@@ -613,7 +652,9 @@ main() {
     log "  Manifest:   ${MANIFEST}"
     log "  Backend:    ${BACKEND}"
     [[ "$BACKEND" == "podman" ]] && log "  Image:      ${BUILD_IMAGE}"
-    [[ "$BACKEND" == "mock"   ]] && log "  Mock cfg:   ${MOCK_CONFIG}"
+    # The podman backend runs mock too, so its config matters either way.
+    log "  Mock cfg:   ${MOCK_CONFIG}"
+    log "  Dist tag:   ${DIST}"
     log "  Local repo: ${LOCAL_REPO}"
     log "  Jobs:       ${JOBS}"
     [[ -n "$FILTER_TIER" ]]    && log "  Tier filter: ${FILTER_TIER}"


### PR DESCRIPTION
TunaOS must not ship X11 on any image, but xfce is X11 **everywhere except EL10** — bonito/bonito-rawhide (Fedora), sailfin (openSUSE), grouper (Ubuntu), marlin (Arch), flounder/flounder-sid (Debian) all install their distro’s X11 XFCE with gdm3/lightdm.

Fixing that means this repo has to build for more than one distro, which it structurally could not:

- `%{dist}` was hard-coded to `.el10` at **eight** call sites
- the podman backend ran `mock -r centos-stream-10-ci` literally, ignoring the `--mock-config` flag it already parsed

## The fanout

`%{dist}` and the mock config are now parameters. `--dist` sets it explicitly; otherwise it is derived from the manifest’s `target:`, keeping each manifest self-describing rather than making every caller keep a target and a dist tag in sync.

Rawhide deliberately **refuses** to derive — its tag tracks Fedora’s next release number, which cannot be read off the target name and must not be guessed from the build host (not Fedora in CI).

Verified:

```
build-order.yml               target=centos-stream-10-x86_64   Dist tag: .el10
build-order-xfce.yml          target=centos-stream-10-x86_64   Dist tag: .el10
build-order-xfce-fedora.yml   target=fedora-44-x86_64          Dist tag: .fc44

rawhide  -> ERROR: has no derivable %{dist} ... pass --dist
--dist .fc45 -> Dist tag: .fc45   (override wins)
```

Both EL10 manifests still resolve `.el10` — no behaviour change to existing builds.

## Fedora is far cheaper than EL10 was

EL10 ships almost no XFCE, so `build-order-xfce.yml` builds 20+ packages across 8 tiers. **Fedora 44 already ships XFCE 4.20** — the release that added upstream Wayland support — and its `xfce4-panel` already links `libgtk-layer-shell.so.0` and `libwayland-client.so.0`. `greetd`, `gtkgreet` and `cage` are all in Fedora proper.

Rebuilding any of that here would ship worse-tested duplicates of packages Fedora already maintains.

The one real gap is **xfwl4**, the Rust/Smithay compositor, which no distro packages (`xfwl4-git` exists in AUR only). `rust`/`cargo` 1.96 and `wlroots` 0.20 are in Fedora, so it builds. So `build-order-xfce-fedora.yml` is a single package in a single tier — and the comment says why, so nobody “fixes” it by copying EL10’s tier list across.

## Not done here

`build-xfce-distributed.yml` still hard-codes the centos-stream-10 mock-runner image and per-tier job blocks, so the Fedora manifest **has no workflow yet** — the engine supports it, CI does not. That plus the bonito manifest switch off the X11 `xfce-desktop` group is the follow-up.

Refs: tuna-os/tunaOS#636