### PR TITLE
fix(mock): repair the quoting and chown I broke in #88

### DIFF
--- a/scripts/build-chain.sh
+++ b/scripts/build-chain.sh
@@ -93,6 +93,10 @@ done
 # --- Helpers ---
 log() { echo "==> $*"; }
 err() { echo "ERROR: $*" >&2; }
+# Used by update_local_repo()'s retry path but never defined, so a
+# createrepo_c hiccup became "warn: command not found" (exit 127) and buried
+# whatever actually went wrong.
+warn() { echo "WARNING: $*" >&2; }
 
 # Derive the %{dist} tag from the manifest's `target:` when --dist was not
 # given. Keeps a manifest self-describing: build-order-xfce.yml says
@@ -343,18 +347,21 @@ build_package_podman() {
             # producing build.log or root.log, so the failure looked like an
             # infrastructure glitch rather than a permissions rule.
             #
-            # The build user needs to own what it writes: the result dir and
-            # the local repo it publishes into.
-            chown -R builder /builddir /local-repo 2>/dev/null || true
+            # Only /builddir: that is what mock writes results into.
+            # /local-repo is a HOST-mounted directory that mock merely reads as
+            # a repo, and chowning it to the in-container builder uid locked the
+            # runner out of its own workspace — createrepo_c then failed with
+            # "Permission denied" creating .repodata.
+            chown -R builder /builddir 2>/dev/null || true
             # Use flock to ensure only one process runs mock at a time
             # because they share mock chroot initialization.
             flock /local-repo/repo.lock -c \"
                 setpriv --reuid=builder --regid=mock --init-groups \\
-                mock -r \"${MOCK_CONFIG}\" \\
+                mock -r '${MOCK_CONFIG}' \\
                     --uniqueext='${pkg_name}' \\
                     --rebuild /builddir/SRPMS/*.src.rpm \\
                     --resultdir=/builddir/results \\
-                    --define \"dist ${DIST}\" \\
+                    --define 'dist ${DIST}' \\
                     --nocheck \\
                     --no-clean \\
                     --no-cleanup-after || {


### PR DESCRIPTION
#88 fixed mock-as-root but **shipped two new bugs**, because I verified the *config* parsed rather than executing the command the script actually emits. The gtkgreet build failed on the very next run:

```
flock: -c requires exactly one command argument
Error while creating temporary repodata directory: Permission denied
./scripts/build-chain.sh: line 140: warn: command not found
```

## 1. Quote nesting (mine)

The mock invocation lives inside `flock -c \"...\"`. I replaced `mock -r centos-stream-10-ci` with `\"${MOCK_CONFIG}\"` and `--define 'dist .el10'` with `--define \"dist ${DIST}\"`. Both use the **same escaped-quote level as the flock wrapper**, so they terminated its argument early and flock saw several. The values are expanded by the outer shell anyway, so single quotes are correct inside.

## 2. chown scope (mine)

I chowned `/local-repo` to the in-container `builder` uid — but that is a **host-mounted directory the runner owns**, and mock only *reads* it as a repo. The runner then could not create `.repodata` in its own workspace. Only `/builddir` needs to change hands.

## 3. `warn` undefined (pre-existing)

Used by `update_local_repo()`’s retry path but never defined, so a `createrepo_c` hiccup became `command not found`, exited 127, and buried the real error. Defined it.

## Verification — executed, not inspected

Ran the emitted command inside the real runner image:

```
=== does flock accept the emitted command? ===
6.5
  FLOCK+SETPRIV+MOCK PATH OK
=== /local-repo still writable by a non-builder uid? ===
  drwxr-xr-x 2 root root /local-repo
```

flock accepts it, setpriv drops to `builder`, mock answers **6.5** — the version that refuses to run as root, confirming #88’s diagnosis — and `/local-repo` stays root-owned so the host keeps write access.

shellcheck clean.