### PR TITLE
feat(input-remapper): package input-remapper 2.2.1 and python3-evdev 1.9.2 for EL10 (fixes #126)

### DIFF
--- a/packages/input-remapper/package.yaml
+++ b/packages/input-remapper/package.yaml
@@ -1,0 +1,121 @@
+# input-remapper for EL10 and Arch (#126).
+#
+# This is the package that breaks the marlin KDE build outright.  pacman has
+# no "skip if missing", so one unresolvable target fails the whole
+# transaction:
+#
+#   error: target not found: input-remapper
+#
+# ghcr.io/tuna-os/marlin:kde has been serving a stale pre-desktop image since,
+# which the live payload then mis-detected as GNOME (tunaOS#858).
+#
+# Availability, checked against real repository metadata rather than mdapi
+# (see docs/CHECKING_PACKAGE_AVAILABILITY.md):
+#
+#   Arch official   0 results   -- AUR only, and the AUR is not a repo we use
+#   EPEL 10         0 matches in primary.xml
+#   Fedora          present, so Fedora keeps using its own
+#
+# On EL10 this additionally needs python3-evdev, which is absent from BaseOS,
+# AppStream, CRB and EPEL 10 and is packaged alongside this recipe.  Arch
+# already has python-evdev 1.9.3 in extra, so only this package is new there.
+#
+# Uses build_system: custom because Tideforge has no python build system yet
+# (#137).  That is not a workaround for this recipe specifically — upstream
+# ships its own installer for a real reason, see the install commands below.
+schema: 1
+name: input-remapper
+version: "2.2.1"
+release: 1
+summary: Change the mapping of input device buttons
+description: >-
+  GUI and daemon for remapping keyboard, mouse and gamepad buttons, including
+  the input-remapper service and its udev rules.
+license: GPL-3.0-or-later
+source:
+  url: https://github.com/sezanzeb/input-remapper/archive/refs/tags/2.2.1.tar.gz
+  sha256: 6ad3d58829e29f2943cbc874b910a94e699428547240f3e5b2a4acbd34e62d2f
+  directory: input-remapper-2.2.1
+build_system: custom
+build:
+  # Everything happens in the install step.  Upstream's installer compiles the
+  # translations itself (install.language.make_lang), so there is no separate
+  # build phase to run.
+  commands:
+    - ':'
+install:
+  # Deliberately NOT pip.  Upstream's install/__main__.py documents why, and
+  # it is not a preference:
+  #
+  #   "pip, in many cases, fails to install data files, which need to go into
+  #    system paths, and instead puts them (despite them being absolute paths)
+  #    into /usr/lib/python3/inputremapper/usr/share/..."
+  #
+  # The udev rules, polkit action, systemd unit and D-Bus policy are exactly
+  # those data files.  A pip install would appear to succeed and produce a
+  # package whose service could not start and whose rules were never read.
+  #
+  # install/module.py additionally resolves site-packages vs dist-packages per
+  # distribution, which is what makes one recipe work on both EL10 and Arch.
+  commands:
+    - python3 -m install --root "{destdir}"
+dependencies:
+  build:
+    common: [gettext]
+    targets:
+      el10: [python3-devel, python3-setuptools]
+      arch: [python]
+  runtime:
+    targets:
+      # python3-evdev is the Tideforge package built alongside this one.  All
+      # other EL10 names here were verified against repository metadata in a
+      # CentOS Stream 10 container with EPEL enabled (2026-07-31):
+      # python3-dasbus, python3-gobject, python3-cairo, python3-psutil, gtk3
+      #   → AppStream
+      # python3-packaging → BaseOS
+      # python3-pydantic, gtksourceview4 → EPEL 10
+      el10:
+        - python3
+        - python3-evdev
+        - python3-dasbus
+        - python3-gobject
+        - python3-cairo
+        - python3-pydantic
+        - python3-packaging
+        - python3-psutil
+        - gtk3
+        - gtksourceview4
+      # All present in core/extra, so Arch needs nothing new beyond this
+      # package itself.
+      arch:
+        - python
+        - python-evdev
+        - python-dasbus
+        - python-gobject
+        - python-cairo
+        - python-pydantic
+        - python-packaging
+        - python-psutil
+        - gtk3
+        - gtksourceview4
+        - polkit
+files:
+  common:
+    - usr/bin/input-remapper-gtk
+    - usr/bin/input-remapper-service
+    - usr/bin/input-remapper-control
+    - usr/bin/input-remapper-reader-service
+    - usr/share/input-remapper/
+    - usr/share/applications/input-remapper-gtk.desktop
+    - usr/share/metainfo/io.github.sezanzeb.input_remapper.metainfo.xml
+    - usr/share/icons/hicolor/scalable/apps/input-remapper.svg
+    - usr/share/polkit-1/actions/input-remapper.policy
+    - usr/lib/systemd/system/input-remapper.service
+    - usr/share/dbus-1/system.d/inputremapper.Control.conf
+    - etc/xdg/autostart/input-remapper-autoload.desktop
+    - usr/lib/udev/rules.d/69-input-remapper-forwarded.rules
+    - usr/lib/udev/rules.d/99-input-remapper.rules
+    # Version-globbed: install/module.py picks the interpreter's own
+    # site-packages, so pinning a minor version here would break on rebase.
+    - usr/lib/python3*/site-packages/inputremapper/
+targets: [el10, arch]

--- a/packages/python3-evdev/package.yaml
+++ b/packages/python3-evdev/package.yaml
@@ -1,0 +1,73 @@
+# python-evdev for EL10 (#126).
+#
+# input-remapper declares `evdev` and nothing on EL10 provides it.  Checked
+# against real repository metadata, not the mdapi endpoint (see
+# docs/CHECKING_PACKAGE_AVAILABILITY.md): absent from CentOS Stream 10
+# BaseOS, AppStream and CRB, and 0 matches in EPEL 10's primary.xml.zst.
+# Arch already has python-evdev 1.9.3 in extra, so this recipe is EL10-only —
+# under the project rule we use a distribution's own package where it exists.
+#
+# VERSION PIN, READ BEFORE BUMPING.  1.9.2, deliberately not the current
+# 1.9.3:
+#
+#   1.9.3  build-requires setuptools>=77.0   (PEP 639 `license = "BSD-3-Clause"`)
+#   1.9.2  build-requires setuptools>=61.0   (`license = {file = "LICENSE"}`)
+#
+# EL10 ships python3-setuptools 69.0.3, so 1.9.3 cannot build here and 1.9.2
+# can.  As with labwc, the blocker is invisible from the version number and
+# only appears in pyproject.toml.  Do not bump past 1.9.2 until EL10 has
+# setuptools 77 or newer.
+#
+# BUILD METHOD, READ BEFORE CHANGING.  setup.py, deliberately not pip wheel:
+#
+#   pip wheel (and pip install from source under PEP 517) requires the `wheel`
+#   Python package for the `bdist_wheel` setuptools command.  EL10 has no
+#   python3-wheel RPM (verified: 0 matches in BaseOS, AppStream, EPEL, CRB),
+#   and python3-pip 23.3.2 on EL10 does not bundle wheel.  setup.py build +
+#   setup.py install compiles the three C extensions (_input, _uinput,
+#   _ecodes) without needing wheel at all.
+#
+#   The SetuptoolsDeprecationWarning is harmless here — build_system: custom
+#   means Tideforge executes whatever commands the recipe prescribes, not what
+#   a build frontend expects.
+schema: 1
+name: python3-evdev
+version: "1.9.2"
+release: 1
+summary: Python bindings to the Linux input handling subsystem
+description: >-
+  Bindings for the Linux input subsystem, exposing evdev devices, event codes
+  and uinput.  Required by input-remapper, which EL10 cannot otherwise provide.
+license: BSD-3-Clause
+source:
+  url: https://github.com/gvalkov/python-evdev/archive/refs/tags/v1.9.2.tar.gz
+  sha256: 1cfb65765b8c63e587110d9b42fa26806bd6dd76565c55c3618afd4c4c48c5a5
+  directory: python-evdev-1.9.2
+build_system: custom
+build:
+  # Three C extensions (_input, _uinput, _ecodes) are compiled here, and
+  # src/evdev/ecodes.c is generated at build time by genecodes_c.py reading
+  # the kernel input headers — so this needs python3-devel, a C compiler and
+  # kernel-headers in a real buildroot.
+  commands:
+    - python3 setup.py build
+install:
+  commands:
+    - python3 setup.py install --root "{destdir}" --prefix /usr --skip-build
+dependencies:
+  build:
+    capabilities: [c-compiler]
+    targets:
+      el10: [python3-devel, python3-setuptools, kernel-headers]
+  runtime:
+    targets:
+      el10: [python3]
+files:
+  common:
+    # Version-globbed on purpose: the interpreter minor version owns this path
+    # and an EL10 python rebase would otherwise silently unpackage everything.
+    # setup.py install creates an .egg-info directory, not .dist-info; glob
+    # matches either.
+    - usr/lib64/python3*/site-packages/evdev/
+    - usr/lib64/python3*/site-packages/evdev-*.{dist,egg}-info/
+targets: [el10]


### PR DESCRIPTION
## What

Two new package recipes to fix the marlin KDE build (issue #126):

| Package | Version | Targets | Reason |
|---|---|---|---|
| `python3-evdev` | 1.9.2 | EL10 only | input-remapper needs `evdev`; absent from all EL10 repos |
| `input-remapper` | 2.2.1 | EL10 + Arch | marlin KDE hard-depends on it; absent from EPEL 10 |

## Dependency verification

Every EL10 dependency was verified against a real CentOS Stream 10 container with EPEL enabled (2026-07-31):

| Dependency | Source |
|---|---|
| python3-dasbus, python3-gobject, python3-cairo, python3-psutil, gtk3 | AppStream |
| python3-packaging | BaseOS |
| python3-pydantic, gtksourceview4 | EPEL 10 |
| python3-evdev | This recipe |

## Key design decision: setup.py, not pip wheel

EL10 has **no `python3-wheel` RPM** (0 matches in BaseOS, AppStream, EPEL, CRB) and `python3-pip` 23.3.2 does not bundle it. `pip wheel` and PEP 517 builds both require the `wheel` Python package for `bdist_wheel`.

python3-evdev uses `python3 setup.py build` + `python3 setup.py install --skip-build` instead, which compiles the three C extensions without needing wheel. Build confirmed end-to-end in a Stream 10 container.

## What has NOT been verified

- [ ] CI build (needs Tideforge workflows to run)
- [ ] Runtime test (input-remapper service startup, device remapping)
- [ ] Arch build (not tested; deps from extra repo should resolve)
- [ ] Install from built RPMs

## Post-merge

After merge, Tideforge needs to build `python3-evdev` before `input-remapper` in the build order. The recipes declare the dependency via `dependencies.runtime`, but the build-order manifest will need the explicit ordering.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->