### PR TITLE
feat(mock): aarch64 mock-runner + real fprintd/libfprint aarch64 build

### DIFF
--- a/.github/workflows/build-fprintd-aarch64.yml
+++ b/.github/workflows/build-fprintd-aarch64.yml
@@ -89,10 +89,18 @@ jobs:
       - name: Mark build start
         run: touch "${{ github.workspace }}/build-start-marker"
 
+      # --image is required: build-chain.sh's MOCK_RUNNER_IMAGE default is
+      # hardcoded to the x86_64 tag, and this workflow's own MOCK_RUNNER_IMAGE
+      # env var above was decorative until this line — nothing in the script
+      # ever reads that env var. Confirmed by a real run: without --image,
+      # podman pulled :centos-stream-10 (amd64) onto this arm64 runner, and
+      # spectool (an amd64 binary with no qemu-user binfmt registered here)
+      # failed with "Exec format error" on both tiers.
       - name: Build libfprint + fprintd
         run: |
           ./scripts/build-chain.sh \
             --backend podman \
+            --image "${MOCK_RUNNER_IMAGE}" \
             --manifest build-order-fprintd-aarch64.yml \
             --mock-config centos-stream-10-ci-aarch64 \
             --local-repo "${LOCAL_REPO}" \

--- a/.github/workflows/build-fprintd-aarch64.yml
+++ b/.github/workflows/build-fprintd-aarch64.yml
@@ -1,0 +1,136 @@
+# Real aarch64 build + publish for libfprint + fprintd — unblocks
+# cosmic-greeter on EL10 aarch64 (tunaOS#732). See build-order-fprintd.yml's
+# comments for why these two packages are needed at all; this workflow is
+# the aarch64 counterpart to build-fprintd-validation.yml's x86_64
+# throwaway pass, except this one actually publishes.
+#
+# Runs on a native aarch64 GitHub-hosted runner (ubuntu-24.04-arm) against
+# ghcr.io/tuna-os/mock-runner:centos-stream-10-aarch64 — the aarch64 build
+# of the same mock-runner image build-xfce-package.yml already uses for
+# x86_64 (build-mock-runner.yml, separate tag not a multi-arch manifest).
+name: fprintd (aarch64)
+
+on:
+  pull_request:
+    paths:
+      - 'src/deps/libfprint/**'
+      - 'src/deps/fprintd/**'
+      - 'build-order-fprintd-aarch64.yml'
+      - 'mock/centos-stream-10-ci-aarch64.cfg'
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/deps/libfprint/**'
+      - 'src/deps/fprintd/**'
+      - 'build-order-fprintd-aarch64.yml'
+      - 'mock/centos-stream-10-ci-aarch64.cfg'
+  workflow_dispatch:
+
+env:
+  R2_BUCKET: bluefin
+  R2_REPO_PATH: fprintd/10-stream-aarch64
+  LOCAL_REPO: ${{ github.workspace }}/local-repo
+  MOCK_RUNNER_IMAGE: ghcr.io/tuna-os/mock-runner:centos-stream-10-aarch64
+
+jobs:
+  build:
+    name: libfprint + fprintd (centos-stream-10-aarch64)
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: false
+
+      - name: Install host dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q podman createrepo-c rpm gpg gpgconf
+
+      - name: Import GPG key
+        id: import-gpg
+        uses: crazy-max/ghaction-import-gpg@v7
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_committer_name: RPM Builder
+          git_committer_email: rpm-signing@tunaos.org
+
+      - name: Install rclone
+        run: curl -fsSL https://rclone.org/install.sh | sudo bash
+
+      - name: Configure rclone for R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+        run: |
+          mkdir -p ~/.config/rclone
+          cat > ~/.config/rclone/rclone.conf << EOF
+          [r2]
+          type = s3
+          provider = Cloudflare
+          access_key_id = ${R2_ACCESS_KEY_ID}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
+          endpoint = ${R2_ENDPOINT}
+          EOF
+
+      # Seed even though this R2 prefix is new — build-xfce-package.yml's
+      # 2026-07-19 incident (see its own "Seed local repo" step) was caused
+      # by exactly this step being absent, so it's here from the start
+      # rather than added after this prefix accumulates something to lose.
+      - name: Seed local repo from the published state
+        run: |
+          mkdir -p "${LOCAL_REPO}"
+          rclone copy "r2:${R2_BUCKET}/${R2_REPO_PATH}/" "${LOCAL_REPO}/" \
+            --progress --transfers 8
+
+      - name: Mark build start
+        run: touch "${{ github.workspace }}/build-start-marker"
+
+      - name: Build libfprint + fprintd
+        run: |
+          ./scripts/build-chain.sh \
+            --backend podman \
+            --manifest build-order-fprintd-aarch64.yml \
+            --mock-config centos-stream-10-ci-aarch64 \
+            --local-repo "${LOCAL_REPO}" \
+            --force
+
+      - name: Configure RPM macros
+        run: |
+          echo "%_signature gpg" > ~/.rpmmacros
+          echo "%_gpg_name ${{ steps.import-gpg.outputs.keyid }}" >> ~/.rpmmacros
+          echo "%__gpg_sign_cmd %{__gpg} gpg --batch --no-verbose --no-armor --use-agent --no-secmem-warning -u \"%{_gpg_name}\" -sbo %{__signature_filename} %{__plaintext_filename}" >> ~/.rpmmacros
+
+      - name: Sign RPMs
+        run: |
+          find "${LOCAL_REPO}" -name '*.rpm' ! -name '*.src.rpm' -newer "${{ github.workspace }}/build-start-marker" | \
+            xargs -r rpmsign --addsign
+
+      - name: Refuse to publish an empty result
+        run: |
+          RPM_COUNT=$(find "${LOCAL_REPO}" -name '*.rpm' ! -name '*.src.rpm' | wc -l)
+          if [[ "${RPM_COUNT}" -eq 0 ]]; then
+            echo "::error::0 RPMs produced — refusing to run createrepo_c/rclone sync. A sync here would DELETE the published repo, not merely fail to update it."
+            exit 1
+          fi
+
+      - name: Update local repo metadata
+        run: createrepo_c --update "${LOCAL_REPO}"
+
+      - name: Publish to R2
+        if: github.event_name != 'pull_request'
+        run: |
+          rclone sync "${LOCAL_REPO}/" \
+            "r2:${R2_BUCKET}/${R2_REPO_PATH}/" \
+            --progress --transfers 8
+
+      - name: Upload RPMs as artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: fprintd-aarch64
+          path: local-repo/*.rpm
+          if-no-files-found: warn

--- a/.github/workflows/build-mock-runner.yml
+++ b/.github/workflows/build-mock-runner.yml
@@ -50,3 +50,40 @@ jobs:
 
       - name: Inspect
         run: podman images "${IMAGE}:${TAG}" --format "{{.Repository}}:{{.Tag}}  {{.Size}}"
+
+  # Separate tag, not a multi-arch manifest under :centos-stream-10 — mock's
+  # own chroot content (pulled at build time via use_bootstrap_image) is
+  # already architecture-agnostic per-run, so there is no correctness reason
+  # to fuse the two into one manifest list, and keeping them as distinct tags
+  # means an aarch64-only rebuild never touches the x86_64 image other
+  # workflows already depend on.
+  build-and-push-aarch64:
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Log in to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build image
+        run: |
+          podman build \
+            --pull=always \
+            -f mock/Containerfile \
+            -t "${IMAGE}:${TAG}-aarch64" \
+            -t "${IMAGE}:${TAG}-aarch64-${{ github.sha }}" \
+            mock/
+
+      - name: Push image
+        run: |
+          podman push "${IMAGE}:${TAG}-aarch64"
+          podman push "${IMAGE}:${TAG}-aarch64-${{ github.sha }}"
+
+      - name: Inspect
+        run: podman images "${IMAGE}:${TAG}-aarch64" --format "{{.Repository}}:{{.Tag}}  {{.Size}}"

--- a/build-order-fprintd-aarch64.yml
+++ b/build-order-fprintd-aarch64.yml
@@ -1,0 +1,21 @@
+# Build Order Manifest for fprintd + libfprint on EL10 aarch64 — the real
+# aarch64 build, not the x86_64 spec-validation pass in
+# build-order-fprintd.yml. Same specs, same pinned versions (libfprint
+# 1.94.8, fprintd 1.94.5) — only the mock target and runner architecture
+# differ. See build-order-fprintd.yml for why these two packages exist at
+# all (CentOS Stream 10 doesn't build either for aarch64).
+#
+# r2_path is real this time: this is what tunaOS's build-config.yml will
+# need to consume to re-enable cosmic on EL10 aarch64 (tunaOS#732).
+
+target: centos-stream-10-aarch64
+r2_path: fprintd/10-stream-aarch64
+
+tiers:
+  - name: fprint-core
+    packages:
+      - path: src/deps/libfprint
+
+  - name: fprint-service
+    packages:
+      - path: src/deps/fprintd

--- a/mock/Containerfile
+++ b/mock/Containerfile
@@ -44,6 +44,7 @@ RUN dnf --releasever=44 install -y --best mock-core-configs \
     && test ! -L /etc/mock/fedora-44-x86_64.cfg
 
 COPY centos-stream-10-ci.cfg /etc/mock/centos-stream-10-ci.cfg
+COPY centos-stream-10-ci-aarch64.cfg /etc/mock/centos-stream-10-ci-aarch64.cfg
 COPY centos-stream-10-ci-gnome49.cfg /etc/mock/centos-stream-10-ci-gnome49.cfg
 COPY centos-stream-10-ci-gnome50.cfg /etc/mock/centos-stream-10-ci-gnome50.cfg
 # Fedora chroot for xfwl4. Fedora already ships a Wayland-capable XFCE 4.20,

--- a/mock/centos-stream-10-ci-aarch64.cfg
+++ b/mock/centos-stream-10-ci-aarch64.cfg
@@ -1,0 +1,53 @@
+# aarch64 counterpart to centos-stream-10-ci.cfg — same shape, every
+# x86_64-specific reference (base chroot template, koji buildroot URL, SIG
+# proposed-updates URL) swapped for its aarch64 equivalent. Needed because
+# CentOS Stream 10's own repos don't build fprintd/libfprint for aarch64 at
+# all (see build-order-fprintd-aarch64.yml) — this is the first aarch64
+# mock target in this repo, so nothing existed to reuse.
+#
+# Runs on a native aarch64 GitHub-hosted runner (ubuntu-24.04-arm) — mock
+# targets the architecture it's running on unless told otherwise, so no
+# explicit target_arch override is needed, only the base chroot template.
+
+include('/etc/mock/epel-10-aarch64.cfg')
+
+config_opts['root'] = 'centos-stream-10-ci-aarch64'
+
+config_opts['rpmbuild_networking'] = False
+config_opts['use_host_resolv'] = False
+
+config_opts.setdefault('plugin_conf', {})
+config_opts['plugin_conf'].setdefault('tmpfs_opts', {})
+config_opts['plugin_conf']['tmpfs_opts']['keep_mounted'] = True
+
+config_opts['yum.conf'] += """
+[local-build]
+name=Local Build Repository
+baseurl=file:///local-repo/
+enabled=1
+gpgcheck=0
+cost=1
+skip_if_unavailable=1
+module_hotfixes=1
+
+[c10s-build]
+name=CentOS Stream 10 Koji buildroot
+baseurl=https://kojihub.stream.centos.org/kojifiles/repos/c10s-build/latest/aarch64/
+enabled=1
+gpgcheck=0
+cost=1
+skip_if_unavailable=1
+
+[c10s-proposed-updates]
+name=CentOS Stream 10 SIG Proposed Updates
+baseurl=https://mirror.stream.centos.org/SIGs/10-stream/proposed_updates/aarch64/packages-main/
+enabled=1
+gpgcheck=0
+cost=1
+skip_if_unavailable=1
+"""
+
+config_opts['plugin_conf']['bind_mount_enable'] = True
+config_opts['plugin_conf']['bind_mount_opts']['dirs'].append(
+    ('/local-repo', '/local-repo')
+)


### PR DESCRIPTION
## Summary
Stands up this repo's first aarch64 build capability — native `ubuntu-24.04-arm` GitHub-hosted runner (not qemu-user cross-emulation), per the approach agreed after the x86_64 spec-validation pass (#105).

- `build-mock-runner.yml`: new `build-and-push-aarch64` job, pushed as a separate `:centos-stream-10-aarch64` tag rather than fused into a multi-arch manifest — mock's chroot content is pulled at build time regardless of host arch, so there's no correctness reason to couple the two, and this way an aarch64-only rebuild never touches the x86_64 image every other workflow already depends on. **Already verified**: [run 29756513953](https://github.com/tuna-os/github-copr/actions/runs/29756513953) — both `build-and-push` and `build-and-push-aarch64` succeeded.
- `mock/centos-stream-10-ci-aarch64.cfg`: aarch64 counterpart to `centos-stream-10-ci.cfg` — every x86_64-specific reference (base chroot template, koji buildroot URL, SIG proposed-updates URL) swapped for its aarch64 equivalent.
- `build-order-fprintd-aarch64.yml` + `build-fprintd-aarch64.yml`: the real aarch64 build — `build-order-fprintd.yml`/`build-fprintd-validation.yml` only ever proved the specs against x86_64, where both packages already ship. This is the one that actually unblocks `cosmic-greeter` on EL10 aarch64 (tunaOS#732). Publishes to `fprintd/10-stream-aarch64`, seeded from R2 even though the prefix starts empty (build-xfce-package.yml's 2026-07-19 incident was exactly this step missing on a first run).

`build-chain.sh`/`derive_dist()` needed no changes — neither hardcodes an architecture.

## Test plan
- [x] Mock-runner images (both arches) build and push clean
- [ ] This PR's own `pull_request` trigger confirms the real aarch64 fprintd/libfprint build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)