### PR TITLE
feat(fprintd): package libfprint + fprintd for aarch64 (spec validation)

### DIFF
--- a/.github/workflows/build-fprintd-validation.yml
+++ b/.github/workflows/build-fprintd-validation.yml
@@ -1,0 +1,50 @@
+# Throwaway validation build for src/deps/libfprint + src/deps/fprintd on
+# x86_64 EL10 — proves the specs are correct BEFORE any aarch64 build infra
+# gets built. Both packages already ship on EL10 x86_64 today, so a green
+# run here only confirms "the spec is right", not "aarch64 works" — that
+# is a separate, larger piece of work (aarch64 mock/runner infra does not
+# exist in this repo yet). See docs/FPRINTD-AARCH64.md.
+#
+# No signing, no R2 publish — this manifest's r2_path
+# (fprintd-validation/10-stream-x86_64) is intentionally never published to.
+name: fprintd validation (x86_64, throwaway)
+
+on:
+  pull_request:
+    paths:
+      - 'src/deps/libfprint/**'
+      - 'src/deps/fprintd/**'
+      - 'build-order-fprintd.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: libfprint + fprintd (centos-stream-10-x86_64)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: false
+
+      - name: Install host dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q podman createrepo-c rpm
+
+      - name: Build libfprint + fprintd
+        run: |
+          ./scripts/build-chain.sh \
+            --backend podman \
+            --manifest build-order-fprintd.yml \
+            --mock-config centos-stream-10-ci \
+            --local-repo "${{ github.workspace }}/local-repo" \
+            --force
+
+      - name: Upload RPMs as artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: fprintd-validation-x86_64
+          path: local-repo/*.rpm
+          if-no-files-found: warn

--- a/build-order-fprintd.yml
+++ b/build-order-fprintd.yml
@@ -1,0 +1,34 @@
+# Build Order Manifest for fprintd + libfprint on EL10 aarch64.
+#
+# Neither package is built for aarch64 in CentOS Stream 10's own repos —
+# only x86_64. That makes cosmic-greeter (hard dependency: fprintd-pam)
+# uninstallable on aarch64, which is why tunaOS pinned cosmic to
+# linux/amd64 + linux/amd64/v2 only (tunaOS .github/build-config.yml).
+#
+# Fedora builds both for aarch64 with no ExclusiveArch restriction, so this
+# is a genuine RHEL/CentOS packaging gap, not an upstream limitation.
+# Verified by comparing CentOS Stream 10's AppStream (x86_64 only) against
+# Fedora 44's aarch64 repo, which carries libfprint-1.94.10 and
+# fprintd-pam-1.94.5 for aarch64.
+#
+# Pinned to 1.94.8 (libfprint) / 1.94.5 (fprintd) — the exact versions
+# already shipping in CentOS Stream 10's x86_64 repos, so both
+# architectures carry an identical fprintd/libfprint rather than
+# introducing version skew between arches.
+#
+# target/r2_path below are for the x86_64 validation pass (these packages
+# already exist on x86_64, so this tier only proves the specs are correct —
+# see docs/FPRINTD-AARCH64.md). The aarch64 target that actually matters
+# needs its own manifest once aarch64 build infra exists in this repo.
+
+target: centos-stream-10-x86_64
+r2_path: fprintd-validation/10-stream-x86_64
+
+tiers:
+  - name: fprint-core
+    packages:
+      - path: src/deps/libfprint
+
+  - name: fprint-service
+    packages:
+      - path: src/deps/fprintd

--- a/src/deps/fprintd/fprintd.spec
+++ b/src/deps/fprintd/fprintd.spec
@@ -1,0 +1,106 @@
+Name: fprintd
+Version: 1.94.5
+Release: 1%{?dist}
+Summary: D-Bus service for Fingerprint reader access
+
+# man page is GFDL-1.1-or-later
+License: GPL-2.0-or-later AND GFDL-1.1-or-later
+URL: http://www.freedesktop.org/wiki/Software/fprint/fprintd
+Source0: https://gitlab.freedesktop.org/libfprint/fprintd/-/archive/v%{version}/fprintd-v%{version}.tar.gz
+
+BuildRequires: gcc, gcc-c++, git, meson, ninja-build
+BuildRequires: pam-devel
+BuildRequires: libfprint-devel >= 1.94.0
+BuildRequires: polkit-devel
+BuildRequires: gettext
+BuildRequires: perl-podlators
+BuildRequires: pkgconfig(libsystemd)
+BuildRequires: pkgconfig(systemd)
+
+%description
+D-Bus service to access fingerprint readers. Packaged here, alongside
+libfprint in this same repo, because EL10 does not build either for
+aarch64 — present on x86_64 only — which makes cosmic-greeter (which hard
+requires the fprintd-pam subpackage) uninstallable there. Pinned to
+1.94.5, the same version already shipping in CentOS Stream 10's own
+x86_64 repos, so both architectures carry an identical fprintd rather
+than introducing version skew.
+
+%package pam
+Summary: PAM module for fingerprint authentication
+Requires: %{name} = %{version}-%{release}
+# Note that we obsolete pam_fprint, but as the configuration
+# is different, it will be mentioned in the release notes
+Provides: pam_fprint = %{version}-%{release}
+Obsoletes: pam_fprint < 0.2-3
+Requires(postun): authselect >= 0.3
+
+License: GPL-2.0-or-later
+
+%description pam
+PAM module that uses the fprintd D-Bus service for fingerprint
+authentication. This is the actual dependency cosmic-greeter needs.
+
+%package devel
+Summary: Development files for %{name}
+Requires: %{name} = %{version}-%{release}
+# dbus interfaces are GPL-2.0-or-later
+# documentation is GFDL-1.1-or-later
+License: GPL-2.0-or-later AND GFDL-1.1-or-later
+BuildArch: noarch
+
+%description devel
+Development documentation for fprintd, the D-Bus service for
+fingerprint readers access.
+
+%prep
+%autosetup -S git -n %{name}-v%{version}
+
+%build
+# gtk_doc defaults to false in meson_options.txt (unlike Fedora's spec,
+# which turns it on for its -devel doc subpackage); left off here since
+# nothing downstream needs the generated docs, only the compositor/greeter
+# binary — keeps gtk-doc off the BuildRequires list entirely.
+%meson -Dgtk_doc=false -Dpam=true -Dpam_modules_dir=%{_libdir}/security
+%meson_build
+
+%install
+%meson_install
+mkdir -p %{buildroot}%{_localstatedir}/lib/fprint
+
+%find_lang %{name}
+
+# No %%check: fprintd's test suite needs python3-dbusmock + python3-libpamtest
+# to simulate a live D-Bus session and a PAM stack, neither meaningful in the
+# mock chroot — same reason every other package in this repo skips tests.
+
+%postun pam
+if [ $1 -eq 0 ]; then
+  /bin/authselect disable-feature with-fingerprint || :
+fi
+
+%files -f %{name}.lang
+%doc README COPYING AUTHORS TODO
+%{_bindir}/fprintd-*
+%{_libexecdir}/fprintd
+# FIXME This file should be marked as config when it does something useful
+%{_sysconfdir}/fprintd.conf
+%{_datadir}/dbus-1/system.d/net.reactivated.Fprint.conf
+%{_datadir}/dbus-1/system-services/net.reactivated.Fprint.service
+%{_unitdir}/fprintd.service
+%{_datadir}/polkit-1/actions/net.reactivated.fprint.device.policy
+%attr(0700, -, -) %{_localstatedir}/lib/fprint
+%{_mandir}/man1/fprintd.1.gz
+
+%files pam
+%doc pam/README
+%{_libdir}/security/pam_fprintd.so
+%{_mandir}/man8/pam_fprintd.8.gz
+
+%files devel
+%{_datadir}/dbus-1/interfaces/net.reactivated.Fprint.Device.xml
+%{_datadir}/dbus-1/interfaces/net.reactivated.Fprint.Manager.xml
+
+%changelog
+* Sun Jul 20 2026 TunaOS Bot <bot@tunaos.org> - 1.94.5-1
+- Packaged to unblock cosmic-greeter (fprintd-pam) on EL10 aarch64

--- a/src/deps/libfprint/libfprint.spec
+++ b/src/deps/libfprint/libfprint.spec
@@ -1,0 +1,82 @@
+Name: libfprint
+Version: 1.94.8
+Release: 1%{?dist}
+Summary: Toolkit for fingerprint scanner
+
+# Automatically converted from old format: LGPLv2+ - review is highly recommended.
+# Most of the code is LGPL-2.1-or-later
+# libfprint/nbis is NIST-PD
+License: LGPL-2.1-or-later AND NIST-PD
+URL: http://www.freedesktop.org/wiki/Software/fprint/libfprint
+Source0: https://gitlab.freedesktop.org/libfprint/libfprint/-/archive/v%{version}/libfprint-v%{version}.tar.gz
+
+BuildRequires: gcc, gcc-c++, git, meson, ninja-build
+BuildRequires: openssl-devel
+BuildRequires: pkgconfig(glib-2.0) >= 2.50
+BuildRequires: pkgconfig(gio-2.0) >= 2.44.0
+BuildRequires: pkgconfig(gusb) >= 0.3.0
+BuildRequires: pkgconfig(nss)
+BuildRequires: pkgconfig(pixman-1)
+BuildRequires: libgudev-devel
+BuildRequires: systemd
+BuildRequires: gobject-introspection-devel
+
+%description
+libfprint offers support for consumer fingerprint reader devices. Packaged
+here because EL10 does not build it for aarch64 (present on x86_64), which
+in turn makes fprintd-pam — a hard dependency of cosmic-greeter — uninstallable
+there. Pinned to 1.94.8, the same version already shipping in CentOS Stream
+10's own x86_64 repos, so both architectures carry an identical libfprint
+rather than introducing version skew.
+
+%package devel
+Summary: Development files for %{name}
+Requires: %{name}%{?_isa} = %{version}-%{release}
+
+%description devel
+Headers and pkgconfig files for building applications against libfprint.
+
+%prep
+%autosetup -S git -n libfprint-v%{version}
+
+%build
+# Fedora's spec builds -Ddrivers=all to cover the virtual image driver used
+# by its integration tests; those tests aren't run here (see %%install), so
+# the default driver set is enough and keeps the dependency footprint down.
+#
+# doc and installed-tests default to true in meson_options.txt. gtk-doc is
+# deliberately not in BuildRequires (no docs subpackage here), and installed
+# tests are never listed in %%files, so both must be turned off explicitly —
+# otherwise meson either fails on a missing gtk-doc tool or rpmbuild fails
+# its unpackaged-files check on the installed-tests tree.
+%meson -Ddoc=false -Dinstalled-tests=false
+%meson_build
+
+%install
+%meson_install
+
+%ldconfig_scriptlets
+
+# No %%check: libfprint's test suite needs umockdev-recorded device replay
+# and a D-Bus session, neither available in the mock chroot — same reason
+# every other package in this repo skips tests.
+
+%files
+%license COPYING
+%doc NEWS THANKS AUTHORS README.md
+%{_libdir}/*.so.*
+%{_libdir}/girepository-1.0/*.typelib
+%{_udevhwdbdir}/60-autosuspend-libfprint-2.hwdb
+%{_udevrulesdir}/70-libfprint-2.rules
+%{_datadir}/metainfo/org.freedesktop.libfprint.metainfo.xml
+
+%files devel
+%doc HACKING.md
+%{_includedir}/*
+%{_libdir}/*.so
+%{_libdir}/pkgconfig/%{name}-2.pc
+%{_datadir}/gir-1.0/*.gir
+
+%changelog
+* Sun Jul 20 2026 TunaOS Bot <bot@tunaos.org> - 1.94.8-1
+- Packaged to unblock cosmic-greeter (fprintd-pam) on EL10 aarch64

--- a/src/deps/libfprint/libfprint.spec
+++ b/src/deps/libfprint/libfprint.spec
@@ -68,7 +68,11 @@ Headers and pkgconfig files for building applications against libfprint.
 %{_libdir}/girepository-1.0/*.typelib
 %{_udevhwdbdir}/60-autosuspend-libfprint-2.hwdb
 %{_udevrulesdir}/70-libfprint-2.rules
-%{_datadir}/metainfo/org.freedesktop.libfprint.metainfo.xml
+# NOT %{_datadir}/metainfo/org.freedesktop.libfprint.metainfo.xml — that
+# file is in Fedora's rawhide spec (1.94.10) but does not exist anywhere in
+# the 1.94.8 tarball; a real mock build failed on it (RPM_BUILD_ROOT missing
+# the file) before this was caught, confirming the two versions' Fedora
+# specs are not interchangeable line-for-line.
 
 %files devel
 %doc HACKING.md


### PR DESCRIPTION
## Summary
`cosmic-greeter` hard-requires `fprintd-pam`, which CentOS Stream 10 only builds for x86_64 — confirmed by comparing CentOS Stream 10's AppStream repo (x86_64 only, verified via directory listing) against Fedora 44's aarch64 repo, which carries both `libfprint-1.94.10` and `fprintd-pam-1.94.5` for aarch64 with no `ExclusiveArch` restriction in either spec. This is a RHEL/CentOS packaging gap, not an upstream limitation — which is exactly why cosmic shipped on EL10 x86_64 while being pinned off aarch64 (tunaOS#732).

Specs adapted from Fedora's rawhide `fprintd.spec`/`libfprint.spec`, pinned to `1.94.8`/`1.94.5` — the exact versions CentOS Stream 10 already ships on x86_64, so both architectures would carry an identical fprintd/libfprint rather than introducing version skew. Test-only `BuildRequires` (umockdev, python3-dbusmock, python3-libpamtest) dropped since `%check` is skipped, same convention as every other package in this repo.

**Scope note**: this PR only proves the specs on x86_64 (`build-fprintd-validation.yml`, never published to R2) — both packages already ship there today, so a green run here confirms spec correctness, not aarch64 capability. This repo has no aarch64 mock/runner infra yet; that's separate follow-up work (planned: native `ubuntu-24.04-arm` GitHub-hosted runner).

## Test plan
- [ ] `build-fprintd-validation.yml` builds both packages clean on x86_64 EL10 mock

🤖 Generated with [Claude Code](https://claude.com/claude-code)