### PR TITLE
fix(ci): stop the verify workflows burning a runner slot on every PR

### DIFF
--- a/.github/workflows/build-gnome49-verify.yml
+++ b/.github/workflows/build-gnome49-verify.yml
@@ -5,8 +5,14 @@ on:
     workflows: ["GNOME 49 Distributed Build and Publish"]
     types: [completed]
   workflow_dispatch:
-  pull_request:
-    types: [opened, synchronize]
+  # No pull_request trigger. Every job here is gated to workflow_run/dispatch,
+  # so on a PR they could only ever report "skipped" — while still occupying a
+  # runner slot to decide that. This workflow verifies an ALREADY-PUBLISHED
+  # repo; a PR has not published anything, so there is nothing for it to check.
+  #
+  # It was also actively harmful: the skipped jobs let the workflow report
+  # success on every PR, and that false green used to trigger the dev->prod
+  # promote job that wiped production (see INCIDENT-repo-wipe-gnome.md).
 
 jobs:
   verify-repo:

--- a/.github/workflows/build-gnome50-verify.yml
+++ b/.github/workflows/build-gnome50-verify.yml
@@ -11,8 +11,14 @@ on:
     workflows: ["GNOME 50 Package Build (Incremental)"]
     types: [completed]
   workflow_dispatch:
-  pull_request:
-    types: [opened, synchronize]
+  # No pull_request trigger. Every job here is gated to workflow_run/dispatch,
+  # so on a PR they could only ever report "skipped" — while still occupying a
+  # runner slot to decide that. This workflow verifies an ALREADY-PUBLISHED
+  # repo; a PR has not published anything, so there is nothing for it to check.
+  #
+  # It was also actively harmful: the skipped jobs let the workflow report
+  # success on every PR, and that false green used to trigger the dev->prod
+  # promote job that wiped production (see INCIDENT-repo-wipe-gnome.md).
 
 jobs:
   verify-repo:
@@ -260,7 +266,7 @@ jobs:
       issues: write
     env:
       GH_TOKEN: ${{ github.token }}
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Enable KVM
         run: |


### PR DESCRIPTION
`build-gnome50-verify.yml` ran on every `pull_request`, and its `verify-gdm-copr` job carried an extra `|| github.event_name == 'pull_request'` clause its gnome49 counterpart does **not** have.

So every PR spent ~30 minutes of runner time booting a Lima/QEMU VM to install packages from `copr:jreilly1821/c10s-gnome-50` — an **external** repo whose contents have nothing to do with the PR. It could not fail for a bad PR or pass for a good one.

The other two jobs are gated to `workflow_run`/`dispatch`, so on a PR they could only ever report `skipped` — while still taking a runner slot to decide that:

```
verify-repo      | skipped
verify-gdm       | skipped
verify-gdm-copr  | success   <- 30 min, tests COPR
```

Combined, this saturated the runner pool: with several PRs open, ordinary Lint checks sat queued 20+ minutes behind VM boots testing nothing.

Removing the trigger also closes the last of the promote hazard — those skipped jobs let the workflow report success on every PR, and that false green is what fired the dev→prod promote that wiped production. The promote workflows are gone in #124, but the false-green generator shouldn't outlive them.

Verified both now trigger on `workflow_run` + `workflow_dispatch` only. `actionlint` reports nothing new — its 4 SC2046 warnings are pre-existing on main (confirmed by stashing and re-running).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->