### PR TITLE
fix(ci): repair EL10 xfce-package workflow's broken RPM signing macro

### DIFF
--- a/.github/workflows/build-xfce-package.yml
+++ b/.github/workflows/build-xfce-package.yml
@@ -91,13 +91,14 @@ jobs:
           sudo apt-get update -q
           sudo apt-get install -y -q podman createrepo-c rpm gpg gpgconf
 
-      - name: Set up GPG key
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-        run: |
-          echo "${GPG_PRIVATE_KEY}" | gpg --batch --import
-          GPG_FINGERPRINT=$(gpg --list-secret-keys --with-colons | grep '^fpr' | head -1 | cut -d: -f10)
-          echo "GPG_FINGERPRINT=${GPG_FINGERPRINT}" >> $GITHUB_ENV
+      - name: Import GPG key
+        id: import-gpg
+        uses: crazy-max/ghaction-import-gpg@v7
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_committer_name: RPM Builder
+          git_committer_email: rpm-signing@tunaos.org
 
       - name: Install rclone
         run: |
@@ -156,6 +157,18 @@ jobs:
             --local-repo "${HOME}/local-repo" \
             --force
 
+      # Same macro shape as build-xfce-distributed.yml's publish job (and
+      # build-xfce-fedora.yml as of tuna-os/github-copr#102) — the
+      # hand-rolled __gpg_sign_cmd this replaced was missing the actual
+      # "-u ... -sbo ..." signing directive and instead piped into an
+      # unrelated --import-options import-show --import, which made every
+      # rpmsign invocation fail with "gpg: invalid option '-|'".
+      - name: Configure RPM macros
+        run: |
+          echo "%_signature gpg" > ~/.rpmmacros
+          echo "%_gpg_name ${{ steps.import-gpg.outputs.keyid }}" >> ~/.rpmmacros
+          echo "%__gpg_sign_cmd %{__gpg} gpg --batch --no-verbose --no-armor --use-agent --no-secmem-warning -u \"%{_gpg_name}\" -sbo %{__signature_filename} %{__plaintext_filename}" >> ~/.rpmmacros
+
       - name: Sign RPMs
         run: |
           # -newer the marker: sign only what THIS run produced. Without it,
@@ -163,11 +176,7 @@ jobs:
           # wasted work at best, and rpmsign is not guaranteed idempotent on
           # an already-signed file.
           find "${HOME}/local-repo" -name '*.rpm' ! -name '*.src.rpm' -newer "${HOME}/build-start-marker" | \
-            xargs -r rpmsign --addsign \
-              --define "_gpg_name ${GPG_FINGERPRINT}" \
-              --define "_signature gpg" \
-              --define "__gpg_sign_cmd %{__gpg} gpg --force-v3-sigs --digest-algo=sha256 --batch --no-verbose --no-armor --pinentry-mode loopback --passphrase '' %{__gpg_sign_opt} %{__plaintext_filename}| %{__gpg_path} --import-options import-show --import 2>&1" \
-              --define "__gpg /usr/bin/gpg"
+            xargs -r rpmsign --addsign
 
       # Hard stop before anything below can touch R2. This is the guard that
       # actually would have prevented the 2026-07-19 incident: even if


### PR DESCRIPTION
## Summary
Same bug as #102, independently present in a different workflow: `build-xfce-package.yml` hand-rolled its own `__gpg_sign_cmd`, missing the actual `-u ... -sbo ...` signing directive and instead piping into an unrelated `--import-options import-show --import`.

Confirmed on gtkgreet's real build (run 29720704032, right after the R2 recovery completed and gtk-layer-shell-devel became available again): the build itself succeeded (1 package built) and only the sign step failed with `gpg: invalid option '-|'` — identical signature to the Fedora bug fixed in #102.

Reuses the same known-good macro shape `build-xfce-distributed.yml`'s publish job and the now-fixed `build-xfce-fedora.yml` both use.

## Test plan
- [x] `yaml.safe_load`, no syntax errors
- [ ] Re-dispatch gtkgreet build after merge, confirm signing succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)