### PR TITLE
ci: gate GNOME stable bumps on EL10 runtime tests

### DIFF
--- a/.github/workflows/build-gnome50-package.yml
+++ b/.github/workflows/build-gnome50-package.yml
@@ -149,7 +149,8 @@ jobs:
 
       - name: Smoke test — install RPM in CentOS Stream 10
         run: |
-          RPM=$(find local-repo -name '*.rpm' ! -name '*-debuginfo-*' ! -name '*-debugsource-*' 2>/dev/null | head -1)
+          # Podman requires an absolute host path for a file bind mount.
+          RPM=$(find "$PWD/local-repo" -name '*.rpm' ! -name '*-debuginfo-*' ! -name '*-debugsource-*' 2>/dev/null | head -1)
           if [[ -z "${RPM}" ]]; then
             echo "No non-debug RPM found to test"
             exit 0

--- a/.github/workflows/build-gnome50-package.yml
+++ b/.github/workflows/build-gnome50-package.yml
@@ -1,9 +1,10 @@
 name: GNOME 50 Package Build (Incremental)
 
 on:
+  # This inexpensive detect job runs on every PR so the stable gate job can
+  # be a repository-wide required check.  It exits successfully when no
+  # GNOME 50 source changed; a GNOME update runs the full EL10 gate below.
   pull_request:
-    paths:
-      - 'src/gnome-50/**'
   push:
     branches:
       - main
@@ -120,10 +121,13 @@ jobs:
             --manifest build-order.yml \
             --mock-config centos-stream-10-ci-gnome50 \
             --package "${{ matrix.package }}" \
+            --with-checks \
             --force
 
       - name: Import GPG key and sign
-        if: github.event_name != 'pull_request'
+        # Only a protected main push may sign a release. Workflow dispatches
+        # are test-only so candidate builds cannot publish accidentally.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: crazy-max/ghaction-import-gpg@v7
         id: import-gpg
         with:
@@ -131,7 +135,7 @@ jobs:
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Sign new RPMs
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           echo "%_signature gpg" > ~/.rpmmacros
           echo "%_gpg_name ${{ steps.import-gpg.outputs.keyid }}" >> ~/.rpmmacros
@@ -139,7 +143,7 @@ jobs:
           createrepo_c --update local-repo
 
       - name: Upload updated package to R2
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           rclone sync local-repo/ "r2:${R2_BUCKET}/${R2_REPO_PATH}/"
 
@@ -160,7 +164,7 @@ jobs:
           echo "Smoke test passed: RPM installs cleanly on CentOS Stream 10"
 
       - name: Upload RPMs as artifact (PR builds)
-        if: github.event_name == 'pull_request'
+        if: github.event_name != 'push' || github.ref != 'refs/heads/main'
         uses: actions/upload-artifact@v7
         with:
           name: rpms-${{ strategy.job-index }}
@@ -169,7 +173,10 @@ jobs:
 
   verify-login:
     needs: [detect-changes, build]
-    if: ${{ github.event_name == 'pull_request' && needs.detect-changes.outputs.has_session_package == 'true' }}
+    # A library-only bump can still make the GNOME session fail at runtime.
+    # Boot every GNOME 50 update in an EL10 VM; do not limit this to the
+    # obvious session packages such as mutter and gnome-shell.
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -285,3 +292,26 @@ jobs:
       - name: Stop Lima VM
         if: always()
         run: limactl stop gnome50-pr-test --force || true
+
+  # Keep this job name stable: it is the branch-protection context that
+  # Renovate waits for.  A green package build alone is insufficient; the
+  # candidate must also boot GDM and keep gnome-shell alive on EL10.
+  el10-release-gate:
+    needs: [detect-changes, build, verify-login]
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require build and runtime verification
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
+          LOGIN_RESULT: ${{ needs.verify-login.result }}
+          PACKAGES: ${{ needs.detect-changes.outputs.packages }}
+        run: |
+          if [[ "${PACKAGES}" = '[]' ]]; then
+            echo "No GNOME 50 source changed; EL10 GNOME release gate not applicable."
+            exit 0
+          fi
+          test "${PACKAGES}" != '[]'
+          test "${BUILD_RESULT}" = 'success'
+          test "${LOGIN_RESULT}" = 'success'
+          echo "EL10 build, RPM %check, install, GDM boot, and greeter-stability gates passed."

