### PR TITLE
feat(arch): build xfconf and libxfce4ui for real; confirm xfwl4 builds

### DIFF
--- a/docs/XFWL4-PORTING.md
+++ b/docs/XFWL4-PORTING.md
@@ -154,11 +154,32 @@ Skeleton: `packaging/opensuse/`.
 
 All three share one source package. Skeleton: `packaging/debian/`.
 
-### 5. Arch (marlin) — PKGBUILD
+### 5. Arch (marlin) — PKGBUILD — built, measured
 
-AUR `xfwl4-git` exists and tracks git rather than the 4.21.0 release. Prefer our
-own PKGBUILD pinned to the same commit the RPM uses, so all variants ship the
-identical compositor. Skeleton: `packaging/arch/`.
+AUR `xfwl4-git` exists and tracks git rather than the 4.21.0 release. We
+package our own, pinned to the same commit the RPM and .deb both build, so
+every variant ships the identical compositor.
+
+Confirmed by a real `makepkg` build (Arch container, `xfconf` +
+`libxfce4ui` installed locally via `pacman -U` ahead of the compositor
+build): same three-package set as Fedora, no fourth package needed.
+
+- `xfconf` 4.21.2-1 — `makedepends` needed `glib2-devel` in addition to
+  `glib2`: `glib-genmarshal` lives in the `-devel` split, and meson's
+  `glib-2.0` probe wants it at configure time even though nothing links
+  against it.
+- `libxfce4ui` 4.21.7-1 — same `glib2-devel` fix applied pre-emptively.
+- `xfwl4` 4.21.0-1 — built clean once the two above were installed;
+  `pkg-config --modversion libxfconf-0` / `libxfce4kbd-private-3` confirmed
+  the local packages satisfied both probes before `makepkg` ran.
+
+Unlike Debian and Fedora, Arch's `libxfce4util` ships a `.vapi` (not just a
+`.gir`), so vala did not need to be disabled — one less workaround than the
+other two ecosystems needed.
+
+`makepkg` builds with the network up, so `cargo fetch` works directly for
+xfwl4's `smithay` git dependency — no vendor tarball step like the RPM/deb
+builds need.
 
 ## What makes xfwl4 harder than a normal Rust package
 

--- a/src/xfce-wayland/libxfce4ui/packaging/arch/PKGBUILD
+++ b/src/xfce-wayland/libxfce4ui/packaging/arch/PKGBUILD
@@ -1,0 +1,40 @@
+# Maintainer: TunaOS Bot <bot@tunaos.org>
+#
+# libxfce4ui for marlin (Arch). Arch's repo package is 4.20.2; xfwl4's
+# libxfce4kbd-private-sys crate pins >= 4.21.4. Pinned to the same commit
+# ../../../libxfce4ui.spec builds.
+
+pkgname=libxfce4ui
+pkgver=4.21.7
+pkgrel=1
+_commit=c07644b91e627341452c881392bf417d4dbc0031
+pkgdesc="Widget library for Xfce, including libxfce4kbd-private"
+arch=('x86_64')
+url="https://gitlab.xfce.org/xfce/libxfce4ui"
+license=('GPL-2.0-or-later' 'LGPL-2.1-or-later')
+depends=('gtk3' 'libxfce4util' 'xfconf' 'libsm' 'startup-notification'
+         'libgtop' 'libepoxy' 'libgudev')
+# glib2-devel: glib-genmarshal, needed by meson's glib-2.0 probe at
+# configure time (see xfconf's PKGBUILD — same upstream meson.build pattern).
+makedepends=('meson' 'ninja' 'gobject-introspection' 'vala' 'intltool' 'gettext' 'glib2-devel')
+provides=('libxfce4ui-2.so' 'libxfce4kbd-private-3.so')
+source=("libxfce4ui-${_commit}.tar.gz::${url}/-/archive/${_commit}/libxfce4ui-${_commit}.tar.gz")
+sha256sums=('SKIP')
+
+pkgver() {
+	echo "$pkgver"
+}
+
+build() {
+	cd "libxfce4ui-${_commit}"
+	arch-meson . build
+	meson compile -C build
+}
+
+# No check(): same D-Bus-needs-a-session gap as xfconf's PKGBUILD.
+
+package() {
+	cd "libxfce4ui-${_commit}"
+	meson install -C build --destdir "$pkgdir"
+	install -Dm644 COPYING "$pkgdir/usr/share/licenses/$pkgname/COPYING"
+}

