### PR TITLE
fix(ci): stop the VNC screenshot step from sinking verify-gdm(-copr)

### DIFF
--- a/.github/workflows/build-gnome49-verify.yml
+++ b/.github/workflows/build-gnome49-verify.yml
@@ -224,6 +224,15 @@ jobs:
           exit 1
 
       - name: Take login screen screenshot via VNC
+        # Best-effort: the real verification (GDM active, gnome-shell
+        # stable, no crash signatures) already passed above. This step
+        # was previously unguarded and, when the VNC port lookup came up
+        # empty, would hang until the job's 45-minute timeout killed the
+        # whole job — turning a cosmetic screenshot into the difference
+        # between green and red on every PR. continue-on-error so a
+        # missing screenshot never overrides the real result.
+        timeout-minutes: 3
+        continue-on-error: true
         run: |
           VNC_DISPLAY=$(cat /proc/$(pgrep -f 'qemu.*gnome49-verify' | head -1)/cmdline \
             | tr '\0' '\n' | grep -oP '(?<=vnc=127\.0\.0\.1:)\d+' || echo "0")
@@ -449,6 +458,15 @@ jobs:
           exit 1
 
       - name: Take login screen screenshot via VNC
+        # Best-effort: the real verification (GDM active, gnome-shell
+        # stable, no crash signatures) already passed above. This step
+        # was previously unguarded and, when the VNC port lookup came up
+        # empty, would hang until the job's 45-minute timeout killed the
+        # whole job — turning a cosmetic screenshot into the difference
+        # between green and red on every PR. continue-on-error so a
+        # missing screenshot never overrides the real result.
+        timeout-minutes: 3
+        continue-on-error: true
         run: |
           VNC_DISPLAY=$(cat /proc/$(pgrep -f 'qemu.*gnome49-verify-copr' | head -1)/cmdline \
             | tr '\0' '\n' | grep -oP '(?<=vnc=127\.0\.0\.1:)\d+' || echo "0")

--- a/.github/workflows/build-gnome50-verify.yml
+++ b/.github/workflows/build-gnome50-verify.yml
@@ -210,6 +210,15 @@ jobs:
           exit 1
 
       - name: Take login screen screenshot via VNC
+        # Best-effort: the real verification (GDM active, gnome-shell
+        # stable, no crash signatures) already passed above. This step
+        # was previously unguarded and, when the VNC port lookup came up
+        # empty, would hang until the job's 45-minute timeout killed the
+        # whole job — turning a cosmetic screenshot into the difference
+        # between green and red on every PR. continue-on-error so a
+        # missing screenshot never overrides the real result.
+        timeout-minutes: 3
+        continue-on-error: true
         run: |
           # Lima exposes VNC — find the port from the QEMU process
           VNC_DISPLAY=$(cat /proc/$(pgrep -f 'qemu.*gnome50-verify' | head -1)/cmdline \
@@ -438,6 +447,15 @@ jobs:
           exit 1
 
       - name: Take login screen screenshot via VNC
+        # Best-effort: the real verification (GDM active, gnome-shell
+        # stable, no crash signatures) already passed above. This step
+        # was previously unguarded and, when the VNC port lookup came up
+        # empty, would hang until the job's 45-minute timeout killed the
+        # whole job — turning a cosmetic screenshot into the difference
+        # between green and red on every PR. continue-on-error so a
+        # missing screenshot never overrides the real result.
+        timeout-minutes: 3
+        continue-on-error: true
         run: |
           VNC_DISPLAY=$(cat /proc/$(pgrep -f 'qemu.*gnome50-verify-copr' | head -1)/cmdline \
             | tr '\0' '\n' | grep -oP '(?<=vnc=127\.0\.0\.1:)\d+' || echo "0")


### PR DESCRIPTION
## Summary
Every `verify-gdm` and `verify-gdm-copr` run across every open PR in this repo fails identically at 45m14s — that's the job's own `timeout-minutes: 45` killing it, not a real regression.

Looked at one run in detail ([88267981422](https://github.com/tuna-os/github-copr/actions/runs/29715529193/job/88267981422)): every real verification step (start VM, enable GDM/COPR, wait for GDM active, check greeter stability, scan journal for crash signatures, "Check results and file issue if broken") completes and passes within the first ~4 minutes. The remaining ~41 minutes is "Take login screen screenshot via VNC" hanging — it has no step-level timeout, so when the VNC port lookup doesn't resolve cleanly it just sits until the job budget runs out, and the whole job gets marked failed/cancelled even though the actual thing being verified was fine.

## Fix
Add `timeout-minutes: 3` and `continue-on-error: true` to all four occurrences (gnome49/gnome50 × direct/copr variants). The screenshot is best-effort evidence uploaded as an artifact — it was never part of the pass/fail signal, which already happens earlier in "Check results and file issue if broken".

## Test plan
- [x] `yaml.safe_load` both files, no syntax errors
- [ ] Next `verify-gdm`/`verify-gdm-copr` run completes well under 45 minutes regardless of whether the screenshot succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)