### PR TITLE
ci(tideforge): add xfwm4-themes to gate paths and rpm matrix (fixes #123)

### DIFF
--- a/.github/workflows/build-tideforge-supported.yml
+++ b/.github/workflows/build-tideforge-supported.yml
@@ -40,6 +40,7 @@ on:
       - packages/evtest/package.yaml
       - packages/python3-evdev/package.yaml
       - packages/input-remapper/package.yaml
+      - packages/xfwm4-themes/package.yaml
       - manifests/package-factory.yaml
       - scripts/tideforge.py
       - scripts/verify-tideforge-source.py
@@ -203,6 +204,10 @@ jobs:
             target: el10
             install_name: python3-evdev
             smoke: python3 -c "import evdev"
+          - package: xfwm4-themes
+            target: el10
+            install_name: xfwm4-themes
+            smoke: test -f /usr/share/themes/Default/xfwm4/themerc
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7

--- a/packages/xfwm4-themes/package.yaml
+++ b/packages/xfwm4-themes/package.yaml
@@ -85,7 +85,7 @@ files:
     - usr/share/themes/Default/xfwm4/
     - usr/share/themes/Default-hdpi/xfwm4/
     - usr/share/themes/Default-xhdpi/xfwm4/
-    - usr/share/themes/daloa/xfwm4/
-    - usr/share/themes/kokodi/xfwm4/
-    - usr/share/themes/moheli/xfwm4/
+    - usr/share/themes/Daloa/xfwm4/
+    - usr/share/themes/Kokodi/xfwm4/
+    - usr/share/themes/Moheli/xfwm4/
 targets: [el10]

--- a/packages/xfwm4-themes/package.yaml
+++ b/packages/xfwm4-themes/package.yaml
@@ -88,4 +88,6 @@ files:
     - usr/share/themes/Daloa/xfwm4/
     - usr/share/themes/Kokodi/xfwm4/
     - usr/share/themes/Moheli/xfwm4/
+verify:
+  smoke: test -f /usr/share/themes/Default/xfwm4/themerc
 targets: [el10]


### PR DESCRIPTION
## What

Adds xfwm4-themes to the Tideforge gate. Recipe already landed on main
via the stack merge (#114/#125); this gives it a build/install cell.

- paths trigger entry
- rpm matrix include with smoke: asserts `/usr/share/themes/Default/xfwm4/themerc`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->