### PR TITLE
ci: build xfwl4 for Fedora

### DIFF
--- a/.github/workflows/build-xfce-fedora.yml
+++ b/.github/workflows/build-xfce-fedora.yml
@@ -1,0 +1,126 @@
+# XFCE Wayland compositor build for Fedora.
+#
+# Deliberately much smaller than build-xfce-package.yml (EL10), because Fedora
+# needs almost nothing from us: it already ships XFCE 4.20, the release that
+# added upstream Wayland support, and its xfce4-panel already links
+# gtk-layer-shell and wayland-client. greetd, gtkgreet and cage are in Fedora
+# proper too. The single gap is xfwl4, the Rust/Smithay compositor, which no
+# distro except Gentoo packages.
+#
+# So this builds one package from build-order-xfce-fedora.yml. See
+# docs/XFWL4-PORTING.md for the full survey.
+name: XFCE Wayland (Fedora)
+
+on:
+  pull_request:
+    paths:
+      - 'src/xfce-wayland/xfwl4/**'
+      - 'build-order-xfce-fedora.yml'
+      - 'mock/fedora-44-ci.cfg'
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/xfce-wayland/xfwl4/**'
+      - 'build-order-xfce-fedora.yml'
+      - 'mock/fedora-44-ci.cfg'
+  workflow_dispatch:
+
+env:
+  R2_BUCKET: bluefin
+  # Separate from the EL10 tree (xfce/10-stream-x86_64) — different dist tag,
+  # different ABI, must not be mixed.
+  R2_REPO_PATH: xfce/44-x86_64
+  # Workspace-relative so the artifact upload can reference it by a literal
+  # path — ${{ env.HOME }} is not set at workflow level and expands to empty.
+  LOCAL_REPO: ${{ github.workspace }}/local-repo
+  MOCK_RUNNER_IMAGE: ghcr.io/tuna-os/mock-runner:centos-stream-10
+
+jobs:
+  build:
+    name: xfwl4 (fedora-44)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Install host dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q podman createrepo-c rpm gpg gpgconf
+
+      - name: Set up GPG key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        run: |
+          echo "${GPG_PRIVATE_KEY}" | gpg --batch --import
+          GPG_FINGERPRINT=$(gpg --list-secret-keys --with-colons | grep '^fpr' | head -1 | cut -d: -f10)
+          echo "GPG_FINGERPRINT=${GPG_FINGERPRINT}" >> "$GITHUB_ENV"
+
+      - name: Install rclone
+        run: curl -fsSL https://rclone.org/install.sh | sudo bash
+
+      - name: Configure rclone for R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+        run: |
+          mkdir -p ~/.config/rclone
+          cat > ~/.config/rclone/rclone.conf << EOF
+          [r2]
+          type = s3
+          provider = Cloudflare
+          access_key_id = ${R2_ACCESS_KEY_ID}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
+          endpoint = ${R2_ENDPOINT}
+          EOF
+
+      # --dist is not passed: build-chain.sh derives .fc44 from the manifest's
+      # `target: fedora-44-x86_64`, so the tag cannot drift from the chroot.
+      - name: Build xfwl4
+        run: |
+          ./scripts/build-chain.sh \
+            --backend podman \
+            --manifest build-order-xfce-fedora.yml \
+            --mock-config fedora-44-ci \
+            --local-repo "${LOCAL_REPO}" \
+            --force
+
+      - name: Sign RPMs
+        run: |
+          find "${LOCAL_REPO}" -name '*.rpm' ! -name '*.src.rpm' -print0 | \
+            xargs -0 -r rpmsign --addsign \
+              --define "_gpg_name ${GPG_FINGERPRINT}" \
+              --define "_signature gpg" \
+              --define "__gpg_sign_cmd %{__gpg} gpg --force-v3-sigs --digest-algo=sha256 --batch --no-verbose --no-armor --pinentry-mode loopback --passphrase '' %{__gpg_sign_opt} %{__plaintext_filename}| %{__gpg_path} --import-options import-show --import 2>&1" \
+              --define "__gpg /usr/bin/gpg"
+
+      - name: Update local repo metadata
+        run: createrepo_c --update "${LOCAL_REPO}"
+
+      # copy, not sync. This job builds a single package into an otherwise
+      # empty local repo, so `rclone sync` would delete everything already
+      # published under this prefix. copy uploads without deleting.
+      #
+      # The createrepo_c step above regenerates repodata from the local repo
+      # and that repodata is copied too, overwriting the published metadata.
+      # That is correct only while this prefix holds xfwl4 alone. If a second
+      # Fedora package is ever added, seed the local repo from R2 before
+      # createrepo_c, or the new metadata will hide the other package.
+      - name: Publish to R2
+        if: github.event_name != 'pull_request'
+        run: |
+          rclone copy "${LOCAL_REPO}/" \
+            "r2:${R2_BUCKET}/${R2_REPO_PATH}/" \
+            --progress --transfers 8
+
+      - name: Upload RPMs as artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: xfwl4-fedora-44
+          path: local-repo/*.rpm
+          if-no-files-found: warn


### PR DESCRIPTION
#83 added the Fedora manifest and chroot, #88 baked the chroot into the runner image — but nothing ran them. The engine could target Fedora and CI never did.

Deliberately much smaller than `build-xfce-package.yml`. EL10 needs the whole XFCE stack built because it ships almost none. **Fedora 44 already ships XFCE 4.20**, the release that added upstream Wayland support, and its `xfce4-panel` already links gtk-layer-shell and wayland-client; `greetd`/`gtkgreet`/`cage` are in Fedora proper. The one gap is `xfwl4`, so this builds one package.

## Details worth knowing

- **`--dist` is deliberately not passed.** `build-chain.sh` derives `.fc44` from the manifest’s `target: fedora-44-x86_64`, so the tag cannot drift from the chroot it was built in.
- **Publishes to `xfce/44-x86_64`**, separate from the EL10 tree — different dist tag and ABI, must not be mixed.
- **`rclone copy`, not `sync`.** This job builds a single package into an otherwise empty local repo, so `sync` would delete everything already published under the prefix. The `createrepo_c` step still overwrites published metadata, which is correct only while this prefix holds xfwl4 alone — noted inline for whoever adds a second Fedora package.

## Fixes carried over from the template

Two shellcheck findings inherited from the EL10 workflow (unquoted `$GITHUB_ENV`, `find|xargs` without `-print0`/`-0`), and dropped `${{ env.HOME }}` from the artifact path — `HOME` is not set at workflow level, so it expanded to empty and the upload would have silently found nothing.

actionlint and YAML parse clean.

Refs: tuna-os/tunaOS#636