### PR TITLE
docs: survey the Wayland-XFCE port, and scaffold xfwl4 for every base

### DIFF
--- a/docs/XFWL4-PORTING.md
+++ b/docs/XFWL4-PORTING.md
@@ -1,0 +1,122 @@
+# Porting Wayland XFCE to every TunaOS base
+
+TunaOS must not ship X11 on any image. Today xfce is X11 everywhere except
+EL10. This is the survey of what each ecosystem actually needs, measured
+against the real base images rather than assumed.
+
+## The finding
+
+**Every distro needs exactly one package: `xfwl4`.** Nothing else.
+
+The reason is XFCE 4.20, which added upstream Wayland support. Every base we
+ship already has 4.20 or newer, and their `xfce4-panel` already links
+`libgtk-layer-shell` and `libwayland-client`. The greeter stack
+(`greetd` / `gtkgreet` / `cage`) is packaged in every one of them too.
+
+So this is not "port a 20-package desktop stack to five ecosystems", which is
+what EL10 required and what it looked like from the outside. EL10 is the
+outlier: it ships essentially no XFCE at all, so `build-order-xfce.yml` builds
+the whole stack. Everywhere else, rebuilding those packages would ship
+worse-tested duplicates of what the distro already maintains.
+
+`xfwl4` is the gap because it is a young Rust/Smithay compositor that only
+Gentoo and AUR have picked up.
+
+## Survey
+
+Measured from the base images in `.github/build-config.yml` (tunaOS repo).
+
+| Base | Variant(s) | XFCE | panel is Wayland-capable | greetd | gtkgreet | cage | rust | **xfwl4** |
+|---|---|---|---|---|---|---|---|---|
+| Fedora 44 | bonito, bonito-rawhide | 4.20.3/4.20.7 | ✅ | 0.10.3 | 0.8 | 0.3.1 | 1.96 | ❌ **build** |
+| Debian trixie | flounder | 4.20.2/4.20.4 | ✅ | 0.10.3 | 0.8 | 0.2.0 | 1.85 | ❌ **build** |
+| Debian sid | flounder-sid | ≥ trixie | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ **build** |
+| Ubuntu resolute | grouper | 4.20.4/4.20.7 | ✅ | 0.10.3 | 0.8 | 0.2.1 | 1.93 | ❌ **build** |
+| Arch | marlin | 4.20.4/4.20.7 | ✅ | 0.10.3 | `greetd-gtkgreet` 0.8 | 0.3.1 | 1.97 | ⚠️ AUR `xfwl4-git` |
+| openSUSE TW | sailfin | 4.20.4/4.20.7 | ✅ | 0.10.3 | 0.8 | 0.3.1 | 1.97 | ❌ **build** |
+| Gentoo | guppy | 4.21.2 | ✅ | in tree | 0.8 | in tree | ✅ | ✅ **`xfce-base/xfwl4` 4.21.0** |
+| EL10 | yellowfin, albacore, skipjack | ✗ none | — | COPR | packaged here | base | ✅ | ✅ packaged here |
+
+"panel is Wayland-capable" = `xfce4-panel` declares a dependency on
+gtk-layer-shell **and** wayland-client, verified per base:
+
+- deb: `apt-cache depends xfce4-panel` → `libgtk-layer-shell0`, `libwayland-client0`
+- Arch: `pacman -Si xfce4-panel` → `gtk-layer-shell`
+- openSUSE: `zypper info --requires` → `libgtk-layer-shell.so.0`, `libwayland-client.so.0`
+- Fedora: `dnf repoquery --requires` → same two
+
+## Work per ecosystem
+
+Ordered by leverage. User-facing X11 exposure today is **bonito (+rawhide)** and
+**flounder**; grouper/marlin/flounder-sid/sailfin are experimental per
+tunaOS#641, so they are not shipping X11 to users yet.
+
+### 1. Gentoo (guppy) — zero packaging
+
+`xfce-base/xfwl4` 4.21.0 is already in the official Portage tree. Its
+`keywords` are empty, meaning unkeyworded, so it needs an entry in
+`package.accept_keywords` to install. That is a manifest change in the tunaOS
+repo, not work here.
+
+Note guppy currently has **no xfce flavor at all** (base/gnome/kde), so this is
+adding a flavor rather than de-X11-ing one.
+
+### 2. Fedora (bonito, bonito-rawhide) — reuse the RPM we have
+
+`build-order-xfce-fedora.yml` + `mock/fedora-44-ci.cfg` already exist. One
+package, one tier. Blocked only on `build-xfce-distributed.yml`, which still
+hard-codes the centos-stream-10 mock runner and per-tier job blocks.
+
+### 3. openSUSE (sailfin) — reuse the RPM, adjust macros
+
+Same spec, different macros. Expect to differ on: `BuildRequires` names
+(`pkgconfig(...)` style is portable, bare `-devel` names are not),
+`%license` handling, and the `%{?rhel}` conditional which must not fire.
+Skeleton: `packaging/opensuse/`.
+
+### 4. Debian + Ubuntu (flounder, flounder-sid, grouper) — one `.deb` source
+
+All three share one source package. Skeleton: `packaging/debian/`.
+
+### 5. Arch (marlin) — PKGBUILD
+
+AUR `xfwl4-git` exists and tracks git rather than the 4.21.0 release. Prefer our
+own PKGBUILD pinned to the same commit the RPM uses, so all variants ship the
+identical compositor. Skeleton: `packaging/arch/`.
+
+## What makes xfwl4 harder than a normal Rust package
+
+These constraints come from `xfwl4.spec` and apply to **every** ecosystem, so
+each packaging skeleton has to solve them again:
+
+1. **`resources/xfce-wayland-protocols` is a git submodule.** It holds custom
+   XFCE Wayland protocol XML and is *not* in the release tarball. The build
+   references it by relative path, so it must be unpacked to exactly
+   `resources/xfce-wayland-protocols/`.
+
+2. **Cargo dependencies must be vendored.** `Cargo.toml` pulls `smithay` from
+   git, which cargo cannot fetch in a network-isolated build. The RPM uses a
+   pre-vendored `vendor.tar.gz` plus a `.cargo/config.toml` that redirects both
+   crates.io *and* the smithay git source to it. Debian and Arch builds are
+   also network-isolated by policy, so both need the same treatment.
+
+3. **An upstream patch is required.** `WlrBufferConstraints.dma`'s cfg gate
+   omits the udev feature while three call sites guard it under udev — a
+   udev-only build (ours) fails to compile without
+   `0001-fix-dma-cfg-gate-for-udev-backend.patch`.
+
+4. **Feature flags are not default.** Build with
+   `--no-default-features --features udev,egl,xwayland,smithay/renderer_pixman,smithay/renderer_gl`.
+
+5. **`GETTEXT_SYSTEM=1` must be set.** Otherwise `gettext-sys`'s build.rs
+   compiles its own GNU gettext, which then fails to link against
+   `libintl_gettext`. On glibc targets gettext is in libc, so no linking is
+   needed at all.
+
+6. **`RUSTFLAGS="-C relocation-model=pic"`.**
+
+## Status
+
+Skeletons in `packaging/` are **scaffolds, not working builds** — they encode
+the constraints above and the dependency names, and every one of them still
+needs a real build to be trusted. None has been built yet.

