### PR TITLE
fix(ci): unblock main — required checks must not be path-filtered

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,13 +1,22 @@
 name: Lint
 
 on:
+  # Deliberately NOT path-filtered for pull_request. These jobs are main's
+  # required status checks, and a path-filtered workflow can never be a
+  # reliable required check: when the filter does not match, the workflow
+  # never runs, the check never reports, and the PR is unmergeable forever
+  # rather than merely unverified.
+  #
+  # main was in exactly that state — it required
+  # "GNOME 50 Package Build (Incremental) / el10-release-gate", a job that
+  # exists only in the still-open #112 and whose workflow is filtered to
+  # src/gnome-50/**. Nothing could merge, including the PR that would have
+  # fixed it. These jobs are cheap; running them on every PR is the price of
+  # having them be required.
+  #
+  # push stays filtered: a push to main is already merged, so a missing check
+  # there blocks nothing.
   pull_request:
-    paths:
-      - '**.yml'
-      - '**.yaml'
-      - '**.sh'
-      - 'scripts/**'
-      - '.github/workflows/lint.yml'
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
`main` required `GNOME 50 Package Build (Incremental) / el10-release-gate`. That job **does not exist on main** — it's added by #112, still open — and its workflow is filtered to `paths: src/gnome-50/**`, so it wouldn't run on most PRs even after #112 lands.

Result: **total merge deadlock.** The check could never report, so every PR was unmergeable — including #112 itself, the one PR that would create the job. #112–#115 have sat open since 2026-07-25 for this reason. Merging #124 and #127 required temporarily dropping `enforce_admins`.

**The general defect:** a path-filtered workflow cannot serve as a required status check. When the filter doesn't match, GitHub doesn't run the workflow, so the check reports *nothing* — and "never reported" blocks a PR forever, unlike "reported as skipped", which counts as satisfied.

So `lint.yml` loses its `pull_request` path filter. Its six jobs are cheap, and running them on every PR is the price of having them be required. The `push` filter is left alone — a push to main is already merged, so a missing check there blocks nothing.

Branch protection is updated separately to require these six instead of the phantom gate. `el10-release-gate` can be re-added once #112 lands **and** its workflow runs unconditionally on `pull_request`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->