### PR TITLE
fix(ci): repair Fedora workflow's broken RPM signing macro

### DIFF
--- a/.github/workflows/build-xfce-fedora.yml
+++ b/.github/workflows/build-xfce-fedora.yml
@@ -51,13 +51,14 @@ jobs:
           sudo apt-get update -q
           sudo apt-get install -y -q podman createrepo-c rpm gpg gpgconf
 
-      - name: Set up GPG key
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-        run: |
-          echo "${GPG_PRIVATE_KEY}" | gpg --batch --import
-          GPG_FINGERPRINT=$(gpg --list-secret-keys --with-colons | grep '^fpr' | head -1 | cut -d: -f10)
-          echo "GPG_FINGERPRINT=${GPG_FINGERPRINT}" >> "$GITHUB_ENV"
+      - name: Import GPG key
+        id: import-gpg
+        uses: crazy-max/ghaction-import-gpg@v7
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_committer_name: RPM Builder
+          git_committer_email: rpm-signing@tunaos.org
 
       - name: Install rclone
         run: curl -fsSL https://rclone.org/install.sh | sudo bash
@@ -89,14 +90,22 @@ jobs:
             --local-repo "${LOCAL_REPO}" \
             --force
 
+      # Same macro shape as build-xfce-distributed.yml's publish job — that
+      # one works, this one previously hand-rolled a __gpg_sign_cmd that was
+      # missing the actual "-u ... -sbo ..." signing directive and instead
+      # piped into an unrelated --import-options import-show --import,
+      # which made every rpmsign invocation fail with "gpg: invalid option
+      # '-|'". Reuse the known-good macro instead of re-deriving one.
+      - name: Configure RPM macros
+        run: |
+          echo "%_signature gpg" > ~/.rpmmacros
+          echo "%_gpg_name ${{ steps.import-gpg.outputs.keyid }}" >> ~/.rpmmacros
+          echo "%__gpg_sign_cmd %{__gpg} gpg --batch --no-verbose --no-armor --use-agent --no-secmem-warning -u \"%{_gpg_name}\" -sbo %{__signature_filename} %{__plaintext_filename}" >> ~/.rpmmacros
+
       - name: Sign RPMs
         run: |
           find "${LOCAL_REPO}" -name '*.rpm' ! -name '*.src.rpm' -print0 | \
-            xargs -0 -r rpmsign --addsign \
-              --define "_gpg_name ${GPG_FINGERPRINT}" \
-              --define "_signature gpg" \
-              --define "__gpg_sign_cmd %{__gpg} gpg --force-v3-sigs --digest-algo=sha256 --batch --no-verbose --no-armor --pinentry-mode loopback --passphrase '' %{__gpg_sign_opt} %{__plaintext_filename}| %{__gpg_path} --import-options import-show --import 2>&1" \
-              --define "__gpg /usr/bin/gpg"
+            xargs -0 -r rpmsign --addsign
 
       - name: Update local repo metadata
         run: createrepo_c --update "${LOCAL_REPO}"


### PR DESCRIPTION
## Summary
- `build-xfce-fedora.yml`'s `Sign RPMs` step hand-rolled its own `__gpg_sign_cmd` RPM macro, which was missing the actual `-u ... -sbo ...` signing directive and instead appended an unrelated `| %{__gpg_path} --import-options import-show --import`.
- Every `rpmsign --addsign` call failed with `gpg: invalid option '-|'` — confirmed on PR #98's run: the build itself succeeded (10 RPMs produced: xfwl4, xfconf, libxfce4ui with their debuginfo/devel splits) and only the sign step failed.
- `build-xfce-distributed.yml`'s `publish` job already has a working macro of this exact shape (via `crazy-max/ghaction-import-gpg` + a plain `%__gpg_sign_cmd` echoed into `~/.rpmmacros`). Reused it verbatim instead of re-deriving a new one.

## Test plan
- [x] Diffed the new macro against `build-xfce-distributed.yml`'s known-working one — identical shape
- [ ] Re-run `XFCE Wayland (Fedora)` on a PR touching `src/xfce-wayland/xfwl4/**` to confirm signing succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)