### PR TITLE
ci(tideforge): give openSUSE cells in the gate and fail when a target has none

### DIFF
--- a/.github/workflows/build-tideforge-supported.yml
+++ b/.github/workflows/build-tideforge-supported.yml
@@ -343,7 +343,10 @@ jobs:
             # libseat; the reasoning is identical here.
             zypper --non-interactive addrepo --no-gpgcheck --priority 1 file:///tmp/tideforge-rpms tideforge
             zypper --non-interactive --gpg-auto-import-keys refresh tideforge
-            zypper --non-interactive install --no-gpg-checks --allow-unsigned-rpm ${{ matrix.install_name }}
+            # --no-gpg-checks is a global zypper option, not an install option, so
+            # it has to precede the verb; after it, zypper exits 2 with "The flag
+            # --no-gpg-checks is not known".
+            zypper --non-interactive --no-gpg-checks install ${{ matrix.install_name }}
             rpm -q ${{ matrix.install_name }}
             ${{ matrix.smoke }}
           '

--- a/.github/workflows/build-tideforge-supported.yml
+++ b/.github/workflows/build-tideforge-supported.yml
@@ -257,6 +257,103 @@ jobs:
           path: .tideforge/rpm/${{ matrix.package }}/rpmbuild/RPMS/
           if-no-files-found: warn
 