--- a/renovate.json
+++ b/renovate.json
@@ -3,17 +3,16 @@
   "extends": [
     "config:recommended"
   ],
-  "automerge": true,
+  "automerge": false,
   "packageRules": [
     {
-      "matchUpdateTypes": [
-        "major",
-        "minor",
-        "patch",
-        "pin",
-        "digest"
+      "description": "Only dependency-management updates may merge automatically. Packaged software is handled by the upstream-source rule below, which is held by the EL10 release gate.",
+      "matchManagers": [
+        "github-actions"
       ],
-      "automerge": true
+      "matchUpdateTypes": ["digest", "patch", "minor"],
+      "automerge": true,
+      "platformAutomerge": true
     },
     {
       "description": "Upstream package source pins (commits/versions this repo packages) still automerge, but only once the real mock/podman build for that package passes as a required status check \u2014 a bare version bump alone has repeatedly hidden real breakage (new MSRV, new/dropped files) that only a build catches. See build-xfce-fedora.yml / build-xfce-package.yml / build-fprintd-validation.yml / build-xfce-arch-validation.yml path triggers.",
@@ -25,6 +24,72 @@
     }
   ],
   "customManagers": [
+    {
+      "customType": "regex",
+      "description": "GNOME 50 shell: follow only GNOME's tagged stable releases; every update is built and boot-tested on CentOS Stream 10 before merge/publish.",
+      "fileMatch": ["^src/gnome-50/gnome-shell/gnome-shell\\.spec$"],
+      "matchStrings": ["^Version:\\s*(?<currentValue>\\S+)\\s*$"],
+      "datasourceTemplate": "gitlab-releases",
+      "depNameTemplate": "gnome-shell",
+      "packageNameTemplate": "GNOME/gnome-shell",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.gnome.org"
+    },
+    {
+      "customType": "regex",
+      "description": "GNOME 50 Mutter stable releases.",
+      "fileMatch": ["^src/gnome-50/mutter/mutter\\.spec$"],
+      "matchStrings": ["^Version:\\s*(?<currentValue>\\S+)\\s*$"],
+      "datasourceTemplate": "gitlab-releases",
+      "depNameTemplate": "mutter",
+      "packageNameTemplate": "GNOME/mutter",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.gnome.org"
+    },
+    {
+      "customType": "regex",
+      "description": "GNOME 50 settings daemon stable releases.",
+      "fileMatch": ["^src/gnome-50/gnome-settings-daemon/gnome-settings-daemon\\.spec$"],
+      "matchStrings": ["^Version:\\s*(?<currentValue>\\S+)\\s*$"],
+      "datasourceTemplate": "gitlab-releases",
+      "depNameTemplate": "gnome-settings-daemon",
+      "packageNameTemplate": "GNOME/gnome-settings-daemon",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.gnome.org"
+    },
+    {
+      "customType": "regex",
+      "description": "GNOME 50 session stable releases.",
+      "fileMatch": ["^src/gnome-50/gnome-session/gnome-session\\.spec$"],
+      "matchStrings": ["^Version:\\s*(?<currentValue>\\S+)\\s*$"],
+      "datasourceTemplate": "gitlab-releases",
+      "depNameTemplate": "gnome-session",
+      "packageNameTemplate": "GNOME/gnome-session",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.gnome.org"
+    },
+    {
+      "customType": "regex",
+      "description": "GNOME 50 control-center stable releases.",
+      "fileMatch": ["^src/gnome-50/gnome-control-center/gnome-control-center\\.spec$"],
+      "matchStrings": ["^Version:\\s*(?<currentValue>\\S+)\\s*$"],
+      "datasourceTemplate": "gitlab-releases",
+      "depNameTemplate": "gnome-control-center",
+      "packageNameTemplate": "GNOME/gnome-control-center",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.gnome.org"
+    },
+    {
+      "customType": "regex",
+      "description": "GDM stable releases.",
+      "fileMatch": ["^src/gnome-50/gdm/gdm\\.spec$"],
+      "matchStrings": ["^Version:\\s*(?<currentValue>\\S+)\\s*$"],
+      "datasourceTemplate": "gitlab-releases",
+      "depNameTemplate": "gdm",
+      "packageNameTemplate": "GNOME/gdm",
+      "depTypeTemplate": "upstream-source",
+      "registryUrlTemplate": "https://gitlab.gnome.org"
+    },
     {
       "customType": "regex",
       "description": "xfconf: tracks gitlab.xfce.org/xfce/xfconf's master branch (no stable release yet \u2014 xfwl4's crates require post-4.20 development commits).",

--- a/scripts/build-chain.sh
+++ b/scripts/build-chain.sh
@@ -22,6 +22,7 @@
 #   --jobs <N>           Parallel jobs within a tier (default: nproc/2)
 #   --tier <name>        Only build a specific tier
 #   --package <path>     Only build a specific package path
+#   --with-checks        Run the RPM %check section (release-gate mode)
 #   --dry-run            Print what would be built without building
 
 set -euo pipefail
@@ -45,6 +46,7 @@ FILTER_TIER=""
 FILTER_PACKAGE=""
 DRY_RUN=false
 FORCE=false
+WITH_CHECKS=false
 
 usage() {
     echo "Usage: $0 [options]"
@@ -60,6 +62,7 @@ usage() {
     echo "  --jobs <N>           Parallel jobs within a tier (default: nproc/2)"
     echo "  --tier <name>        Only build a specific tier"
     echo "  --package <path>     Only build a specific package path"
+    echo "  --with-checks        Run the RPM %check section"
     echo "  --dry-run            Print what would be built without building"
     echo "  --force              Force rebuild even if package exists in repo"
     echo "  -h, --help           Show this help message"
@@ -81,6 +84,7 @@ while [[ $# -gt 0 ]]; do
         --jobs)        JOBS="$2";        shift 2 ;;
         --tier)        FILTER_TIER="$2"; shift 2 ;;
         --package)     FILTER_PACKAGE="$2"; shift 2 ;;
+        --with-checks)  WITH_CHECKS=true; shift ;;
         --dry-run)     DRY_RUN=true;     shift ;;
         --force)       FORCE=true;       shift ;;
         *)
