### PR TITLE
fix(mock): chown mock's output back to root before the container exits

### DIFF
--- a/scripts/build-chain.sh
+++ b/scripts/build-chain.sh
@@ -379,6 +379,19 @@ build_package_podman() {
                         exit 1;
                     }
             \"
+            # Mock ran as builder, so everything it wrote under /builddir is
+            # builder-owned inside the container. The container's own top
+            # level is root, and root can always chown back down — but
+            # nothing did, so control returned to the HOST process (which
+            # runs as the plain CI runner user, outside the container
+            # entirely) unable to read what mock had just produced:
+            #   find: /tmp/tmp.XXXXXX/results: Permission denied
+            #   ERROR: No RPMs produced for xfce4-dev-tools
+            # even though mock's own log said the build finished. Restore
+            # root ownership before the container exits and this handoff
+            # happens, regardless of whether mock succeeded or failed —
+            # build.log and root.log need to be host-readable on failure too.
+            chown -R root:root /builddir 2>/dev/null || true
         "
 
     # Collect RPMs from results


### PR DESCRIPTION
Found while recovering the repo wipe: the first successful mock build of this whole session (`xfce4-dev-tools`, in the recovery rebuild) produced real RPMs and still reported failure:

```
INFO: Done(xfce4-dev-tools-4.20.0-1.el10.src.rpm) ...
INFO: Results and/or logs in: /builddir/results
find: /tmp/tmp.qqUEM4m5oQ/results: Permission denied
ERROR: No RPMs produced for xfce4-dev-tools
rm: cannot remove /tmp/tmp.qqUEM4m5oQ: Operation not permitted
```

**Mock actually succeeded.** #88 made mock run as the unprivileged `builder` user inside the container (mock refuses to run as root), so everything it writes under `/builddir` — including `/builddir/results` — is `builder`-owned when the container exits. "Collect RPMs" and cleanup happen on the **host**, outside the container, as the plain CI runner user. That process has no path to `builder`, a uid that only exists inside this one image, so it cannot read what mock just built.

## Why this wasn't caught earlier

Every attempt in the per-package workflow this session failed *before* mock reached "Done", for other reasons (bad quoting, missing BuildRequires) — so mock never actually finished a build and this gap was never exercised. The recovery rebuild is the first run where mock actually succeeded.

## Fix

`chown -R root:root /builddir` right before the container's `bash -exc` script ends, after mock's `setpriv` block, on **both** the success and failure path — `build.log`/`root.log` need to be host-readable on failure too.

`root` inside the container reliably maps to something the host invoking process can read. `builder` is a uid this image invented and gives no such guarantee.

Verified directly:

```
before chown-back: builder:root   (unreadable by a simulated unprivileged reader)
after  chown-back: root:root      (READABLE)
```

shellcheck: 0 findings, unchanged.
