### PR TITLE
fix(mock): run mock as a real user — it refuses to run as root

### DIFF
--- a/.github/workflows/build-mock-runner.yml
+++ b/.github/workflows/build-mock-runner.yml
@@ -7,8 +7,12 @@ on:
   push:
     branches: [main]
     paths:
+      # Any mock config, not just the cs10 one: the configs are baked into the
+      # image, so editing one in the repo has no effect until the image is
+      # rebuilt. Listing them individually meant a new chroot (or an edit to a
+      # gnome config) shipped silently stale.
       - 'mock/Containerfile'
-      - 'mock/centos-stream-10-ci.cfg'
+      - 'mock/*.cfg'
   workflow_dispatch:
 
 env:

--- a/mock/Containerfile
+++ b/mock/Containerfile
@@ -27,6 +27,20 @@ RUN dnf install -y \
 COPY centos-stream-10-ci.cfg /etc/mock/centos-stream-10-ci.cfg
 COPY centos-stream-10-ci-gnome49.cfg /etc/mock/centos-stream-10-ci-gnome49.cfg
 COPY centos-stream-10-ci-gnome50.cfg /etc/mock/centos-stream-10-ci-gnome50.cfg
+# Fedora chroot for xfwl4. Fedora already ships a Wayland-capable XFCE 4.20,
+# so it needs only the compositor built — see build-order-xfce-fedora.yml.
+# mock -r reads /etc/mock, so a config that exists only in the repo is
+# invisible to the build; it has to be baked in like the others.
+COPY fedora-44-ci.cfg /etc/mock/fedora-44-ci.cfg
+
+# mock refuses to run as root outright — even `mock --version` exits with
+# "Insufficient rights." It expects an unprivileged user in the mock group and
+# drops privileges itself. The container previously ran mock as root, which
+# worked with older mock but stopped when this image was last rebuilt and
+# picked up a newer one, breaking every package build with no build.log to
+# show for it. Ship a user for mock to run as.
+RUN useradd -m -u 1010 builder \
+    && usermod -aG mock builder
 
 LABEL org.opencontainers.image.description="Fedora + mock runner for CentOS Stream 10 package builds"
 LABEL org.opencontainers.image.source="https://github.com/tuna-os/github-copr"

--- a/scripts/build-chain.sh
+++ b/scripts/build-chain.sh
@@ -335,9 +335,21 @@ build_package_podman() {
         "${MOCK_CACHE_ARGS[@]}" \
         "${BUILD_IMAGE}" \
         bash -exc "
+            # mock refuses to run as root — even 'mock --version' exits with
+            # 'Insufficient rights.' It wants an unprivileged user in the mock
+            # group and drops privileges itself. This container runs as root,
+            # which was fine with older mock but broke every build once the
+            # runner image was rebuilt onto a newer one: mock exited before
+            # producing build.log or root.log, so the failure looked like an
+            # infrastructure glitch rather than a permissions rule.
+            #
+            # The build user needs to own what it writes: the result dir and
+            # the local repo it publishes into.
+            chown -R builder /builddir /local-repo 2>/dev/null || true
             # Use flock to ensure only one process runs mock at a time
             # because they share mock chroot initialization.
             flock /local-repo/repo.lock -c \"
+                setpriv --reuid=builder --regid=mock --init-groups \\
                 mock -r \"${MOCK_CONFIG}\" \\
                     --uniqueext='${pkg_name}' \\
                     --rebuild /builddir/SRPMS/*.src.rpm \\


### PR DESCRIPTION
Every package build has been failing with a bare `Insufficient rights.` and **no build.log or root.log**, which reads like an infrastructure glitch. It is not.

**mock refuses to run as root outright.** As root, even `mock --version` exits with that message. It expects an unprivileged user in the mock group and drops privileges itself.

The build container runs as root. That was fine with older mock, and broke when the runner image was last rebuilt (2026-07-17) onto a newer one. Because mock exits *before* creating either log, the wrapper’s “printing build.log” handler had nothing to print — which hid the cause completely.

## Reproduced and fixed locally

```
as root:    mock --version           -> Insufficient rights.
as builder: mock -r fedora-44-ci ... -> /var/lib/mock/fedora-44-ci/root/
```

The image now ships a `builder` user in the mock group, and the podman backend invokes mock through `setpriv` as that user, chowning `/builddir` and `/local-repo` first so it can write results and publish into the local repo.

## This is a *second* failure, not the one #85 fixed

| Failure | Since | Fix |
|---|---|---|
| depsolve: BuildRequires from earlier tiers missing | 2026-07-04 | #85 |
| **mock refuses to run as root** | 2026-07-17 image rebuild | **this PR** |

Both had to be fixed for a package to build — which is why #85 alone did not turn the pipeline green.

## Also here (same image)

- **`fedora-44-ci.cfg` is baked in.** `mock -r` reads `/etc/mock`, so a config that exists only in the repo is invisible to the build — the Fedora chroot added in #83 could never have been used. Verified the built image resolves it, and that its include target `/etc/mock/fedora-44-x86_64.cfg` is present.
- **`build-mock-runner.yml` rebuilds on `mock/*.cfg`**, not just `centos-stream-10-ci.cfg`. The configs are baked, so editing one has no effect until the image is rebuilt; listing them individually meant a new chroot shipped silently stale. Confirmed the rebuilt image carries #85’s `tunaos-xfce` repo.

## Verification

Built the image and ran mock through the exact `setpriv` path build-chain now uses:

```
uid=1010(builder) gid=1010(builder) groups=1010(builder),135(mock)
cs10 config    -> tunaos-xfce repo present (#85 live)
fedora-44-ci   -> /var/lib/mock/fedora-44-ci/root/
```

`bash -n` clean, shellcheck clean.