--- a/src/xfce-wayland/xfwl4/packaging/arch/PKGBUILD
+++ b/src/xfce-wayland/xfwl4/packaging/arch/PKGBUILD
@@ -1,0 +1,72 @@
+# Maintainer: TunaOS Bot <bot@tunaos.org>
+#
+# xfwl4 for marlin (Arch). AUR already carries xfwl4-git, but that tracks git
+# HEAD; this pins the same commit the RPM builds so every TunaOS variant ships
+# an identical compositor rather than whatever HEAD was on build day.
+#
+# Arch is otherwise complete: xfce4-panel 4.20.7 already depends on
+# gtk-layer-shell, and greetd / greetd-gtkgreet / cage are all in the repos.
+
+pkgname=xfwl4
+pkgver=4.21.0
+pkgrel=1
+_commit=465880f67b5705136895bf69c60e2178ad351856
+# Custom XFCE Wayland protocol XML — a git submodule, absent from the archive.
+_protocols_commit=6082cfa492154aec266527193bf8f6142ab14977
+pkgdesc="Wayland compositor for Xfce4"
+arch=('x86_64')
+url="https://gitlab.xfce.org/xfce/xfwl4"
+license=('GPL-3.0-or-later' 'Apache-2.0' 'MIT')
+depends=('libdrm' 'libinput' 'mesa' 'seatd' 'libxkbcommon' 'pixman'
+         'wayland' 'gtk3' 'gdk-pixbuf2' 'libdisplay-info' 'libsm'
+         'startup-notification' 'systemd-libs' 'xfconf' 'libxfce4ui')
+makedepends=('cargo' 'rust' 'pkgconf' 'wayland-protocols' 'gettext')
+# The compositor alone is not a session.
+optdepends=('xfce4-session: XFCE session management'
+            'xfce4-panel: XFCE panel'
+            'greetd-gtkgreet: themable greeter for the login screen')
+source=("xfwl4-${_commit}.tar.gz::${url}/-/archive/${_commit}/xfwl4-${_commit}.tar.gz"
+        "xfce-wayland-protocols-${_protocols_commit}.tar.gz::https://gitlab.xfce.org/xfce/xfce-wayland-protocols/-/archive/${_protocols_commit}/xfce-wayland-protocols-${_protocols_commit}.tar.gz"
+        "0001-fix-dma-cfg-gate-for-udev-backend.patch")
+# SKIP is a scaffold placeholder — fill these in before this is trusted.
+sha256sums=('SKIP' 'SKIP' 'SKIP')
+
+prepare() {
+	cd "xfwl4-${_commit}"
+
+	# Upstream bug: WlrBufferConstraints.dma's cfg gate omits the udev feature
+	# while three call sites already guard access to it under udev, so a
+	# udev-only build (ours) fails to compile without this.
+	patch -Np1 -i "${srcdir}/0001-fix-dma-cfg-gate-for-udev-backend.patch"
+
+	# src/protocols/*.rs reference this by relative path via
+	# wayland_scanner::generate_*!, so the location is exact, not incidental.
+	mkdir -p resources/xfce-wayland-protocols
+	tar -xzf "${srcdir}/xfce-wayland-protocols-${_protocols_commit}.tar.gz" \
+		--strip-components=1 -C resources/xfce-wayland-protocols
+
+	# makepkg builds with the network up, so smithay's git dependency can be
+	# fetched normally here — unlike the RPM and .deb builds, which are
+	# network-isolated and need a pre-vendored tree.
+	cargo fetch --locked
+}
+
+build() {
+	cd "xfwl4-${_commit}"
+	export RUSTFLAGS="-C relocation-model=pic"
+	# Otherwise gettext-sys builds its own GNU gettext and fails to link
+	# libintl_gettext; on glibc, gettext lives in libc and needs no linking.
+	export GETTEXT_SYSTEM=1
+	cargo build --release --frozen \
+		--no-default-features \
+		--features udev,egl,xwayland,smithay/renderer_pixman,smithay/renderer_gl
+}
+
+package() {
+	cd "xfwl4-${_commit}"
+	install -Dm755 "target/release/xfwl4" "${pkgdir}/usr/bin/xfwl4"
+	install -Dm644 "resources/defaults" \
+		"${pkgdir}/usr/share/xfce4/xfwl4/defaults"
+	install -Dm644 LICENSE \
+		"${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}

--- a/src/xfce-wayland/xfwl4/packaging/debian/README.source
+++ b/src/xfce-wayland/xfwl4/packaging/debian/README.source
@@ -1,0 +1,24 @@
+Building this package
+=====================
+
+Two artifacts must be staged into the source tree before building, because
+neither is in the upstream release tarball and the build has no network:
+
+1. resources/xfce-wayland-protocols/
+   A git submodule of custom XFCE Wayland protocol XML. Unpack
+   https://gitlab.xfce.org/xfce/xfce-wayland-protocols/-/archive/<rev>/...tar.gz
+   there with --strip-components=1. src/protocols/*.rs reference it by
+   relative path via wayland_scanner::generate_*!, so the path is exact.
+
+2. vendor/
+   Cargo.toml pulls smithay from git, which cargo cannot fetch offline.
+   Produce with `cargo vendor` against the pinned Cargo.lock. debian/rules
+   installs debian/cargo-config.toml as .cargo/config.toml to redirect both
+   crates.io and the smithay git source at it.
+
+Keep the pinned smithay rev in debian/cargo-config.toml identical to the one
+in ../../xfwl4.spec — they must describe the same build.
+
+An upstream patch is also required (see debian/patches): the cfg gate on
+WlrBufferConstraints.dma omits the udev feature while three call sites guard
+it under udev, so a udev-only build does not compile without it.

--- a/src/xfce-wayland/xfwl4/packaging/debian/cargo-config.toml
+++ b/src/xfce-wayland/xfwl4/packaging/debian/cargo-config.toml
@@ -1,0 +1,16 @@
+# Redirects both crates.io and the smithay git dependency at the vendored
+# directory, so the build works with networking disabled. Must match the
+# smithay rev pinned in Cargo.lock — the RPM spec carries the same block.
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source."git+https://github.com/smithay/smithay?rev=4645e03d6bd9377aa368de20e91d69951450392d"]
+git = "https://github.com/smithay/smithay"
+rev = "4645e03d6bd9377aa368de20e91d69951450392d"
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "vendor"
+
+[net]
+offline = true

--- a/src/xfce-wayland/xfwl4/packaging/debian/changelog
+++ b/src/xfce-wayland/xfwl4/packaging/debian/changelog
@@ -1,0 +1,8 @@
+xfwl4 (4.21.0-1) unstable; urgency=medium
+
+  * Initial package: Wayland compositor for XFCE.
+    Packaged so flounder/flounder-sid/grouper can ship a Wayland-only XFCE
+    session — it is the only piece Debian and Ubuntu are missing, since their
+    XFCE 4.20 packages are already Wayland-capable.
+
+ -- TunaOS Bot <bot@tunaos.org>  Sun, 19 Jul 2026 09:00:00 +0000

--- a/src/xfce-wayland/xfwl4/packaging/debian/control
+++ b/src/xfce-wayland/xfwl4/packaging/debian/control
@@ -1,0 +1,50 @@
+Source: xfwl4
+Section: x11
+Priority: optional
+Maintainer: TunaOS Bot <bot@tunaos.org>
+# Covers flounder (Debian trixie), flounder-sid (Debian sid) and grouper
+# (Ubuntu resolute) from one source package — all three ship XFCE 4.20+, whose
+# xfce4-panel already depends on libgtk-layer-shell0 and libwayland-client0, so
+# xfwl4 is the only missing piece of a Wayland-only XFCE on any of them.
+Build-Depends: debhelper-compat (= 13),
+               cargo,
+               rustc (>= 1.85),
+               pkg-config,
+               libdrm-dev,
+               libinput-dev,
+               libgbm-dev,
+               libseat-dev,
+               libxkbcommon-dev,
+               libpixman-1-dev,
+               libwayland-dev,
+               wayland-protocols,
+               libgtk-3-dev,
+               libgdk-pixbuf-2.0-dev,
+               libdisplay-info-dev,
+               libsm-dev,
+               libstartup-notification0-dev,
+               libsystemd-dev,
+# xfconf-sys / libxfce4ui-sys / libxfce4kbd-private-sys link against these via
+# pkg-config (confirmed from Cargo.lock's dependency tree).
+               libxfconf-0-dev,
+               libxfce4ui-2-dev,
+# Without this, gettext-sys's build.rs builds its own GNU gettext in-tree and
+# then fails to link libintl_gettext. See GETTEXT_SYSTEM in debian/rules.
+               gettext
+Standards-Version: 4.7.0
+Homepage: https://gitlab.xfce.org/xfce/xfwl4
+Rules-Requires-Root: no
+
+Package: xfwl4
+Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Depends}
+# xfwl4 is only the compositor; a usable session still needs the XFCE pieces,
+# which the distro already ships in Wayland-capable form.
+Recommends: xfce4-session, xfce4-panel
+Description: Wayland compositor for Xfce4
+ xfwl4 is a Wayland compositor for Xfce4 built on Smithay. It provides both
+ winit (nested) and TTY (udev+egl) backends.
+ .
+ It is the one component missing from a Wayland-only XFCE session on Debian
+ and Ubuntu: XFCE 4.20 added upstream Wayland support, so the panel, session,
+ settings and desktop packages already work under a Wayland compositor.

--- a/src/xfce-wayland/xfwl4/packaging/debian/patches/series
+++ b/src/xfce-wayland/xfwl4/packaging/debian/patches/series
@@ -1,0 +1,3 @@
+# Same patch the RPM applies; copy 0001-fix-dma-cfg-gate-for-udev-backend.patch
+# from ../../ when wiring this up for real.
+0001-fix-dma-cfg-gate-for-udev-backend.patch

--- a/src/xfce-wayland/xfwl4/packaging/debian/rules
+++ b/src/xfce-wayland/xfwl4/packaging/debian/rules
@@ -1,0 +1,44 @@
+#!/usr/bin/make -f
+#
+# xfwl4 for Debian/Ubuntu. Mirrors the logic in ../../xfwl4.spec — keep the two
+# in sync, because every constraint here comes from upstream, not from RPM.
+
+# gettext-sys only skips its own from-source gettext build (which then fails to
+# link libintl_gettext) when GETTEXT_SYSTEM is set. On glibc, gettext is built
+# into libc, so nothing needs linking at all.
+export GETTEXT_SYSTEM = 1
+export RUSTFLAGS = -C relocation-model=pic
+
+# Debian builds have no network. Cargo.toml pulls smithay from git, which cargo
+# cannot fetch offline, so deps are pre-vendored and both crates.io and the
+# smithay git source are redirected at the vendor directory. Regenerate with
+# `cargo vendor` against the pinned Cargo.lock if it is ever bumped.
+export CARGO_HOME = $(CURDIR)/.cargo-home
+
+%:
+	dh $@
+
+override_dh_auto_configure:
+	mkdir -p .cargo
+	cp $(CURDIR)/debian/cargo-config.toml .cargo/config.toml
+	# resources/xfce-wayland-protocols is a git submodule holding custom XFCE
+	# Wayland protocol XML. It is NOT in the release tarball, and the build
+	# refers to it by relative path from src/protocols/*.rs, so it has to land
+	# at exactly this path or compilation fails.
+	test -d resources/xfce-wayland-protocols || \
+		(echo "ERROR: resources/xfce-wayland-protocols missing — unpack the" \
+		      "xfce-wayland-protocols tarball there (see debian/README.source)" && false)
+
+override_dh_auto_build:
+	cargo build --release --offline \
+		--no-default-features \
+		--features udev,egl,xwayland,smithay/renderer_pixman,smithay/renderer_gl
+
+override_dh_auto_install:
+	install -Dm755 target/release/xfwl4 \
+		debian/xfwl4/usr/bin/xfwl4
+	install -Dm644 resources/defaults \
+		debian/xfwl4/usr/share/xfce4/xfwl4/defaults
+
+# The test suite needs a live compositor session; skip like the RPM's --nocheck.
+override_dh_auto_test:

--- a/src/xfce-wayland/xfwl4/packaging/gentoo/README.md
+++ b/src/xfce-wayland/xfwl4/packaging/gentoo/README.md
@@ -1,0 +1,39 @@
+# Gentoo (guppy) — no packaging required
+
+`xfce-base/xfwl4` **4.21.0 is already in the official Portage tree**, so there
+is deliberately no ebuild here. Writing one would fork a package Gentoo already
+maintains.
+
+Verified via `packages.gentoo.org/packages/xfce-base/xfwl4.json`:
+
+```
+atom:     xfce-base/xfwl4
+desc:     Xfce's [experimental] Wayland Compositor
+version:  4.21.0   keywords: ['']
+```
+
+## The one catch: it is unkeyworded
+
+`keywords: ['']` means no arch is keyworded, not even `~amd64`. Portage will
+refuse to merge it until it is explicitly accepted, so the tunaOS image build
+needs:
+
+```
+# /etc/portage/package.accept_keywords/xfwl4
+xfce-base/xfwl4 **
+```
+
+`**` (rather than `~amd64`) is required precisely because the ebuild carries no
+keywords at all.
+
+## Rest of the stack
+
+Gentoo also already has everything else a Wayland-only XFCE session needs —
+`gui-apps/gtkgreet` 0.8, `gui-libs/gtk-layer-shell` 0.10.1, and
+`xfce-base/xfce4-panel` 4.21.2, which is newer than every other base we ship.
+
+## Note on scope
+
+guppy currently has **no xfce flavor at all** (base/gnome/kde only), so this is
+adding a flavor, not de-X11-ing an existing one — no X11 is being shipped here
+today.

--- a/src/xfce-wayland/xfwl4/packaging/opensuse/README.md
+++ b/src/xfce-wayland/xfwl4/packaging/opensuse/README.md
@@ -1,0 +1,46 @@
+# openSUSE (sailfin) — reuse the RPM, with macro adjustments
+
+openSUSE Tumbleweed is RPM, so `../../xfwl4.spec` is the starting point rather
+than a new packaging format. There is no separate spec here on purpose: forking
+it would mean maintaining two specs that must stay byte-compatible on the six
+upstream constraints (vendored cargo tree, protocol submodule, dma cfg patch,
+feature flags, `GETTEXT_SYSTEM`, PIC relocation).
+
+Tumbleweed already has everything else: `xfce4-panel` 4.20.7 requires
+`libgtk-layer-shell.so.0` and `libwayland-client.so.0`, and `greetd` 0.10.3,
+`gtkgreet` 0.8, `cage` 0.3.1, `rust`/`cargo` 1.97 are all in the repos. `xfwl4`
+is the only gap — repology confirms no openSUSE packaging of it exists.
+
+## Expected differences from the Fedora/EL10 spec
+
+1. **`%{?rhel}` conditional must not fire.** The spec sets
+   `__cargo_requires_buildrequires` under `0%{?rhel} >= 10`; on openSUSE that
+   is simply skipped, which is correct, but verify it does not trip
+   `rpmlint`'s unresolved-BuildRequires check.
+
+2. **BuildRequires naming.** The `pkgconfig(...)` style entries port as-is.
+   The bare `-devel` names do not reliably: expect to map
+   `mesa-libgbm-devel` → `Mesa-libgbm-devel`, `libxkbcommon-devel` →
+   `libxkbcommon-devel` (same), `gtk3-devel` → `gtk3-devel` (same),
+   `libSM-devel` → `libSM-devel` (same). Prefer converting each to
+   `pkgconfig(...)` where one exists — that is portable across both.
+
+3. **`%license` vs `%doc`.** Supported on Tumbleweed; no change expected.
+
+4. **Group tag.** openSUSE still wants `Group:` in some submission paths
+   (OBS/Factory), unlike Fedora which dropped it.
+
+## Build route
+
+Either:
+
+- **OBS** (`devel:XFCE` or a TunaOS home project) — the idiomatic route if
+  these are ever submitted upstream to Factory; or
+- **our own mock/rpmbuild chain**, once `build-chain.sh` grows an openSUSE
+  target. `derive_dist()` currently understands fedora/centos/epel only, so it
+  would need an arm for openSUSE — Tumbleweed is rolling and conventionally
+  uses no dist tag, so this likely means passing `--dist ''` explicitly rather
+  than deriving.
+
+Nothing here has been built. Treat every mapping above as a hypothesis until a
+real build confirms it.


### PR DESCRIPTION
Surveyed each base image directly instead of assuming. The job is **far smaller** than “port a 20-package desktop stack to five ecosystems”:

> **Every distro needs exactly one package: `xfwl4`.**

XFCE 4.20 added upstream Wayland support, and every base already ships 4.20+ with an `xfce4-panel` that depends on gtk-layer-shell **and** wayland-client. `greetd`/`gtkgreet`/`cage` are packaged in all of them too. EL10 is the outlier — it ships essentially no XFCE, which is why `build-order-xfce.yml` builds the whole stack.

## Survey

| Base | Variant(s) | XFCE | panel Wayland-capable | greetd | gtkgreet | cage | **xfwl4** |
|---|---|---|---|---|---|---|---|
| Fedora 44 | bonito, bonito-rawhide | 4.20.3/7 | ✅ | 0.10.3 | 0.8 | 0.3.1 | ❌ build |
| Debian trixie | flounder | 4.20.2/4 | ✅ | 0.10.3 | 0.8 | 0.2.0 | ❌ build |
| Debian sid | flounder-sid | ≥trixie | ✅ | ✅ | ✅ | ✅ | ❌ build |
| Ubuntu resolute | grouper | 4.20.4/7 | ✅ | 0.10.3 | 0.8 | 0.2.1 | ❌ build |
| Arch | marlin | 4.20.4/7 | ✅ | 0.10.3 | ✅ | 0.3.1 | ⚠️ AUR `xfwl4-git` |
| openSUSE TW | sailfin | 4.20.4/7 | ✅ | 0.10.3 | 0.8 | 0.3.1 | ❌ build |
| **Gentoo** | guppy | 4.21.2 | ✅ | ✅ | 0.8 | ✅ | ✅ **already in tree** |

## Two results shrink it further

**Gentoo needs nothing.** `xfce-base/xfwl4` 4.21.0 is already in the official Portage tree, so there is deliberately no ebuild here — writing one would fork a package Gentoo maintains. It *is* unkeyworded (`keywords: []`), so it needs `package.accept_keywords` with `**`; that is a tunaOS manifest change, not packaging. guppy also has no xfce flavor today, so this **adds** one rather than de-X11-ing one.

**Arch** has AUR `xfwl4-git`, but it tracks git HEAD. The PKGBUILD here pins the same commit the RPM builds, so every variant ships an identical compositor rather than whatever HEAD was on build day.

**openSUSE** deliberately gets no second spec — the Fedora/EL10 one is the starting point, and forking it would mean keeping two specs byte-compatible on six upstream constraints. Its README records expected macro differences as hypotheses.

## The real content: six constraints each ecosystem must re-solve

From `xfwl4.spec` — these are why xfwl4 is harder than a normal Rust package:

1. `resources/xfce-wayland-protocols` is a **git submodule**, absent from release tarballs, referenced by exact relative path
2. **Cargo deps must be vendored** — smithay comes from git, and RPM/deb builds are network-isolated
3. An **upstream patch** is required: the `dma` cfg gate omits `udev` while three call sites guard it under udev, so a udev-only build will not compile
4. **Non-default feature flags**
5. **`GETTEXT_SYSTEM=1`**, or gettext-sys builds its own gettext and fails to link
6. **`RUSTFLAGS=-C relocation-model=pic`**

## Status

**Nothing here has been built.** The skeletons encode constraints and dependency names; every one still needs a real build before it is trusted, and the docs say so. Arch `sha256sums` are `SKIP` placeholders.

Targets `feat/multi-distro-fanout` (#83), which provides the `--dist`/mock-config parameterization this depends on.

Refs: tuna-os/tunaOS#636