+  # openSUSE Tumbleweed is declared in manifests/package-factory.yaml with its
+  # own architectures and r2_path, and 19 recipes opt into it — yet it had zero
+  # cells in this gate, so no openSUSE package had ever been built or installed
+  # by this pipeline. See #139. "Never tested" and "passing" looked identical.
+  #
+  # This job starts deliberately small. It is scoped to two packages rather than
+  # all 19 so that the first openSUSE result has one readable cause instead of
+  # nineteen unrelated ones. dgop is a go build and cli11-devel is a header-only
+  # cmake build; neither exercises the cargo path, whose fat-LTO and debuginfo
+  # handling is tuned for el10 and Arch and has never run under zypper.
+  #
+  # The renderer needs no change: render() dispatches on the target format, and
+  # opensuse-tumbleweed is format: rpm, so it already reaches render_rpm.
+  opensuse-rpm:
+    name: ${{ matrix.package }} (opensuse-tumbleweed RPM)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: dgop
+            install_name: dgop
+            smoke: dgop --help
+          - package: cli11-devel
+            install_name: cli11-devel
+            smoke: test -f /usr/include/CLI/CLI.hpp
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.14'
+      - run: pip install pyyaml
+      - name: Render and fetch the exact source archive
+        run: |
+          set -euo pipefail
+          recipe="packages/${{ matrix.package }}/package.yaml"
+          root="$PWD/.tideforge/rpm/${{ matrix.package }}"
+          python3 scripts/tideforge.py validate "$recipe"
+          python3 scripts/verify-tideforge-source.py "$recipe"
+          python3 scripts/tideforge.py render "$recipe" --target opensuse-tumbleweed --output "$root/rpmbuild/SPECS"
+          mkdir -p "$root/rpmbuild"/{BUILD,BUILDROOT,RPMS,SOURCES,SRPMS}
+          python3 scripts/fetch-tideforge-sources.py "$recipe" "$root/rpmbuild/SOURCES"
+      - name: Pull the build image, retrying transient registry failures
+        run: scripts/pull-container-image.sh registry.opensuse.org/opensuse/tumbleweed:latest
+      - name: Build generated RPM with only declared BuildRequires
+        run: |
+          set -euo pipefail
+          root="$PWD/.tideforge/rpm/${{ matrix.package }}"
+          docker run --rm --volume "$root:/work" registry.opensuse.org/opensuse/tumbleweed:latest bash -lc '
+            set -euo pipefail
+            zypper --non-interactive --gpg-auto-import-keys refresh
+            zypper --non-interactive install rpm-build
+            # zypper has no builddep verb. rpmspec -q --buildrequires prints the
+            # BuildRequires the generated spec declares, which is exactly the set
+            # dnf builddep would have resolved on el10. Verified in a real
+            # tumbleweed container; see #139.
+            mapfile -t build_requires < <(rpmspec -q --buildrequires /work/rpmbuild/SPECS/*.spec)
+            # A recipe may legitimately declare no BuildRequires, and zypper
+            # install with no arguments is an error rather than a no-op.
+            if [ "${#build_requires[@]}" -gt 0 ]; then
+              zypper --non-interactive install "${build_requires[@]}"
+            fi
+            rpmbuild -ba --define "_topdir /work/rpmbuild" /work/rpmbuild/SPECS/*.spec
+          '
+      - name: Lint the generated RPM
+        run: |
+          set -euo pipefail
+          root="$PWD/.tideforge/rpm/${{ matrix.package }}"
+          docker run --rm --volume "$root:/work:ro" --volume "$PWD/scripts:/scripts:ro" registry.opensuse.org/opensuse/tumbleweed:latest \
+            bash /scripts/lint-generated-rpm.sh /work/rpmbuild/RPMS
+      - name: Clean-install RPM from an ephemeral repository
+        run: |
+          set -euo pipefail
+          root="$PWD/.tideforge/rpm/${{ matrix.package }}"
+          docker run --rm --volume "$root:/work:ro" registry.opensuse.org/opensuse/tumbleweed:latest bash -lc '
+            set -euo pipefail
+            zypper --non-interactive --gpg-auto-import-keys refresh
+            zypper --non-interactive install createrepo_c
+            cp -a /work/rpmbuild/RPMS /tmp/tideforge-rpms
+            createrepo_c /tmp/tideforge-rpms
+            # Priority 1 pins the ephemeral repo above the distro repositories so
+            # the smoke test exercises the RPM built in this job, not a same-named
+            # package from Tumbleweed. The el10 job needs the same override for
+            # libseat; the reasoning is identical here.
+            zypper --non-interactive addrepo --no-gpgcheck --priority 1 file:///tmp/tideforge-rpms tideforge
+            zypper --non-interactive --gpg-auto-import-keys refresh tideforge
+            zypper --non-interactive install --no-gpg-checks --allow-unsigned-rpm ${{ matrix.install_name }}
+            rpm -q ${{ matrix.install_name }}
+            ${{ matrix.smoke }}
+          '
+      - uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: ${{ matrix.package }}-opensuse-tumbleweed-rpm
+          path: .tideforge/rpm/${{ matrix.package }}/rpmbuild/RPMS/
+          if-no-files-found: warn
+
   xfconf-split:
     name: xfconf (split-package contract)
     needs: [rpm, deb]

--- a/.github/workflows/validate-package-factory.yml
+++ b/.github/workflows/validate-package-factory.yml
@@ -17,6 +17,12 @@ on:
       - docs/PACKAGE_FACTORY.md
       - packaging/**
       - .github/workflows/validate-package-factory.yml
+      # The validator now asserts that every declared target has at least one
+      # cell in the Tideforge gate (#139), so it must re-run when the gate
+      # workflows change. Without these paths, deleting the openSUSE job would
+      # not trip the check that exists to notice exactly that.
+      - .github/workflows/build-tideforge-supported.yml
+      - .github/workflows/build-tideforge-arch.yml
   push:
     branches: [main]
     paths:
@@ -32,6 +38,8 @@ on:
       - docs/PATCH_POLICY.md
       - docs/PACKAGE_FACTORY.md
       - packaging/**
+      - .github/workflows/build-tideforge-supported.yml
+      - .github/workflows/build-tideforge-arch.yml
   workflow_dispatch:
 
 permissions:

--- a/scripts/lint-generated-rpm.sh
+++ b/scripts/lint-generated-rpm.sh
@@ -42,8 +42,16 @@ fatal_checks=(
     invalid-license
 )
 
-dnf -y install epel-release >/dev/null
-dnf -y install rpmlint >/dev/null
+# This script runs inside whichever RPM build container the calling job used,
+# so it cannot assume dnf. openSUSE Tumbleweed (issue #139) ships zypper and
+# has no EPEL; rpmlint is in the base repositories there. Detect rather than
+# branch on a target name, so a future rpm-family target needs no edit here.
+if command -v zypper >/dev/null 2>&1; then
+    zypper --non-interactive install rpmlint >/dev/null
+else
+    dnf -y install epel-release >/dev/null
+    dnf -y install rpmlint >/dev/null
+fi
 
 mapfile -t rpms < <(find "$rpm_directory" -name '*.rpm' -type f | sort)
 if [ "${#rpms[@]}" -eq 0 ]; then

--- a/scripts/validate-package-factory.py
+++ b/scripts/validate-package-factory.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+import re
 import sys
 
 import yaml
@@ -14,9 +15,59 @@ def fail(message: str) -> None:
     raise SystemExit(1)
 
 
+def gate_targets(workflows: list[Path]) -> set[str]:
+    """Return every target name the Tideforge gate workflows actually exercise.
+
+    A cell counts only if it names a target, either as an explicit `target:`
+    matrix key or via `tideforge.py render --target <name>`. Reading the
+    workflows rather than trusting a hand-maintained list is the whole point:
+    the list is what went stale.
+    """
+    exercised: set[str] = set()
+    for workflow in workflows:
+        if not workflow.exists():
+            continue
+        text = workflow.read_text()
+        # `--target "${{ matrix.target }}"` names a target indirectly; the
+        # literal value comes from that job's matrix `target:` keys, which the
+        # second pattern collects. Skip the expression itself so it does not
+        # enter the set as a target literally called "matrix.target".
+        for match in re.finditer(r"--target\s+\"?([a-z0-9-]+)\b", text):
+            exercised.add(match.group(1))
+        for match in re.finditer(r"^\s*target:\s*([a-z0-9-]+)\s*$", text, re.MULTILINE):
+            exercised.add(match.group(1))
+    return exercised
+
+
+def check_gate_coverage(targets: set[str], workflows: list[Path]) -> None:
+    """Fail when a declared target has no cells in the gate.
+
+    openSUSE was declared with its own architectures and r2_path, 19 recipes
+    opted into it, and it still had zero cells for months (#139). Nothing
+    failed, because nothing was looking. A target that is never exercised must
+    not be indistinguishable from one that passes.
+    """
+    exercised = gate_targets(workflows)
+    uncovered = sorted(target for target in targets if target not in exercised)
+    if uncovered:
+        fail(
+            f"declared target(s) with zero cells in the Tideforge gate: {uncovered}. "
+            "Every target in package-factory.yaml must be exercised by at least one "
+            "job, or it is untested while looking supported. See #139."
+        )
+    print(f"Gate coverage: all {len(targets)} declared targets are exercised")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("manifest", type=Path)
+    parser.add_argument(
+        "--gate-workflow",
+        type=Path,
+        action="append",
+        default=None,
+        help="Tideforge gate workflow to scan for target coverage (repeatable)",
+    )
     args = parser.parse_args()
     data = yaml.safe_load(args.manifest.read_text())
     if data.get("schema") != 1:
@@ -55,6 +106,15 @@ def main() -> None:
         ):
             fail(f"{target_id}: build_repositories must be a list of non-empty names")
     print("Package factory manifest: valid")
+
+    workflows = args.gate_workflow
+    if workflows is None:
+        workflow_directory = args.manifest.parent.parent / ".github" / "workflows"
+        workflows = [
+            workflow_directory / "build-tideforge-supported.yml",
+            workflow_directory / "build-tideforge-arch.yml",
+        ]
+    check_gate_coverage(set(targets), workflows)
 
 
 if __name__ == "__main__":

--- a/tests/test_validate_package_factory.py
+++ b/tests/test_validate_package_factory.py
@@ -1,0 +1,108 @@
+"""Tests for the package-factory contract validator.
+
+The gate-coverage check exists because openSUSE was a declared target with zero
+cells in the Tideforge gate for months (#139). Nothing failed, because nothing
+was looking: "never tested" and "passing" were indistinguishable. These tests
+assert the check actually distinguishes them, in both directions.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "validate_package_factory", ROOT / "scripts" / "validate-package-factory.py"
+)
+assert SPEC and SPEC.loader
+validator = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(validator)
+
+
+DECLARED = {"el10", "ubuntu", "debian", "opensuse-tumbleweed", "arch"}
+
+
+def write(tmp_path: Path, name: str, text: str) -> Path:
+    path = tmp_path / name
+    path.write_text(text)
+    return path
+
+
+def test_gate_targets_reads_explicit_matrix_keys(tmp_path: Path) -> None:
+    workflow = write(
+        tmp_path,
+        "gate.yml",
+        "jobs:\n  rpm:\n    strategy:\n      matrix:\n        include:\n"
+        "          - package: uupd\n            target: el10\n"
+        "          - package: dgop\n            target: ubuntu\n",
+    )
+    assert validator.gate_targets([workflow]) == {"el10", "ubuntu"}
+
+
+def test_gate_targets_reads_render_target_flags(tmp_path: Path) -> None:
+    workflow = write(
+        tmp_path,
+        "gate.yml",
+        "run: python3 scripts/tideforge.py render r --target opensuse-tumbleweed --output o\n",
+    )
+    assert validator.gate_targets([workflow]) == {"opensuse-tumbleweed"}
+
+
+def test_gate_targets_ignores_the_matrix_expression(tmp_path: Path) -> None:
+    """`--target "${{ matrix.target }}"` names no target by itself.
+
+    Its literal values come from that job's `target:` keys. Capturing the
+    expression would add a phantom target called "matrix.target" to the set.
+    """
+    workflow = write(
+        tmp_path,
+        "gate.yml",
+        'run: python3 scripts/tideforge.py render r --target "${{ matrix.target }}"\n',
+    )
+    assert validator.gate_targets([workflow]) == set()
+
+
+def test_gate_targets_skips_missing_files(tmp_path: Path) -> None:
+    assert validator.gate_targets([tmp_path / "absent.yml"]) == set()
+
+
+def test_check_gate_coverage_passes_when_every_target_has_a_cell(tmp_path: Path) -> None:
+    workflow = write(
+        tmp_path,
+        "gate.yml",
+        "".join(f"        target: {target}\n" for target in sorted(DECLARED)),
+    )
+    validator.check_gate_coverage(DECLARED, [workflow])
+
+
+def test_check_gate_coverage_fails_on_a_target_with_zero_cells(tmp_path: Path) -> None:
+    """The exact #139 regression: openSUSE declared, exercised nowhere."""
+    workflow = write(
+        tmp_path,
+        "gate.yml",
+        "".join(
+            f"        target: {target}\n"
+            for target in sorted(DECLARED - {"opensuse-tumbleweed"})
+        ),
+    )
+    with pytest.raises(SystemExit):
+        validator.check_gate_coverage(DECLARED, [workflow])
+
+
+def test_the_real_gate_exercises_every_declared_target() -> None:
+    """Guards the live workflows, not a fixture.
+
+    This is the assertion that would have failed before #139 and must keep
+    failing if a target is ever added to the manifest without cells.
+    """
+    workflows = ROOT / ".github" / "workflows"
+    validator.check_gate_coverage(
+        DECLARED,
+        [
+            workflows / "build-tideforge-supported.yml",
+            workflows / "build-tideforge-arch.yml",
+        ],
+    )


### PR DESCRIPTION
Closes #139 (first half — cells; derivation follows separately, see below).

## The gap

openSUSE Tumbleweed is declared in `manifests/package-factory.yaml` with its own
architectures and `r2_path`, and **19 of 44 recipes opt into it** — yet it had
zero cells in the Tideforge gate. No openSUSE package had ever been built or
installed by this pipeline. "Never tested" and "passing" looked identical.

**The recipes were never the gap.** `render()` dispatches on the target format
and `opensuse-tumbleweed` is `format: rpm`, so it already reached `render_rpm`;
rendering `dgop` for openSUSE succeeds with no renderer change. The gap was
purely the hand-written matrix `include:` list, which nothing checked against
the manifest.

## What this adds

An `opensuse-rpm` job, deliberately scoped to **two** packages rather than all
19, so the first openSUSE result has one readable cause instead of nineteen
unrelated ones. `dgop` is a go build and `cli11-devel` is header-only cmake;
neither exercises the cargo path, whose fat-LTO and debuginfo handling is tuned
for el10 and Arch and has never run under zypper.

The zypper mapping follows the table verified in a real Tumbleweed container in
 #139, with one addition: `zypper install` with zero arguments is an error rather
than a no-op, so the `rpmspec -q --buildrequires` result is guarded for recipes
that declare no BuildRequires.

## The part that stops this recurring

Adding cells fixes today's hole but not the class of defect, so
`validate-package-factory.py` now reads the gate workflows and **fails when any
declared target has no cells at all**. Verified in both directions:

- on the tree as it stood before this commit → **fails**, naming `opensuse-tumbleweed`
- with the new job → **passes**, all 5 targets exercised

Note the check that would *not* have caught this: "every declared target has at
least one recipe" was already true — 19 recipes opted into openSUSE the whole
time. The gap was cells, so cells are what is asserted.

Its trigger paths now include the gate workflows, so deleting the openSUSE job
trips the check that exists to notice exactly that.

## Also

`scripts/lint-generated-rpm.sh` hardcoded `dnf` and EPEL. It now detects
zypper, so it works in any rpm-family build container without branching on a
target name.

## Not in this PR

Deriving the matrix from `recipe.targets ∩ manifest.targets` — the fix for the
*recipe*-level version of this gap, where a recipe declares a target no cell
builds. That is blocked on a prerequisite: 27 gate cells carry hand-written
`smoke:`/`install_name:` values and **no recipe carries any such field**, so
derivation has nowhere to read them from. That migration is behaviour-neutral
and belongs in its own PR; derivation is ~40 lines once it lands.

## Gates run locally

yamllint (CI config), actionlint, shellcheck all exit 0; pytest 129 passed,
including 7 new tests — one of which asserts against the **live** workflows
rather than a fixture, so it keeps failing if a target ever loses its cells.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->