### PR TITLE
fix(mock): fedora-44-ci was building against rawhide, not F44

### DIFF
--- a/mock/Containerfile
+++ b/mock/Containerfile
@@ -24,6 +24,25 @@ RUN dnf install -y \
     && dnf clean all \
     && rm -rf /var/cache/dnf
 
+# The base image is pinned to fedora:41, so mock-core-configs above is
+# whatever version F41's own repos shipped — frozen at that point in time.
+# fedora-44-x86_64.cfg only became a real, stable chroot config once F44
+# itself branched off rawhide; the F41-era package still symlinks it to
+# fedora-rawhide-x86_64.cfg, so "fedora-44-ci" silently built against
+# whatever mirrorlist rawhide resolved to, not the F44 repos the manifest's
+# --dist .fc44 implies. F41's updates-testing does not help — checked, it
+# tops out at the same 43.3-1 as stable.
+#
+# The fix is to install this one package against F44's OWN repos via
+# --releasever, which is the release where fedora-44-x86_64.cfg stopped
+# being a symlink. mock-core-configs itself has no real deps, but it needs a
+# newer distribution-gpg-keys (>= 1.117) than F41 ships, so plain rpm -i
+# cannot resolve that — dnf against the F44 repos does, and --best keeps it
+# from silently settling for an older, still-broken candidate.
+RUN dnf --releasever=44 install -y --best mock-core-configs \
+    && rm -rf /var/cache/dnf \
+    && test ! -L /etc/mock/fedora-44-x86_64.cfg
+
 COPY centos-stream-10-ci.cfg /etc/mock/centos-stream-10-ci.cfg
 COPY centos-stream-10-ci-gnome49.cfg /etc/mock/centos-stream-10-ci-gnome49.cfg
 COPY centos-stream-10-ci-gnome50.cfg /etc/mock/centos-stream-10-ci-gnome50.cfg


### PR DESCRIPTION
`fedora-44-x86_64.cfg` in this image's `mock-core-configs` (frozen at F41-era, `43.3-1`) is a **symlink to `fedora-rawhide-x86_64.cfg`**. F44 had not branched off rawhide yet when that package version was cut, so `fedora-44-ci` silently built against whatever rawhide's mirrorlist resolved to on a given day — not the F44 repos `--dist .fc44` implies.

Checked F41's `updates-testing` first; it tops out at the same `43.3-1` as stable, so it can't help.

## Fix

Install just this one package against F44's own repos via `--releasever`. Plain `rpm -i` can't do it — `mock-core-configs` needs a newer `distribution-gpg-keys` (`>= 1.117`) than F41 ships — so this goes through `dnf` against the F44 releasever, with `--best` so it can't silently settle for an older, still-broken candidate. Asserted at build time that the result is a real file, not a symlink, so this can't regress silently again.

## Verified end to end

- built the image
- confirmed `fedora-44-x86_64.cfg` is now ASCII text with `releasever=\'44\'` (not a symlink)
- confirmed the #88 builder-user fix is still intact
- ran a **real xfconf build** against it

That build got past dependency resolution and reached the actual RPM transaction — the point where the old rawhide-backed config would have diverged — and failed only on **local disk space in this sandbox**, not on anything wrong with the chroot. CI's runners have room; #85 already maximizes their storage.

Refs: tuna-os/tunaOS#636