@@ -336,6 +340,9 @@ build_package_podman() {
         MOCK_CACHE_ARGS=(-v "${MOCK_CACHE_DIR}:/var/cache/mock:Z")
     fi
 
+    local mock_check_flag="--nocheck"
+    $WITH_CHECKS && mock_check_flag=""
+
     podman run --rm --privileged \
         --pull=always \
         -v "${builddir}:/builddir:Z" \
@@ -373,7 +380,7 @@ build_package_podman() {
                     --rebuild /builddir/SRPMS/*.src.rpm \\
                     --resultdir=/builddir/results \\
                     --define 'dist ${DIST}' \\
-                    --nocheck \\
+                    ${mock_check_flag} \\
                     --no-clean \\
                     --no-cleanup-after || {
                         echo 'ERROR: mock failed. Printing build.log:';
@@ -463,13 +470,16 @@ build_package_mock() {
     # locked to prevent parallel jobs from corrupting it.
     flock "${LOCAL_REPO}/repo.lock" -c "createrepo_c --update \"${LOCAL_REPO}\""
 
+    local mock_check_flag="--nocheck"
+    $WITH_CHECKS && mock_check_flag=""
+
     flock "${LOCAL_REPO}/repo.lock" -c "
         mock -r \"${MOCK_CONFIG}\" \\
             --uniqueext=\"${pkg_name}\" \\
             --rebuild \"$srpm\" \\
             --resultdir=\"$resultdir\" \\
             --define \"dist ${DIST}\" \\
-            --nocheck \\
+            ${mock_check_flag} \\
             --no-clean \\
             --no-cleanup-after || {
                 echo 'ERROR: mock failed. Printing build.log:';
@@ -702,6 +712,7 @@ main() {
     log "  Jobs:       ${JOBS}"
     [[ -n "$FILTER_TIER" ]]    && log "  Tier filter: ${FILTER_TIER}"
     [[ -n "$FILTER_PACKAGE" ]] && log "  Pkg filter:  ${FILTER_PACKAGE}"
+    $WITH_CHECKS && log "  RPM %check: enabled"
 
     if ! $DRY_RUN; then
         case "$BACKEND" in


### PR DESCRIPTION
## Release gate

- Track tagged stable releases for GNOME Shell, Mutter, GDM, Session, Settings Daemon, and Control Center.
- Run package `%check`, RPM installation, and a CentOS Stream 10 GDM/gnome-shell boot-stability test on every GNOME 50 source PR.
- Make the stable `el10-release-gate` status check required on `main`; Renovate can therefore auto-merge only after the gate passes.

The post-merge build remains the publishing path, so only a protected, tested commit can be signed and released to R2.