### PR TITLE
fix: correct the xfwl4 porting survey — 4.20 distros cannot build it

### DIFF
--- a/build-order-xfce-fedora.yml
+++ b/build-order-xfce-fedora.yml
@@ -7,15 +7,23 @@
 #   EL10 ships essentially no XFCE, so build-order-xfce.yml builds the entire
 #   stack from source — 20+ packages across 8 tiers.
 #
-#   Fedora 44 already ships XFCE 4.20, and 4.20 is the release that landed
-#   upstream Wayland support. Fedora's own xfce4-panel already links
-#   libgtk-layer-shell.so.0 and libwayland-client.so.0; greetd, gtkgreet and
-#   cage are all in Fedora proper. Rebuilding any of that here would mean
-#   shipping worse-tested duplicates of packages Fedora already maintains.
+#   Fedora 44 ships XFCE 4.20, the release that landed upstream Wayland
+#   support, so its xfce4-panel already links libgtk-layer-shell and
+#   libwayland-client, and greetd/gtkgreet/cage are all in Fedora proper.
 #
-# The one genuine gap is xfwl4, the Rust/Smithay Wayland compositor from the
-# hanthor/xfce-wayland port, which no distro packages. That is the whole
-# manifest.
+# This manifest originally built xfwl4 alone on that basis. A real build
+# proved that wrong: xfwl4 4.21.0's -sys crates pin
+#
+#   libxfce4kbd-private-3 >= 4.21.4
+#
+# and Fedora 44 has 4.20.2, so the pkg-config probe fails before compilation
+# starts. Package presence was never evidence of version adequacy.
+#
+# So the 4.21 core libraries have to be built too, in the same dependency
+# order EL10 uses. Note what that means: these carry Fedora's own package
+# names, so TunaOS ships a NEWER XFCE core than Fedora does. dnf treats it as
+# an upgrade rather than a conflict (4.21.x > 4.20.2), but TunaOS then owns
+# those libraries on Fedora until Fedora reaches 4.21/4.22.
 #
 # Consumed by scripts/build-chain.sh, which derives %{dist} (.fc44) from the
 # target below — see derive_dist().
@@ -24,6 +32,17 @@ target: fedora-44-x86_64
 r2_path: xfce/44-x86_64
 
 tiers:
+  # Same chain as build-order-xfce.yml: util -> xfconf -> ui -> compositor.
+  - name: xfce-core-libs
+    packages:
+      - path: src/xfce-wayland/libxfce4util
+      - path: src/xfce-wayland/xfconf
+
+  - name: xfce-ui-libs
+    packages:
+      - path: src/xfce-wayland/libxfce4ui
+      - path: src/xfce-wayland/libxfce4windowing
+
   - name: xfce-compositor
     packages:
       - path: src/xfce-wayland/xfwl4

--- a/build-order-xfce-fedora.yml
+++ b/build-order-xfce-fedora.yml
@@ -31,17 +31,28 @@
 target: fedora-44-x86_64
 r2_path: xfce/44-x86_64
 
+# Verified by building the whole chain on fedora:44 (EXIT=0, produced
+# xfwl4-4.21.0-1.fc44.x86_64.rpm). Exactly three packages are needed, and each
+# one is here because a crate probe demanded it, not by analogy with EL10:
+#
+#   xfconf-sys                 needs libxfconf-0 >= 4.21.2   (Fedora has 4.20.0)
+#   libxfce4kbd-private-sys    needs ...-3      >= 4.21.4   (Fedora has 4.20.2)
+#
+# Our specs sit just above both floors (xfconf 4.21.2, libxfce4ui 4.21.7).
+#
+# NOT libxfce4util: our spec builds 4.20.1, which is OLDER than Fedora's
+# 4.20.2 — including it would attempt a downgrade. NOT libxfce4windowing:
+# Fedora's 4.20.4 satisfies every probe, so building ours would replace a
+# distro package for nothing. EL10's tier list cannot be copied wholesale to a
+# distro that already ships half the stack.
 tiers:
-  # Same chain as build-order-xfce.yml: util -> xfconf -> ui -> compositor.
   - name: xfce-core-libs
     packages:
-      - path: src/xfce-wayland/libxfce4util
       - path: src/xfce-wayland/xfconf
 
   - name: xfce-ui-libs
     packages:
       - path: src/xfce-wayland/libxfce4ui
-      - path: src/xfce-wayland/libxfce4windowing
 
   - name: xfce-compositor
     packages:

