### PR TITLE
fix(mock): a comment in the container script silently disabled every build

### DIFF
--- a/scripts/build-chain.sh
+++ b/scripts/build-chain.sh
@@ -350,8 +350,15 @@ build_package_podman() {
             # Only /builddir: that is what mock writes results into.
             # /local-repo is a HOST-mounted directory that mock merely reads as
             # a repo, and chowning it to the in-container builder uid locked the
-            # runner out of its own workspace — createrepo_c then failed with
-            # "Permission denied" creating .repodata.
+            # runner out of its own workspace, so createrepo_c could not create
+            # .repodata there.
+            #
+            # NOTE: never put a double quote in this string, not even inside a
+            # comment. It is passed as bash -exc from the host shell, so a
+            # literal double quote closes it early; bash then gets the script
+            # as two arguments, treats the second as $0, and silently drops
+            # everything after the break. A quoted phrase in this very comment
+            # did that and turned the whole container step into a no-op.
             chown -R builder /builddir 2>/dev/null || true
             # Use flock to ensure only one process runs mock at a time
             # because they share mock chroot initialization.


### PR DESCRIPTION
**I broke this in #95.** The fix there was right; the comment I wrote alongside it was not.

The container step is passed as `bash -exc` from the host shell, so it is one double-quoted string. My comment contained a quoted phrase. Those literal double quotes **closed the string early**, and bash received the script as TWO arguments:

```
bash -exc $'...failed with\n  # Permission' $'denied creating...'
```

With `-c`, the first argument is the script and the second becomes `$0`. **The first argument was nothing but comment lines** — so the container ran no commands at all, exited 0, and produced no RPMs. Every podman-backend build has been a silent no-op since.

## Why it was hard to see

It fails *quietly*. podman pulls the image, returns success, and the caller reports only:

```
ERROR: No RPMs produced for xfconf
```

No mock output. No build.log. No error. The full 836-line run log contains **zero** occurrences of `flock`, `setpriv`, `mock -r` or `chown`. That absence is the signature: not a mock failure — an empty script.

I chased the wrong causes first (mock config not loading, image entrypoint swallowing the command, `--log-failed` filtering) and eliminated each. What settled it was reproducing locally and tracing the invocation with `bash -x` to see the argument split.

## After the fix

The container script runs again — mock initialises the chroot, reaches the build phase, and prints real diagnostics including `build.log` and `root.log` on failure.

Added a note where the string is built, written **without any double quotes**. The first version of that very warning contained quotes and reintroduced the bug — loudly enough that `bash -n` caught it that time.

## Not fixed here

This unblocks, but does not fix, the Fedora chain. With the script running, `xfconf` now fails for a *real* reason, and the chroot is pulling **fc45** packages because `fedora-44-x86_64.cfg` is a symlink to `fedora-rawhide-x86_64.cfg`. Separate problem, separate PR.