### PR TITLE
feat(renovate): track upstream source pins for all packaged software

### DIFF
--- a/.github/workflows/build-xfce-arch-validation.yml
+++ b/.github/workflows/build-xfce-arch-validation.yml
@@ -1,0 +1,84 @@
+# Throwaway validation build for the Arch xfce-wayland chain (xfconf ->
+# libxfce4ui -> xfwl4) — no equivalent of build-chain.sh/mock exists for
+# Arch, so this drives makepkg directly in an archlinux container, same
+# steps as the manual session that first got these three PKGBUILDs
+# building (tuna-os/github-copr#101).
+#
+# No signing, no publish — this exists purely so a Renovate bump to any of
+# these three PKGBUILDs' _commit= pins is CI-gated instead of landing
+# unverified. Each tier's output is installed via `pacman -U` before the
+# next tier builds, exactly like the RPM chain's tiered dependency order.
+name: xfce Wayland (Arch, throwaway)
+
+on:
+  pull_request:
+    paths:
+      - 'src/xfce-wayland/xfconf/packaging/arch/**'
+      - 'src/xfce-wayland/libxfce4ui/packaging/arch/**'
+      - 'src/xfce-wayland/xfwl4/packaging/arch/**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: xfconf + libxfce4ui + xfwl4 (archlinux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: false
+
+      - name: Build xfconf -> libxfce4ui -> xfwl4 in an Arch container
+        run: |
+          set -euo pipefail
+          mkdir -p "${{ github.workspace }}/arch-out"
+
+          cat > /tmp/run.sh <<'SCRIPT'
+          set -euo pipefail
+          pacman -Sy --noconfirm --needed base-devel git \
+            libdrm libinput mesa seatd libxkbcommon pixman wayland gtk3 gdk-pixbuf2 \
+            libdisplay-info libsm startup-notification systemd-libs cargo rust pkgconf \
+            wayland-protocols gettext glib2-devel
+
+          useradd -m builder
+          chown -R builder:builder /work
+
+          build_one() {
+            local dir="$1"
+            cd "/work/$dir"
+            chown -R builder:builder .
+            su builder -c "makepkg --noconfirm --skippgpcheck --nodeps"
+            pacman -U --noconfirm ./*.pkg.tar.zst --overwrite '*'
+          }
+
+          build_one xfconf
+          build_one libxfce4ui
+          build_one xfwl4
+
+          mkdir -p /work/arch-out
+          find /work -maxdepth 2 -name '*.pkg.tar.zst' -exec cp {} /work/arch-out/ \;
+          SCRIPT
+
+          mkdir -p /tmp/arch-build/xfconf /tmp/arch-build/libxfce4ui /tmp/arch-build/xfwl4
+          cp src/xfce-wayland/xfconf/packaging/arch/PKGBUILD /tmp/arch-build/xfconf/
+          cp src/xfce-wayland/libxfce4ui/packaging/arch/PKGBUILD /tmp/arch-build/libxfce4ui/
+          cp src/xfce-wayland/xfwl4/packaging/arch/PKGBUILD /tmp/arch-build/xfwl4/
+          find src/xfce-wayland/xfwl4 -iname "*.patch" -exec cp {} /tmp/arch-build/xfwl4/ \;
+
+          podman run --rm \
+            -v /tmp/arch-build:/work:Z \
+            archlinux:latest \
+            bash /tmp/run.sh 2>&1 | tee /tmp/build.log || {
+            echo "::error::Arch validation build failed — see log above"
+            exit 1
+          }
+
+          cp /tmp/arch-build/arch-out/*.pkg.tar.zst "${{ github.workspace }}/arch-out/" 2>/dev/null || true
+
+      - name: Upload built packages as artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: xfce-wayland-arch-validation
+          path: arch-out/*.pkg.tar.zst
+          if-no-files-found: warn

--- a/.github/workflows/build-xfce-fedora.yml
+++ b/.github/workflows/build-xfce-fedora.yml
@@ -15,6 +15,14 @@ on:
   pull_request:
     paths:
       - 'src/xfce-wayland/xfwl4/**'
+      # xfconf and libxfce4ui are the two "4.21 core lib" tiers this chain
+      # builds before xfwl4 (see docs/XFWL4-PORTING.md) — a Renovate bump
+      # to either was previously invisible to this workflow's path filter,
+      # so a broken xfconf/libxfce4ui commit could only surface once xfwl4
+      # itself failed to build against it, several steps too late to say
+      # which package actually regressed.
+      - 'src/xfce-wayland/xfconf/xfconf.spec'
+      - 'src/xfce-wayland/libxfce4ui/libxfce4ui.spec'
       - 'build-order-xfce-fedora.yml'
       - 'mock/fedora-44-ci.cfg'
   push:
@@ -22,6 +30,8 @@ on:
       - main
     paths:
       - 'src/xfce-wayland/xfwl4/**'
+      - 'src/xfce-wayland/xfconf/xfconf.spec'
+      - 'src/xfce-wayland/libxfce4ui/libxfce4ui.spec'
       - 'build-order-xfce-fedora.yml'
       - 'mock/fedora-44-ci.cfg'
   workflow_dispatch:

--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,621 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": [
+    "config:recommended"
+  ],
   "automerge": true,
   "packageRules": [
     {
-      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
       "automerge": true
+    },
+    {
+      "description": "Upstream package source pins (commits/versions this repo packages) still automerge, but only once the real mock/podman build for that package passes as a required status check \u2014 a bare version bump alone has repeatedly hidden real breakage (new MSRV, new/dropped files) that only a build catches. See build-xfce-fedora.yml / build-xfce-package.yml / build-fprintd-validation.yml / build-xfce-arch-validation.yml path triggers.",
+      "matchDepTypes": [
+        "upstream-source"
+      ],
+      "automerge": true,
+      "platformAutomerge": true
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "xfconf: tracks gitlab.xfce.org/xfce/xfconf's master branch (no stable release yet \u2014 xfwl4's crates require post-4.20 development commits).",
+      "fileMatch": [
+        "^src/xfce-wayland/xfconf/xfconf\\.spec$",
+        "^src/xfce-wayland/xfconf/packaging/arch/PKGBUILD$"
+      ],
+      "matchStrings": [
+        "(?:%global commit\\s+|_commit=)(?<currentDigest>[a-f0-9]{40})"
+      ],
+      "currentValueTemplate": "master",
+      "datasourceTemplate": "git-refs",
+      "depNameTemplate": "xfconf",
+      "depTypeTemplate": "upstream-source",
+      "packageNameTemplate": "https://gitlab.xfce.org/xfce/xfconf"
+    },
+    {
+      "customType": "regex",
+      "description": "libxfce4ui: tracks gitlab.xfce.org/xfce/libxfce4ui's master branch \u2014 same reason as xfconf, xfwl4 needs libxfce4kbd-private-3 >= 4.21.4.",
+      "fileMatch": [
+        "^src/xfce-wayland/libxfce4ui/libxfce4ui\\.spec$",
+        "^src/xfce-wayland/libxfce4ui/packaging/arch/PKGBUILD$"
+      ],
+      "matchStrings": [
+        "(?:%global commit\\s+|_commit=)(?<currentDigest>[a-f0-9]{40})"
+      ],
+      "currentValueTemplate": "master",
+      "datasourceTemplate": "git-refs",
+      "depNameTemplate": "libxfce4ui",
+      "depTypeTemplate": "upstream-source",
+      "packageNameTemplate": "https://gitlab.xfce.org/xfce/libxfce4ui"
+    },
+    {
+      "customType": "regex",
+      "description": "xfwl4: tracks gitlab.xfce.org/xfce/xfwl4's main branch \u2014 pre-1.0 compositor, no tagged releases to pin to instead.",
+      "fileMatch": [
+        "^src/xfce-wayland/xfwl4/xfwl4\\.spec$",
+        "^src/xfce-wayland/xfwl4/packaging/arch/PKGBUILD$"
+      ],
+      "matchStrings": [
+        "(?:%global commit\\s+|(?<!protocols)_commit=)(?<currentDigest>[a-f0-9]{40})"
+      ],
+      "currentValueTemplate": "main",
+      "datasourceTemplate": "git-refs",
+      "depNameTemplate": "xfwl4",
+      "depTypeTemplate": "upstream-source",
+      "packageNameTemplate": "https://gitlab.xfce.org/xfce/xfwl4"
+    },
+    {
+      "customType": "regex",
+      "description": "fprintd: real version tags exist (unlike the xfce packages above), so track those directly instead of a branch tip.",
+      "fileMatch": [
+        "^src/deps/fprintd/fprintd\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>[\\d.]+)"
+      ],
+      "datasourceTemplate": "git-tags",
+      "depNameTemplate": "fprintd",
+      "depTypeTemplate": "upstream-source",
+      "packageNameTemplate": "https://gitlab.freedesktop.org/libfprint/fprintd",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "description": "libfprint: real version tags exist, tracked the same way as fprintd.",
+      "fileMatch": [
+        "^src/deps/libfprint/libfprint\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>[\\d.]+)"
+      ],
+      "datasourceTemplate": "git-tags",
+      "depNameTemplate": "libfprint",
+      "depTypeTemplate": "upstream-source",
+      "packageNameTemplate": "https://gitlab.freedesktop.org/libfprint/libfprint",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "description": "avahi: tracks avahi/avahi (github-releases).",
+      "fileMatch": [
+        "^src/deps/avahi/avahi\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "avahi",
+      "packageNameTemplate": "avahi/avahi",
+      "depTypeTemplate": "upstream-source"
+    },
+    {
+      "customType": "regex",
+      "description": "colord-gtk: tracks hughsie/colord-gtk (github-releases).",
+      "fileMatch": [
+        "^src/deps/colord-gtk/colord-gtk\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "colord-gtk",
+      "packageNameTemplate": "hughsie/colord-gtk",
+      "depTypeTemplate": "upstream-source"
+    },
+    {
+      "customType": "regex",
+      "description": "evolution-data-server: tracks GNOME/evolution-data-server (gitlab-releases).",
+      "fileMatch": [
+        "^src/deps/evolution-data-server/evolution-data-server\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "gitlab-releases",
+      "depNameTemplate": "evolution-data-server",
+      "packageNameTemplate": "GNOME/evolution-data-server",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.gnome.org"
+    },
+    {
+      "customType": "regex",
+      "description": "flatpak: tracks flatpak/flatpak (github-releases).",
+      "fileMatch": [
+        "^src/deps/flatpak/flatpak\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "flatpak",
+      "packageNameTemplate": "flatpak/flatpak",
+      "depTypeTemplate": "upstream-source"
+    },
+    {
+      "customType": "regex",
+      "description": "fontconfig: tracks fontconfig/fontconfig (gitlab-tags).",
+      "fileMatch": [
+        "^src/deps/fontconfig/fontconfig\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "gitlab-tags",
+      "depNameTemplate": "fontconfig",
+      "packageNameTemplate": "fontconfig/fontconfig",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.freedesktop.org"
+    },
+    {
+      "customType": "regex",
+      "description": "gdk-pixbuf2: tracks GNOME/gdk-pixbuf (gitlab-releases).",
+      "fileMatch": [
+        "^src/deps/gdk-pixbuf2/gdk-pixbuf2\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "gitlab-releases",
+      "depNameTemplate": "gdk-pixbuf2",
+      "packageNameTemplate": "GNOME/gdk-pixbuf",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.gnome.org"
+    },
+    {
+      "customType": "regex",
+      "description": "gi-docgen: tracks gi-docgen (pypi).",
+      "fileMatch": [
+        "^src/deps/gi-docgen/gi-docgen\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "pypi",
+      "depNameTemplate": "gi-docgen",
+      "packageNameTemplate": "gi-docgen",
+      "depTypeTemplate": "upstream-source"
+    },
+    {
+      "customType": "regex",
+      "description": "glycin: tracks GNOME/glycin (gitlab-releases).",
+      "fileMatch": [
+        "^src/deps/glycin/glycin\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "gitlab-releases",
+      "depNameTemplate": "glycin",
+      "packageNameTemplate": "GNOME/glycin",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.gnome.org"
+    },
+    {
+      "customType": "regex",
+      "description": "gnome-autoar: tracks GNOME/gnome-autoar (gitlab-releases).",
+      "fileMatch": [
+        "^src/deps/gnome-autoar/gnome-autoar\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "gitlab-releases",
+      "depNameTemplate": "gnome-autoar",
+      "packageNameTemplate": "GNOME/gnome-autoar",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.gnome.org"
+    },
+    {
+      "customType": "regex",
+      "description": "gnome-online-accounts: tracks GNOME/gnome-online-accounts (gitlab-releases).",
+      "fileMatch": [
+        "^src/deps/gnome-online-accounts/gnome-online-accounts\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "gitlab-releases",
+      "depNameTemplate": "gnome-online-accounts",
+      "packageNameTemplate": "GNOME/gnome-online-accounts",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.gnome.org"
+    },
+    {
+      "customType": "regex",
+      "description": "gnome-user-share: tracks GNOME/gnome-user-share (gitlab-releases).",
+      "fileMatch": [
+        "^src/deps/gnome-user-share/gnome-user-share\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "gitlab-releases",
+      "depNameTemplate": "gnome-user-share",
+      "packageNameTemplate": "GNOME/gnome-user-share",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.gnome.org"
+    },
+    {
+      "customType": "regex",
+      "description": "gsound: tracks GNOME/gsound (gitlab-releases).",
+      "fileMatch": [
+        "^src/deps/gsound/gsound\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "gitlab-releases",
+      "depNameTemplate": "gsound",
+      "packageNameTemplate": "GNOME/gsound",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.gnome.org"
+    },
+    {
+      "customType": "regex",
+      "description": "gtk4: tracks GNOME/gtk (gitlab-releases).",
+      "fileMatch": [
+        "^src/deps/gtk4/gtk4\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "gitlab-releases",
+      "depNameTemplate": "gtk4",
+      "packageNameTemplate": "GNOME/gtk",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.gnome.org"
+    },
+    {
+      "customType": "regex",
+      "description": "harfbuzz: tracks harfbuzz/harfbuzz (github-releases).",
+      "fileMatch": [
+        "^src/deps/harfbuzz/harfbuzz\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "harfbuzz",
+      "packageNameTemplate": "harfbuzz/harfbuzz",
+      "depTypeTemplate": "upstream-source"
+    },
+    {
+      "customType": "regex",
+      "description": "icu: tracks unicode-org/icu (github-releases).",
+      "fileMatch": [
+        "^src/deps/icu/icu\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "icu",
+      "packageNameTemplate": "unicode-org/icu",
+      "depTypeTemplate": "upstream-source",
+      "extractVersionTemplate": "^release-(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "description": "libdecor: tracks libdecor/libdecor (gitlab-tags).",
+      "fileMatch": [
+        "^src/deps/libdecor/libdecor\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "gitlab-tags",
+      "depNameTemplate": "libdecor",
+      "packageNameTemplate": "libdecor/libdecor",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.freedesktop.org"
+    },
+    {
+      "customType": "regex",
+      "description": "libei: tracks libinput/libei (gitlab-tags).",
+      "fileMatch": [
+        "^src/deps/libei/libei\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "gitlab-tags",
+      "depNameTemplate": "libei",
+      "packageNameTemplate": "libinput/libei",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.freedesktop.org"
+    },
+    {
+      "customType": "regex",
+      "description": "libgda: tracks GNOME/libgda (gitlab-releases).",
+      "fileMatch": [
+        "^src/deps/libgda/libgda\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "gitlab-releases",
+      "depNameTemplate": "libgda",
+      "packageNameTemplate": "GNOME/libgda",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.gnome.org"
+    },
+    {
+      "customType": "regex",
+      "description": "libgexiv2: tracks GNOME/gexiv2 (gitlab-releases).",
+      "fileMatch": [
+        "^src/deps/libgexiv2/libgexiv2\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "gitlab-releases",
+      "depNameTemplate": "libgexiv2",
+      "packageNameTemplate": "GNOME/gexiv2",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.gnome.org"
+    },
+    {
+      "customType": "regex",
+      "description": "libglib-testing: tracks pwithnall/libglib-testing (gitlab-tags).",
+      "fileMatch": [
+        "^src/deps/libglib-testing/libglib-testing\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "gitlab-tags",
+      "depNameTemplate": "libglib-testing",
+      "packageNameTemplate": "pwithnall/libglib-testing",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.gnome.org"
+    },
+    {
+      "customType": "regex",
+      "description": "libical: tracks libical/libical (github-releases).",
+      "fileMatch": [
+        "^src/deps/libical/libical\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "libical",
+      "packageNameTemplate": "libical/libical",
+      "depTypeTemplate": "upstream-source"
+    },
+    {
+      "customType": "regex",
+      "description": "libsoup: tracks GNOME/libsoup (gitlab-releases).",
+      "fileMatch": [
+        "^src/deps/libsoup/libsoup\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "gitlab-releases",
+      "depNameTemplate": "libsoup",
+      "packageNameTemplate": "GNOME/libsoup",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.gnome.org"
+    },
+    {
+      "customType": "regex",
+      "description": "localsearch: tracks GNOME/localsearch (gitlab-releases).",
+      "fileMatch": [
+        "^src/deps/localsearch/localsearch\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "gitlab-releases",
+      "depNameTemplate": "localsearch",
+      "packageNameTemplate": "GNOME/localsearch",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.gnome.org"
+    },
+    {
+      "customType": "regex",
+      "description": "meson: tracks mesonbuild/meson (github-releases).",
+      "fileMatch": [
+        "^src/deps/meson/meson\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "meson",
+      "packageNameTemplate": "mesonbuild/meson",
+      "depTypeTemplate": "upstream-source"
+    },
+    {
+      "customType": "regex",
+      "description": "pango: tracks GNOME/pango (gitlab-releases).",
+      "fileMatch": [
+        "^src/deps/pango/pango\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "gitlab-releases",
+      "depNameTemplate": "pango",
+      "packageNameTemplate": "GNOME/pango",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.gnome.org"
+    },
+    {
+      "customType": "regex",
+      "description": "pango-fresh: tracks GNOME/pango (gitlab-releases).",
+      "fileMatch": [
+        "^src/deps/pango-fresh/pango-fresh\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "gitlab-releases",
+      "depNameTemplate": "pango-fresh",
+      "packageNameTemplate": "GNOME/pango",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.gnome.org"
+    },
+    {
+      "customType": "regex",
+      "description": "python-dbusmock: tracks python-dbusmock (pypi).",
+      "fileMatch": [
+        "^src/deps/python-dbusmock/python-dbusmock\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "pypi",
+      "depNameTemplate": "python-dbusmock",
+      "packageNameTemplate": "python-dbusmock",
+      "depTypeTemplate": "upstream-source"
+    },
+    {
+      "customType": "regex",
+      "description": "python-smartypants: tracks smartypants (pypi).",
+      "fileMatch": [
+        "^src/deps/python-smartypants/python-smartypants\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "pypi",
+      "depNameTemplate": "python-smartypants",
+      "packageNameTemplate": "smartypants",
+      "depTypeTemplate": "upstream-source"
+    },
+    {
+      "customType": "regex",
+      "description": "python-typogrify: tracks typogrify (pypi).",
+      "fileMatch": [
+        "^src/deps/python-typogrify/python-typogrify\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "pypi",
+      "depNameTemplate": "python-typogrify",
+      "packageNameTemplate": "typogrify",
+      "depTypeTemplate": "upstream-source"
+    },
+    {
+      "customType": "regex",
+      "description": "tecla: tracks GNOME/tecla (gitlab-releases).",
+      "fileMatch": [
+        "^src/deps/tecla/tecla\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "gitlab-releases",
+      "depNameTemplate": "tecla",
+      "packageNameTemplate": "GNOME/tecla",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.gnome.org"
+    },
+    {
+      "customType": "regex",
+      "description": "tinysparql: tracks GNOME/tinysparql (gitlab-releases).",
+      "fileMatch": [
+        "^src/deps/tinysparql/tinysparql\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "gitlab-releases",
+      "depNameTemplate": "tinysparql",
+      "packageNameTemplate": "GNOME/tinysparql",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.gnome.org"
+    },
+    {
+      "customType": "regex",
+      "description": "umockdev: tracks martinpitt/umockdev (github-releases).",
+      "fileMatch": [
+        "^src/deps/umockdev/umockdev\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "umockdev",
+      "packageNameTemplate": "martinpitt/umockdev",
+      "depTypeTemplate": "upstream-source"
+    },
+    {
+      "customType": "regex",
+      "description": "vte291: tracks GNOME/vte (gitlab-releases).",
+      "fileMatch": [
+        "^src/deps/vte291/vte291\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "gitlab-releases",
+      "depNameTemplate": "vte291",
+      "packageNameTemplate": "GNOME/vte",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.gnome.org"
+    },
+    {
+      "customType": "regex",
+      "description": "wayland-protocols: tracks wayland/wayland-protocols (gitlab-tags).",
+      "fileMatch": [
+        "^src/deps/wayland-protocols/wayland-protocols\\.spec$"
+      ],
+      "matchStrings": [
+        "^Version:\\s*(?<currentValue>\\S+)\\s*\\nRelease:"
+      ],
+      "datasourceTemplate": "gitlab-tags",
+      "depNameTemplate": "wayland-protocols",
+      "packageNameTemplate": "wayland/wayland-protocols",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.freedesktop.org"
+    },
+    {
+      "customType": "regex",
+      "description": "selinux-policy: tracks fedora-selinux/selinux-policy's rawhide branch (commit-pinned, no stable release tags used here).",
+      "fileMatch": [
+        "^src/deps/selinux-policy/selinux-policy\\.spec$"
+      ],
+      "matchStrings": [
+        "%global commit\\s+(?<currentDigest>[a-f0-9]{40})"
+      ],
+      "currentValueTemplate": "rawhide",
+      "datasourceTemplate": "git-refs",
+      "depNameTemplate": "selinux-policy",
+      "depTypeTemplate": "upstream-source",
+      "packageNameTemplate": "https://github.com/fedora-selinux/selinux-policy"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Renovate here only ever tracked CI tooling (GH Actions, docker tags, python) — every actual packaged version/commit (xfconf, xfwl4, fprintd, the ~40 GNOME 49/50 deps, etc.) was a hand-typed pin that nothing would ever notice going stale or vulnerable.

Adds 40 `customManagers`:
- **xfconf/libxfce4ui/xfwl4** (RPM spec + Arch PKGBUILD): `git-refs` against each project's default branch — none have stable release tags yet (pre-4.21/pre-1.0), so branch-tip tracking is the only option.
- **fprintd/libfprint**: `git-tags`, real version tags exist.
- **selinux-policy**: `git-refs` against `fedora-selinux/selinux-policy`'s `rawhide` branch (commit-pinned, matches its existing pattern).
- **33 more `src/deps/` packages**: `gitlab-releases` (GNOME modules — verified each project slug against the gitlab.gnome.org API rather than assuming RPM-name == project-name; `gdk-pixbuf2`/`gtk4`/`libgexiv2`/`vte291` all differ from their upstream slug), `github-releases`, or `pypi`, matched to whatever their real `Source0` actually points at.

**16 packages deliberately NOT covered** (autoconf, cairo, freetype, libcanberra, libebur128, libldac, libxcvt, libzip, lzo, malcontent, mod_dnssd, mozjs128/140, pipewire/pipewire-f43, shaderc) — each has a non-standard host or version macro (GNU/savannah, personal sites, Firefox ESR source tarballs, a `glslang` commit masquerading as a shaderc version) that needs individual research to get right rather than guessed.

## The gating question
These automerge, but only once the real build for that package passes. GitHub branch protection can't require these as static checks (this repo's build job names are dynamic per package path), so the actual gate is Renovate's own default behavior of waiting for all reported checks before automerging — which only works if the right build workflow *fires* for a given bump. Two real gaps that would have silently defeated this:

- `build-xfce-fedora.yml`'s path filters never included `xfconf`/`libxfce4ui` — a bump to either was invisible to the Fedora build chain that depends on them. Fixed.
- Arch's xfconf/libxfce4ui/xfwl4 chain (#101) had **zero CI** at all — any PKGBUILD change would land completely unverified. New `build-xfce-arch-validation.yml` closes that the same way `build-fprintd-validation.yml` already does for libfprint/fprintd.

## Test plan
- [x] All 40 regexes verified against real file content (not guessed) — every `matchStrings` pattern confirmed to extract exactly one correct value per file
- [x] Every GNOME project slug verified to exist via the gitlab.gnome.org API
- [x] `renovate.json` valid JSON, both new/modified workflow YAMLs valid
- [ ] Renovate's own config-validation check (runs automatically on this PR) confirms no schema errors
- [ ] First real Renovate PR from one of these managers confirms end-to-end (can't fully verify without waiting for Renovate's next run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)