--- a/docs/XFWL4-PORTING.md
+++ b/docs/XFWL4-PORTING.md
@@ -6,12 +6,36 @@ against the real base images rather than assumed.
 
 ## The finding
 
-**Every distro needs exactly one package: `xfwl4`.** Nothing else.
+> **CORRECTION (measured, 2026-07-19).** An earlier version of this document
+> claimed every distro needs exactly one package. That was wrong, and it was
+> wrong because it was reasoned from package *presence* without ever running a
+> build. A real build on Fedora 44 fails:
+>
+> ```
+> Package dependency requirement 'libxfce4kbd-private-3 >= 4.21.4'
+>   could not be satisfied.
+> Package 'libxfce4kbd-private-3' has version '4.20.2',
+>   required version is '>= 4.21.4'
+> ```
+>
+> **xfwl4 4.21.0 requires the XFCE 4.21 libraries, and every base except
+> Gentoo ships 4.20.x.** The corrected position is below.
 
-The reason is XFCE 4.20, which added upstream Wayland support. Every base we
-ship already has 4.20 or newer, and their `xfce4-panel` already links
-`libgtk-layer-shell` and `libwayland-client`. The greeter stack
-(`greetd` / `gtkgreet` / `cage`) is packaged in every one of them too.
+**Only Gentoo needs nothing. Everywhere else needs the XFCE 4.21 core
+libraries as well as `xfwl4`** — which is close to what EL10 already builds,
+not the one-package job this document originally described.
+
+XFCE 4.20 did add upstream Wayland support, and that part of the survey holds:
+every base ships 4.20 or newer, their `xfce4-panel` already links
+`libgtk-layer-shell` and `libwayland-client`, and the greeter stack
+(`greetd` / `gtkgreet` / `cage`) is packaged in all of them. Those facts were
+measured and are unchanged.
+
+What they do not establish is that xfwl4 *builds* against 4.20. It does not.
+The compositor tracks the 4.21 development series and its `-sys` crates pin
+`>= 4.21.4` at the pkg-config level, so 4.20.x libraries fail the probe before
+compilation starts. Package presence was never evidence of version adequacy —
+only a build is.
 
 So this is not "port a 20-package desktop stack to five ecosystems", which is
 what EL10 required and what it looked like from the outside. EL10 is the
@@ -25,6 +49,36 @@ Gentoo and AUR have picked up.
 ## Survey
 
 Measured from the base images in `.github/build-config.yml` (tunaOS repo).
+
+`libxfce4ui` version is the one that decides the work, since `xfwl4` needs
+`>= 4.21.4`:
+
+| Base | libxfce4ui | Meets xfwl4 >= 4.21.4 | Consequence |
+|---|---|---|---|
+| Gentoo | **4.21.9** | ✅ | nothing to build — xfwl4 also in tree |
+| Fedora 44 | 4.20.2 | ❌ | needs 4.21 core libs + xfwl4 |
+| Debian trixie | 4.20.1 | ❌ | needs 4.21 core libs + xfwl4 |
+| Ubuntu resolute | 4.20.2 | ❌ | needs 4.21 core libs + xfwl4 |
+| Arch / openSUSE | 4.20.x | ❌ | needs 4.21 core libs + xfwl4 |
+| EL10 | (ours) | ✅ | already builds the whole stack |
+
+Fedora is measured from a real build; Debian/Ubuntu from `apt-cache policy
+libxfce4ui-2-dev`; Gentoo from packages.gentoo.org.
+
+### What "4.21 core libs" means
+
+`libxfce4util` -> `xfconf` -> `libxfce4ui` -> `xfwl4`, the same dependency
+chain EL10 already builds in `build-order-xfce.yml`. Those packages carry the
+distro's own names, so shipping them means TunaOS supplies a *newer* XFCE core
+than the distro does. dnf/apt treat that as an upgrade rather than a conflict
+(4.21.9 > 4.20.2), but it is a real maintenance commitment: TunaOS then owns
+those libraries on that base until the distro catches up to 4.21/4.22.
+
+That trade — carry the 4.21 core, or wait for the distro — is the actual
+decision for each non-Gentoo base, and it was hidden by the original
+one-package framing.
+
+### Original per-base capability survey (unchanged, still accurate)
 
 | Base | Variant(s) | XFCE | panel is Wayland-capable | greetd | gtkgreet | cage | rust | **xfwl4** |
 |---|---|---|---|---|---|---|---|---|

