### PR TITLE
fix(mock): let isolated package builds resolve our own BuildRequires

### DIFF
--- a/mock/centos-stream-10-ci.cfg
+++ b/mock/centos-stream-10-ci.cfg
@@ -52,6 +52,32 @@ gpgcheck=0
 cost=1
 skip_if_unavailable=1
 
+# Our own already-published XFCE packages.
+#
+# Without this, building a single package in isolation cannot resolve
+# BuildRequires that other packages in THIS repo provide. build-chain.sh
+# populates [local-build] as it walks the tiers, so a full run is fine — but
+# the per-package workflow builds one package with an empty local repo, and
+# every tier logs "Directory walk done - 0 packages". That is why
+# build-xfce-package.yml has failed on main since 2026-07-04:
+# xfce4-cpugraph-plugin wants exo-devel, libxfce4ui-devel,
+# libxfce4windowing-devel, xfce4-panel-devel and xfce4-dev-tools, all built by
+# earlier tiers and none of them present.
+#
+# They are all published here already, so pointing at it makes an isolated
+# rebuild resolve exactly like a full chain run.
+#
+# cost is deliberately higher than [local-build]'s 1: a package just built in
+# this run must always win over the published copy of itself, otherwise a
+# rebuild would silently link against the previous release.
+[tunaos-xfce]
+name=TunaOS XFCE Wayland (published)
+baseurl=https://repo.tunaos.org/xfce/10-stream-x86_64/
+enabled=1
+gpgcheck=0
+cost=10
+skip_if_unavailable=1
+
 """
 
 # Bind-mount the local repo into the chroot


### PR DESCRIPTION
`build-xfce-package.yml` has **failed on main every run since 2026-07-04**. The error is a depsolve one:

```
No matching package to install: exo-devel
No matching package to install: libxfce4ui-devel
No matching package to install: libxfce4windowing-devel
No matching package to install: xfce4-panel-devel
No matching package to install: xfce4-dev-tools
```

Every one of those is **built by an earlier tier of this same repo**.

`build-chain.sh` fills `[local-build]` as it walks the tiers, so a full chain run resolves them fine. But the per-package workflow builds one package against an empty local repo — and the log says so at every single tier:

```
Directory walk done - 0 packages
```

Nothing was ever going to satisfy those BuildRequires.

## Fix

They are all published at `repo.tunaos.org` already, so let mock see it. An isolated rebuild then resolves exactly like a full chain run.

Verified all six against the live repo metadata (98 packages published):

```
✅ exo-devel              ✅ xfce4-dev-tools
✅ libxfce4ui-devel       ✅ xfce4-panel-devel
✅ libxfce4windowing-devel ✅ gtk-layer-shell-devel
```

`cost=10` is deliberate, against `[local-build]`’s `cost=1`: a package built in the current run must always beat the published copy of itself, or a rebuild would silently link against the previous release.

## Also unblocks #82

gtkgreet needs `gtk-layer-shell-devel`, which comes from this repo’s `xfce-layer-shell` tier — it would have hit the identical wall.

## Note

The failing pipeline is orthogonal to `xfce4-cpugraph-plugin` itself; that package was simply the first tier the workflow reached. This is not a packaging bug in any individual spec.