--- a/src/xfce-wayland/xfconf/packaging/arch/PKGBUILD
+++ b/src/xfce-wayland/xfconf/packaging/arch/PKGBUILD
@@ -1,0 +1,51 @@
+# Maintainer: TunaOS Bot <bot@tunaos.org>
+#
+# xfconf for marlin (Arch). Arch's repo package is 4.20.0; xfwl4's
+# libxfce4kbd-private-sys and xfconf-sys crates pin >= 4.21.4/4.21.2
+# respectively (measured by building against Fedora and Debian's stock
+# packages, both of which fail the same way). Pinned to the same commit
+# ../../../xfconf.spec builds, so every TunaOS variant ships an identical
+# xfconf.
+#
+# Unlike Debian/Fedora, vala is left enabled: Arch's libxfce4util ships
+# /usr/share/vala/vapi/libxfce4util-1.0.vapi (Debian and Fedora only ship
+# the .gir), so vapigen has what it needs and there is nothing to disable.
+
+pkgname=xfconf
+pkgver=4.21.2
+pkgrel=1
+_commit=a6f0a7aa9073f9d8a0935cee73c0da52b6e49660
+pkgdesc="Xfce configuration daemon and library"
+arch=('x86_64')
+url="https://gitlab.xfce.org/xfce/xfconf"
+license=('GPL-2.0-or-later')
+depends=('glib2' 'dbus' 'libxfce4util')
+# glib-genmarshal lives in glib2-devel, not glib2 itself — meson's
+# glib-2.0 dependency probe needs it at configure time even though it is
+# never linked into the final binary.
+makedepends=('meson' 'ninja' 'gobject-introspection' 'vala' 'intltool' 'gettext' 'glib2-devel')
+provides=('libxfconf-0.so')
+source=("xfconf-${_commit}.tar.gz::${url}/-/archive/${_commit}/xfconf-${_commit}.tar.gz")
+# SKIP is a scaffold placeholder — fill in before this is trusted.
+sha256sums=('SKIP')
+
+pkgver() {
+	echo "$pkgver"
+}
+
+build() {
+	cd "xfconf-${_commit}"
+	arch-meson . build
+	meson compile -C build
+}
+
+# Same D-Bus-needs-a-session gap as the Debian/RPM builds: meson test tries
+# to launch xfconfd against dbus-launch, which has nothing to autolaunch
+# into inside makepkg's chroot. No `check()` function is defined for the
+# same reason the RPM spec and Debian rules both skip tests.
+
+package() {
+	cd "xfconf-${_commit}"
+	meson install -C build --destdir "$pkgdir"
+	install -Dm644 COPYING "$pkgdir/usr/share/licenses/$pkgname/COPYING"
+}


### PR DESCRIPTION
## Summary
- Same 4.21 version-floor gap already fixed on Fedora and (partially) Debian: Arch's stock `xfconf` (4.20.0) and `libxfce4ui` (4.20.2) fall below what xfwl4's `-sys` crates pin (`>= 4.21.2` / `>= 4.21.4`).
- Packaged both at the identical pinned commits the RPM/`.deb` build, so every TunaOS variant ships the same XFCE core and compositor.
- Confirmed the whole chain with a real `makepkg` build in a fresh Arch container: `xfconf` → `libxfce4ui` → `xfwl4`, installing each local package via `pacman -U` before the next stage, verified with `pkg-config --modversion` at each step.
- Same three-package set Fedora needed — no fourth package, no AUR dependency.
- Real bug found and fixed: `glib-genmarshal` lives in Arch's `glib2-devel` split, not `glib2` itself; meson's `glib-2.0` probe wants it at configure time even though nothing links against it. Added to both `xfconf` and `libxfce4ui` `makedepends`.
- Arch's `libxfce4util` ships a `.vapi` (unlike Debian/Fedora, which only ship `.gir`), so vala did not need disabling — one less workaround than the other ecosystems needed.

## Test plan
- [x] `xfconf-4.21.2-1-x86_64.pkg.tar.zst` built clean via `makepkg` in an `archlinux:latest` container
- [x] `libxfce4ui-4.21.7-1-x86_64.pkg.tar.zst` built clean the same way
- [x] `xfwl4-4.21.0-1-x86_64.pkg.tar.zst` built clean against the two local packages, `pkg-config --modversion libxfconf-0` / `libxfce4kbd-private-3` confirmed the version floors were satisfied before compilation started

🤖 Generated with [Claude Code](https://claude.com/claude-code)