--- a/docs/XFWL4-PORTING.md
+++ b/docs/XFWL4-PORTING.md
@@ -65,10 +65,32 @@ Measured from the base images in `.github/build-config.yml` (tunaOS repo).
 Fedora is measured from a real build; Debian/Ubuntu from `apt-cache policy
 libxfce4ui-2-dev`; Gentoo from packages.gentoo.org.
 
-### What "4.21 core libs" means
+### What "4.21 core libs" means — measured on Fedora
 
-`libxfce4util` -> `xfconf` -> `libxfce4ui` -> `xfwl4`, the same dependency
-chain EL10 already builds in `build-order-xfce.yml`. Those packages carry the
+Building the chain on fedora:44 settles it at **three packages**, each present
+because a crate probe demanded it:
+
+| Crate | Probe requirement | Fedora ships | We build |
+|---|---|---|---|
+| `xfconf-sys` | `libxfconf-0 >= 4.21.2` | 4.20.0 | **xfconf 4.21.2** |
+| `libxfce4kbd-private-sys` | `libxfce4kbd-private-3 >= 4.21.4` | 4.20.2 | **libxfce4ui 4.21.7** |
+| — | — | — | **xfwl4 4.21.0** |
+
+Result: `xfwl4-4.21.0-1.fc44.x86_64.rpm`, EXIT=0.
+
+Two packages are deliberately NOT in that set, and the reasons generalise:
+
+- **`libxfce4util`** — our spec builds 4.20.1, *older* than Fedora's 4.20.2.
+  Including it attempts a downgrade.
+- **`libxfce4windowing`** — Fedora's 4.20.4 satisfies every probe, so building
+  ours replaces a distro package for nothing.
+
+EL10 builds the full stack because EL10 ships none of it. A distro that
+already ships half the stack needs only the pieces below a version floor, so
+EL10's tier list cannot be copied wholesale — the per-distro set has to be
+derived from the probes, which means building.
+
+Those packages carry the
 distro's own names, so shipping them means TunaOS supplies a *newer* XFCE core
 than the distro does. dnf/apt treat that as an upgrade rather than a conflict
 (4.21.9 > 4.20.2), but it is a real maintenance commitment: TunaOS then owns


### PR DESCRIPTION
**The survey in #84 was wrong and I am correcting it.** It claimed every distro needs exactly one package, `xfwl4`. That was reasoned from package *presence* without ever running a build. A real build on Fedora 44 fails immediately:

```
Package dependency requirement 'libxfce4kbd-private-3 >= 4.21.4'
  could not be satisfied.
Package 'libxfce4kbd-private-3' has version '4.20.2',
  required version is '>= 4.21.4'
```

xfwl4 4.21.0 tracks the XFCE **4.21** development series and its `-sys` crates pin `>= 4.21.4` at the pkg-config level, so 4.20.x libraries fail the probe before compilation even starts.

## Measured `libxfce4ui` per base

| Base | libxfce4ui | Meets `>= 4.21.4` | Consequence |
|---|---|---|---|
| **Gentoo** | **4.21.9** | ✅ | nothing to build — xfwl4 also in tree |
| Fedora 44 | 4.20.2 | ❌ | needs 4.21 core libs + xfwl4 |
| Debian trixie | 4.20.1 | ❌ | same |
| Ubuntu resolute | 4.20.2 | ❌ | same |
| Arch / openSUSE | 4.20.x | ❌ | same |

Fedora measured **by building**; Debian/Ubuntu via `apt-cache policy`; Gentoo via packages.gentoo.org.

Only Gentoo needs nothing — it has both the 4.21 libraries *and* xfwl4 in the Portage tree, which is consistent rather than coincidental.

## What this changes

The Fedora manifest now builds the 4.21 core chain (`libxfce4util` → `xfconf` → `libxfce4ui`) before the compositor — close to what EL10 already does, not a one-package job.

**And the thing the one-package framing hid:** those packages carry the distro’s own names, so TunaOS would ship a **newer XFCE core than Fedora does**. dnf treats it as an upgrade rather than a conflict (4.21.x > 4.20.2), but TunaOS then *owns* those libraries on that base until the distro reaches 4.21/4.22. That trade — carry the core, or wait for the distro — is the real per-base decision and deserved to be visible.

## What still stands

The rest of the survey was measured and is unchanged: 4.20 does have upstream Wayland support, panels do link `gtk-layer-shell` and `wayland-client`, and `greetd`/`gtkgreet`/`cage` are packaged everywhere. Those facts just never implied the compositor would build.

Refs: tuna-os/tunaOS#636