### PR TITLE
feat(ci): content-addressed source cache for Tideforge builds

### DIFF
--- a/.github/actions/tideforge-source-cache/action.yml
+++ b/.github/actions/tideforge-source-cache/action.yml
@@ -1,0 +1,30 @@
+name: Tideforge source cache
+description: >
+  Restore the content-addressed Tideforge source store for one recipe.
+  The key hashes only the recipe's pinned sha256 digests, so it is
+  identical across every build target (el10, Fedora, Debian, Ubuntu,
+  Arch) and changes exactly when a source pin changes. A miss is a
+  normal, silent path — the fetch/verify scripts download as before and
+  the post step saves what they stored. Requires python3 + pyyaml on
+  the runner (every Tideforge job installs them before this action).
+inputs:
+  recipe:
+    description: Path to the package.yaml recipe
+    required: true
+outputs:
+  cache-hit:
+    description: Whether the exact key was already cached
+    value: ${{ steps.restore.outputs.cache-hit }}
+runs:
+  using: composite
+  steps:
+    - id: key
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "key=tideforge-src-v1-$(python3 scripts/tideforge_cache.py key '${{ inputs.recipe }}')" >> "$GITHUB_OUTPUT"
+    - id: restore
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/tideforge/sources
+        key: ${{ steps.key.outputs.key }}

--- a/.github/workflows/build-tideforge-arch.yml
+++ b/.github/workflows/build-tideforge-arch.yml
@@ -72,8 +72,12 @@ jobs:
         with:
           python-version: '3.14'
       - run: pip install pyyaml
+      - name: Restore the content-addressed source cache
+        uses: ./.github/actions/tideforge-source-cache
+        with:
+          recipe: packages/${{ matrix.package }}/package.yaml
       - run: python3 scripts/tideforge.py validate packages/${{ matrix.package }}/package.yaml
-      - run: python3 scripts/verify-tideforge-source.py packages/${{ matrix.package }}/package.yaml
+      - run: python3 scripts/verify-tideforge-source.py packages/${{ matrix.package }}/package.yaml --cache-dir "$HOME/.cache/tideforge/sources"
       - run: python3 scripts/tideforge.py render packages/${{ matrix.package }}/package.yaml --target arch --output .tideforge/arch/${{ matrix.package }}
       - name: Pull the build image, retrying transient registry failures
         run: scripts/pull-container-image.sh docker.io/library/archlinux:latest

--- a/.github/workflows/build-tideforge-supported.yml
+++ b/.github/workflows/build-tideforge-supported.yml
@@ -78,16 +78,20 @@ jobs:
         with:
           python-version: '3.14'
       - run: pip install pyyaml
+      - name: Restore the content-addressed source cache
+        uses: ./.github/actions/tideforge-source-cache
+        with:
+          recipe: packages/${{ matrix.package }}/package.yaml
       - name: Render and fetch the exact source archive
         run: |
           set -euo pipefail
           recipe="packages/${{ matrix.package }}/package.yaml"
           root="$PWD/.tideforge/rpm-payload/${{ matrix.package }}"
           python3 scripts/tideforge.py validate "$recipe"
-          python3 scripts/verify-tideforge-source.py "$recipe"
+          python3 scripts/verify-tideforge-source.py "$recipe" --cache-dir "$HOME/.cache/tideforge/sources"
           python3 scripts/tideforge.py render "$recipe" --target el10 --output "$root/rpmbuild/SPECS"
           mkdir -p "$root/rpmbuild"/{BUILD,BUILDROOT,RPMS,SOURCES,SRPMS}
-          python3 scripts/fetch-tideforge-sources.py "$recipe" "$root/rpmbuild/SOURCES"
+          python3 scripts/fetch-tideforge-sources.py "$recipe" "$root/rpmbuild/SOURCES" --cache-dir "$HOME/.cache/tideforge/sources"
       - name: Pull the build image, retrying transient registry failures
         run: scripts/pull-container-image.sh quay.io/centos/centos:stream10
       - name: Build generated RPM payload
@@ -194,16 +198,20 @@ jobs:
         with:
           python-version: '3.14'
       - run: pip install pyyaml
+      - name: Restore the content-addressed source cache
+        uses: ./.github/actions/tideforge-source-cache
+        with:
+          recipe: packages/${{ matrix.package }}/package.yaml
       - name: Render and fetch the exact source archive
         run: |
           set -euo pipefail
           recipe="packages/${{ matrix.package }}/package.yaml"
           root="$PWD/.tideforge/rpm/${{ matrix.package }}"
           python3 scripts/tideforge.py validate "$recipe"
-          python3 scripts/verify-tideforge-source.py "$recipe"
+          python3 scripts/verify-tideforge-source.py "$recipe" --cache-dir "$HOME/.cache/tideforge/sources"
           python3 scripts/tideforge.py render "$recipe" --target "${{ matrix.target }}" --output "$root/rpmbuild/SPECS"
           mkdir -p "$root/rpmbuild"/{BUILD,BUILDROOT,RPMS,SOURCES,SRPMS}
-          python3 scripts/fetch-tideforge-sources.py "$recipe" "$root/rpmbuild/SOURCES"
+          python3 scripts/fetch-tideforge-sources.py "$recipe" "$root/rpmbuild/SOURCES" --cache-dir "$HOME/.cache/tideforge/sources"
       - name: Pull the build image, retrying transient registry failures
         run: scripts/pull-container-image.sh quay.io/centos/centos:stream10
       - name: Build generated RPM with only declared BuildRequires
@@ -396,6 +404,10 @@ jobs:
         with:
           python-version: '3.14'
       - run: pip install pyyaml
+      - name: Restore the content-addressed source cache
+        uses: ./.github/actions/tideforge-source-cache
+        with:
+          recipe: packages/gtkgreet/package.yaml
       - uses: actions/download-artifact@v8
         with:
           name: gtk-layer-shell-el10-rpm
@@ -410,10 +422,10 @@ jobs:
           recipe=packages/gtkgreet/package.yaml
           root="$PWD/.tideforge/gtkgreet"
           python3 scripts/tideforge.py validate "$recipe"
-          python3 scripts/verify-tideforge-source.py "$recipe"
+          python3 scripts/verify-tideforge-source.py "$recipe" --cache-dir "$HOME/.cache/tideforge/sources"
           python3 scripts/tideforge.py render "$recipe" --target el10 --output "$root/rpmbuild/SPECS"
           mkdir -p "$root/rpmbuild"/{BUILD,BUILDROOT,RPMS,SOURCES,SRPMS}
-          python3 scripts/fetch-tideforge-sources.py "$recipe" "$root/rpmbuild/SOURCES"
+          python3 scripts/fetch-tideforge-sources.py "$recipe" "$root/rpmbuild/SOURCES" --cache-dir "$HOME/.cache/tideforge/sources"
       - name: Pull the build image, retrying transient registry failures
         run: scripts/pull-container-image.sh quay.io/centos/centos:stream10
       - name: Build gtkgreet against staged Tideforge dependencies
@@ -464,6 +476,10 @@ jobs:
         with:
           python-version: '3.14'
       - run: pip install pyyaml
+      - name: Restore the content-addressed source cache
+        uses: ./.github/actions/tideforge-source-cache
+        with:
+          recipe: packages/cpptrace-devel/package.yaml
       - uses: actions/download-artifact@v8
         with:
           name: libunwind-devel-el10-rpm
@@ -474,19 +490,10 @@ jobs:
           recipe=packages/cpptrace-devel/package.yaml
           root="$PWD/.tideforge/cpptrace"
           python3 scripts/tideforge.py validate "$recipe"
-          python3 scripts/verify-tideforge-source.py "$recipe"
+          python3 scripts/verify-tideforge-source.py "$recipe" --cache-dir "$HOME/.cache/tideforge/sources"
           python3 scripts/tideforge.py render "$recipe" --target el10 --output "$root/rpmbuild/SPECS"
           mkdir -p "$root/rpmbuild"/{BUILD,BUILDROOT,RPMS,SOURCES,SRPMS}
-          python3 - "$recipe" "$root/rpmbuild/SOURCES" <<'PY'
-          import sys
-          from pathlib import Path
-          from urllib.parse import urlparse
-          from urllib.request import urlretrieve
-          import yaml
-          recipe = yaml.safe_load(Path(sys.argv[1]).read_text())
-          destination = Path(sys.argv[2]) / Path(urlparse(recipe["source"]["url"]).path).name
-          urlretrieve(recipe["source"]["url"], destination)
-          PY
+          python3 scripts/fetch-tideforge-sources.py "$recipe" "$root/rpmbuild/SOURCES" --cache-dir "$HOME/.cache/tideforge/sources"
       - name: Pull the build image, retrying transient registry failures
         run: scripts/pull-container-image.sh quay.io/centos/centos:stream10
       - name: Build cpptrace with Tideforge libunwind
@@ -536,6 +543,10 @@ jobs:
         with:
           python-version: '3.14'
       - run: pip install pyyaml
+      - name: Restore the content-addressed source cache
+        uses: ./.github/actions/tideforge-source-cache
+        with:
+          recipe: packages/quickshell/package.yaml
       - uses: actions/download-artifact@v8
         with:
           name: cli11-devel-el10-rpm
@@ -562,19 +573,10 @@ jobs:
           recipe=packages/quickshell/package.yaml
           root="$PWD/.tideforge/quickshell"
           python3 scripts/tideforge.py validate "$recipe"
-          python3 scripts/verify-tideforge-source.py "$recipe"
+          python3 scripts/verify-tideforge-source.py "$recipe" --cache-dir "$HOME/.cache/tideforge/sources"
           python3 scripts/tideforge.py render "$recipe" --target el10 --output "$root/rpmbuild/SPECS"
           mkdir -p "$root/rpmbuild"/{BUILD,BUILDROOT,RPMS,SOURCES,SRPMS}
-          python3 - "$recipe" "$root/rpmbuild/SOURCES" <<'PY'
-          import sys
-          from pathlib import Path
-          from urllib.parse import urlparse
-          from urllib.request import urlretrieve
-          import yaml
-          recipe = yaml.safe_load(Path(sys.argv[1]).read_text())
-          destination = Path(sys.argv[2]) / Path(urlparse(recipe["source"]["url"]).path).name
-          urlretrieve(recipe["source"]["url"], destination)
-          PY
+          python3 scripts/fetch-tideforge-sources.py "$recipe" "$root/rpmbuild/SOURCES" --cache-dir "$HOME/.cache/tideforge/sources"
       - name: Pull the build image, retrying transient registry failures
         run: scripts/pull-container-image.sh quay.io/centos/centos:stream10
       - name: Build Quickshell with Tideforge prerequisite packages
@@ -623,6 +625,10 @@ jobs:
         with:
           python-version: '3.14'
       - run: pip install pyyaml
+      - name: Restore the content-addressed source cache
+        uses: ./.github/actions/tideforge-source-cache
+        with:
+          recipe: packages/niri/package.yaml
       - uses: actions/download-artifact@v8
         with:
           name: libseat-el10-rpm
@@ -633,19 +639,10 @@ jobs:
           recipe=packages/niri/package.yaml
           root="$PWD/.tideforge/niri"
           python3 scripts/tideforge.py validate "$recipe"
-          python3 scripts/verify-tideforge-source.py "$recipe"
+          python3 scripts/verify-tideforge-source.py "$recipe" --cache-dir "$HOME/.cache/tideforge/sources"
           python3 scripts/tideforge.py render "$recipe" --target el10 --output "$root/rpmbuild/SPECS"
           mkdir -p "$root/rpmbuild"/{BUILD,BUILDROOT,RPMS,SOURCES,SRPMS}
-          python3 - "$recipe" "$root/rpmbuild/SOURCES" <<'PY'
-          import sys
-          from pathlib import Path
-          from urllib.parse import urlparse
-          from urllib.request import urlretrieve
-          import yaml
-          recipe = yaml.safe_load(Path(sys.argv[1]).read_text())
-          destination = Path(sys.argv[2]) / Path(urlparse(recipe["source"]["url"]).path).name
-          urlretrieve(recipe["source"]["url"], destination)
-          PY
+          python3 scripts/fetch-tideforge-sources.py "$recipe" "$root/rpmbuild/SOURCES" --cache-dir "$HOME/.cache/tideforge/sources"
       - name: Pull the build image, retrying transient registry failures
         run: scripts/pull-container-image.sh quay.io/centos/centos:stream10
       - name: Build Niri with Tideforge libseat
@@ -699,6 +696,10 @@ jobs:
         with:
           python-version: '3.14'
       - run: pip install pyyaml
+      - name: Restore the content-addressed source cache
+        uses: ./.github/actions/tideforge-source-cache
+        with:
+          recipe: packages/iio-niri/package.yaml
       - uses: actions/download-artifact@v8
         with:
           name: libseat-el10-rpm
@@ -713,19 +714,10 @@ jobs:
           recipe=packages/iio-niri/package.yaml
           root="$PWD/.tideforge/iio-niri"
           python3 scripts/tideforge.py validate "$recipe"
-          python3 scripts/verify-tideforge-source.py "$recipe"
+          python3 scripts/verify-tideforge-source.py "$recipe" --cache-dir "$HOME/.cache/tideforge/sources"
           python3 scripts/tideforge.py render "$recipe" --target el10 --output "$root/rpmbuild/SPECS"
           mkdir -p "$root/rpmbuild"/{BUILD,BUILDROOT,RPMS,SOURCES,SRPMS}
-          python3 - "$recipe" "$root/rpmbuild/SOURCES" <<'PY'
-          import sys
-          from pathlib import Path
-          from urllib.parse import urlparse
-          from urllib.request import urlretrieve
-          import yaml
-          recipe = yaml.safe_load(Path(sys.argv[1]).read_text())
-          destination = Path(sys.argv[2]) / Path(urlparse(recipe["source"]["url"]).path).name
-          urlretrieve(recipe["source"]["url"], destination)
-          PY
+          python3 scripts/fetch-tideforge-sources.py "$recipe" "$root/rpmbuild/SOURCES" --cache-dir "$HOME/.cache/tideforge/sources"
       - name: Pull the build image, retrying transient registry failures
         run: scripts/pull-container-image.sh quay.io/centos/centos:stream10
       - name: Build iio-niri with only declared BuildRequires
@@ -957,13 +949,17 @@ jobs:
         with:
           python-version: '3.14'
       - run: pip install pyyaml
+      - name: Restore the content-addressed source cache
+        uses: ./.github/actions/tideforge-source-cache
+        with:
+          recipe: packages/${{ matrix.package }}/package.yaml
       - name: Render and assemble a Debian source tree
         run: |
           set -euo pipefail
           recipe="packages/${{ matrix.package }}/package.yaml"
           root="$PWD/.tideforge/deb/${{ matrix.target }}-${{ matrix.package }}"
           python3 scripts/tideforge.py validate "$recipe"
-          python3 scripts/verify-tideforge-source.py "$recipe"
+          python3 scripts/verify-tideforge-source.py "$recipe" --cache-dir "$HOME/.cache/tideforge/sources"
           python3 scripts/tideforge.py render "$recipe" --target "${{ matrix.target }}" --output "$root/rendered"
           python3 - "$recipe" "$root" <<'PY'
           import sys
@@ -973,12 +969,24 @@ jobs:
           from pathlib import Path
           from urllib.request import urlretrieve
           import yaml
+          sys.path.insert(0, "scripts")
+          import tideforge_cache
+          cache_dir = Path.home() / ".cache" / "tideforge" / "sources"
+          def materialise(source, destination, label):
+              payload = tideforge_cache.lookup(cache_dir, source["sha256"])
+              if payload is not None:
+                  destination.write_bytes(payload)
+                  print(f"source cache hit: {label}")
+                  return
+              urlretrieve(source["url"], destination)
+              if hashlib.file_digest(destination.open("rb"), "sha256").hexdigest() != source["sha256"]:
+                  raise SystemExit(f"checksum mismatch for {label}")
+              tideforge_cache.store(cache_dir, destination.read_bytes())
+              print(f"source cache miss, downloaded: {label}")
           recipe = yaml.safe_load(Path(sys.argv[1]).read_text())
           root = Path(sys.argv[2])
           archive = root / "source.tar.gz"
-          urlretrieve(recipe["source"]["url"], archive)
-          if hashlib.file_digest(archive.open("rb"), "sha256").hexdigest() != recipe["source"]["sha256"]:
-              raise SystemExit("checksum mismatch for primary source")
+          materialise(recipe["source"], archive, "primary source")
           with tarfile.open(archive) as tar:
               tar.extractall(root / "source")
           source = root / "source" / recipe["source"].get("directory", f"{recipe['name']}-{recipe['version']}")
@@ -988,9 +996,7 @@ jobs:
           # submodules) in the same paths used by the RPM/Pacman renderers.
           for index, extra in enumerate(recipe.get("sources", []), start=1):
               extra_archive = root / f"source-{index}.tar"
-              urlretrieve(extra["url"], extra_archive)
-              if hashlib.file_digest(extra_archive.open("rb"), "sha256").hexdigest() != extra["sha256"]:
-                  raise SystemExit(f"checksum mismatch for auxiliary source {index}")
+              materialise(extra, extra_archive, f"auxiliary source {index}")
               destination = source / extra["destination"]
               if not extra.get("extract", True):
                   destination.parent.mkdir(parents=True, exist_ok=True)

--- a/.github/workflows/build-tideforge-supported.yml
+++ b/.github/workflows/build-tideforge-supported.yml
@@ -297,16 +297,20 @@ jobs:
         with:
           python-version: '3.14'
       - run: pip install pyyaml
+      - name: Restore the content-addressed source cache
+        uses: ./.github/actions/tideforge-source-cache
+        with:
+          recipe: packages/${{ matrix.package }}/package.yaml
       - name: Render and fetch the exact source archive
         run: |
           set -euo pipefail
           recipe="packages/${{ matrix.package }}/package.yaml"
           root="$PWD/.tideforge/rpm/${{ matrix.package }}"
           python3 scripts/tideforge.py validate "$recipe"
-          python3 scripts/verify-tideforge-source.py "$recipe"
+          python3 scripts/verify-tideforge-source.py "$recipe" --cache-dir "$HOME/.cache/tideforge/sources"
           python3 scripts/tideforge.py render "$recipe" --target opensuse-tumbleweed --output "$root/rpmbuild/SPECS"
           mkdir -p "$root/rpmbuild"/{BUILD,BUILDROOT,RPMS,SOURCES,SRPMS}
-          python3 scripts/fetch-tideforge-sources.py "$recipe" "$root/rpmbuild/SOURCES"
+          python3 scripts/fetch-tideforge-sources.py "$recipe" "$root/rpmbuild/SOURCES" --cache-dir "$HOME/.cache/tideforge/sources"
       - name: Pull the build image, retrying transient registry failures
         run: scripts/pull-container-image.sh registry.opensuse.org/opensuse/tumbleweed:latest
       - name: Build generated RPM with only declared BuildRequires

--- a/.github/workflows/seed-tideforge-source-cache.yml
+++ b/.github/workflows/seed-tideforge-source-cache.yml
@@ -1,0 +1,70 @@
+name: Seed Tideforge source cache
+
+# PR branches can read main's actions/cache scope but cannot write to it, so
+# something on main has to populate the content-addressed source store or
+# every PR pays a cold first run. This seeds one cache entry per recipe,
+# keyed only on the recipe's pinned sha256 digests — the same key every
+# build target restores. Unchanged recipes are a restore-hit and a no-op
+# (actions/cache skips the save and the fetch script never touches the
+# network), so re-runs are cheap and idempotent.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - packages/**/package.yaml
+      - scripts/fetch-tideforge-sources.py
+      - scripts/tideforge_cache.py
+      - .github/actions/tideforge-source-cache/action.yml
+      - .github/workflows/seed-tideforge-source-cache.yml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  list-recipes:
+    name: List recipes
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.list.outputs.packages }}
+    steps:
+      - uses: actions/checkout@v7
+      - id: list
+        run: |
+          set -euo pipefail
+          packages=$(ls packages/*/package.yaml | xargs -n1 dirname | xargs -n1 basename | jq -R . | jq -cs .)
+          echo "packages=$packages" >> "$GITHUB_OUTPUT"
+
+  seed:
+    name: ${{ matrix.package }}
+    needs: list-recipes
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      # Every job is seconds of work; cap parallelism so a recipe-wide push
+      # does not crowd out real builds queuing for org runners (see #130).
+      max-parallel: 8
+      matrix:
+        package: ${{ fromJSON(needs.list-recipes.outputs.packages) }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.14'
+      - run: pip install pyyaml
+      - name: Restore the content-addressed source cache
+        uses: ./.github/actions/tideforge-source-cache
+        with:
+          recipe: packages/${{ matrix.package }}/package.yaml
+      - name: Populate the store for this recipe
+        run: |
+          set -euo pipefail
+          python3 scripts/fetch-tideforge-sources.py \
+            "packages/${{ matrix.package }}/package.yaml" \
+            "$RUNNER_TEMP/tideforge-seed-sources" \
+            --cache-dir "$HOME/.cache/tideforge/sources"

--- a/scripts/fetch-tideforge-sources.py
+++ b/scripts/fetch-tideforge-sources.py
@@ -10,6 +10,8 @@ from urllib.request import Request, urlopen
 
 import yaml
 
+import tideforge_cache
+
 
 def filename(source: dict) -> str:
     value = source.get("filename") or Path(urlparse(source["url"]).path).name
@@ -22,15 +24,26 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("recipe", type=Path)
     parser.add_argument("destination", type=Path)
+    parser.add_argument("--cache-dir", type=Path, default=None,
+                        help="content-addressed store consulted before the network")
     args = parser.parse_args()
     recipe = yaml.safe_load(args.recipe.read_text())
     args.destination.mkdir(parents=True, exist_ok=True)
-    for source in [recipe["source"], *recipe.get("sources", [])]:
-        request = Request(source["url"], headers={"User-Agent": "tunaos-package-factory"})
-        payload = urlopen(request).read()  # nosec B310 - schema validates pinned HTTPS sources
-        digest = hashlib.sha256(payload).hexdigest()
-        if digest != source["sha256"]:
-            raise SystemExit(f"checksum mismatch for {source['url']}")
+    for source in tideforge_cache.recipe_sources(recipe):
+        payload = None
+        if args.cache_dir is not None:
+            payload = tideforge_cache.lookup(args.cache_dir, source["sha256"])
+        if payload is None:
+            request = Request(source["url"], headers={"User-Agent": "tunaos-package-factory"})
+            payload = urlopen(request).read()  # nosec B310 - schema validates pinned HTTPS sources
+            digest = hashlib.sha256(payload).hexdigest()
+            if digest != source["sha256"]:
+                raise SystemExit(f"checksum mismatch for {source['url']}")
+            if args.cache_dir is not None:
+                tideforge_cache.store(args.cache_dir, payload)
+            print(f"source cache miss, downloaded: {source['url']}")
+        else:
+            print(f"source cache hit: {filename(source)} ({source['sha256'][:12]})")
         (args.destination / filename(source)).write_bytes(payload)
 
 

--- a/scripts/tideforge_cache.py
+++ b/scripts/tideforge_cache.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Content-addressed store for Tideforge source archives.
+
+Blobs live at ``<cache_dir>/<sha256>``. The pinned recipe checksum is both
+the lookup key and the integrity proof, so a hit is provably the recipe's
+bytes and a corrupted entry is indistinguishable from a miss. The ``key``
+subcommand prints a digest over a recipe's pinned checksums — the same
+value on every build target, changing exactly when a source pin changes —
+for use as an actions/cache key.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+
+import yaml
+
+
+def recipe_sources(recipe: dict) -> list[dict]:
+    return [recipe["source"], *recipe.get("sources", [])]
+
+
+def cache_key(recipe: dict) -> str:
+    digests = sorted(source["sha256"] for source in recipe_sources(recipe))
+    return hashlib.sha256("\n".join(digests).encode()).hexdigest()
+
+
+def lookup(cache_dir: Path, sha256: str) -> bytes | None:
+    blob = cache_dir / sha256
+    if not blob.is_file():
+        return None
+    payload = blob.read_bytes()
+    if hashlib.sha256(payload).hexdigest() != sha256:
+        blob.unlink()
+        return None
+    return payload
+
+
+def store(cache_dir: Path, payload: bytes) -> Path:
+    digest = hashlib.sha256(payload).hexdigest()
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    staging = cache_dir / f".{digest}.tmp"
+    staging.write_bytes(payload)
+    staging.replace(cache_dir / digest)
+    return cache_dir / digest
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    key = subparsers.add_parser("key", help="print the cache key for a recipe")
+    key.add_argument("recipe", type=Path)
+    args = parser.parse_args()
+    print(cache_key(yaml.safe_load(args.recipe.read_text())))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify-tideforge-source.py
+++ b/scripts/verify-tideforge-source.py
@@ -9,19 +9,34 @@ from urllib.request import Request, urlopen
 
 import yaml
 
+import tideforge_cache
+
 
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("recipe", type=Path)
+    parser.add_argument("--cache-dir", type=Path, default=None,
+                        help="content-addressed store consulted before the network; "
+                             "verified downloads are stored for later fetches")
     args = parser.parse_args()
     recipe = yaml.safe_load(args.recipe.read_text())
-    sources = [recipe["source"], *recipe.get("sources", [])]
+    sources = tideforge_cache.recipe_sources(recipe)
     for index, source in enumerate(sources):
+        if args.cache_dir is not None:
+            if tideforge_cache.lookup(args.cache_dir, source["sha256"]) is not None:
+                print(f"source {index} verified from cache ({source['sha256'][:12]})")
+                continue
         request = Request(source["url"], headers={"User-Agent": "tunaos-package-factory"})
         with urlopen(request) as response:  # nosec B310 - recipe validation requires HTTPS
-            digest = hashlib.file_digest(response, "sha256").hexdigest()
+            if args.cache_dir is None:
+                digest = hashlib.file_digest(response, "sha256").hexdigest()
+            else:
+                payload = response.read()
+                digest = hashlib.sha256(payload).hexdigest()
         if digest != source["sha256"]:
             raise SystemExit(f"source {index} checksum mismatch: expected {source['sha256']}, got {digest}")
+        if args.cache_dir is not None:
+            tideforge_cache.store(args.cache_dir, payload)
     print(f"{recipe['name']}: {len(sources)} source checksum(s) verified")
 
 

--- a/tests/test_tideforge_cache.py
+++ b/tests/test_tideforge_cache.py
@@ -1,0 +1,151 @@
+import hashlib
+import importlib.util
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts import tideforge_cache
+
+
+def load_script(name):
+    path = Path(__file__).parent.parent / "scripts" / name
+    spec = importlib.util.spec_from_file_location(name.replace("-", "_").removesuffix(".py"), path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+fetch_sources = load_script("fetch-tideforge-sources.py")
+verify_source = load_script("verify-tideforge-source.py")
+
+PAYLOAD = b"tideforge test archive bytes"
+DIGEST = hashlib.sha256(PAYLOAD).hexdigest()
+
+
+def make_recipe(tmp_path, sources=None):
+    recipe = {
+        "name": "demo",
+        "version": "1.0",
+        "source": {"url": "https://example.invalid/demo-1.0.tar.gz", "sha256": DIGEST},
+    }
+    if sources is not None:
+        recipe["sources"] = sources
+    path = tmp_path / "package.yaml"
+    path.write_text(yaml.safe_dump(recipe))
+    return path, recipe
+
+
+def test_cache_key_ignores_source_order():
+    one = {"source": {"sha256": "a" * 64}, "sources": [{"sha256": "b" * 64}]}
+    two = {"source": {"sha256": "b" * 64}, "sources": [{"sha256": "a" * 64}]}
+    assert tideforge_cache.cache_key(one) == tideforge_cache.cache_key(two)
+
+
+def test_cache_key_changes_when_a_pin_changes():
+    base = {"source": {"sha256": "a" * 64}}
+    bumped = {"source": {"sha256": "c" * 64}}
+    assert tideforge_cache.cache_key(base) != tideforge_cache.cache_key(bumped)
+
+
+def test_lookup_misses_on_empty_store(tmp_path):
+    assert tideforge_cache.lookup(tmp_path, DIGEST) is None
+
+
+def test_store_then_lookup_round_trips(tmp_path):
+    tideforge_cache.store(tmp_path, PAYLOAD)
+    assert tideforge_cache.lookup(tmp_path, DIGEST) == PAYLOAD
+
+
+def test_corrupted_blob_reads_as_miss_and_is_deleted(tmp_path):
+    (tmp_path / DIGEST).write_bytes(b"not the pinned bytes")
+    assert tideforge_cache.lookup(tmp_path, DIGEST) is None
+    assert not (tmp_path / DIGEST).exists()
+
+
+def test_fetch_hit_serves_from_cache_without_network(tmp_path, monkeypatch):
+    recipe_path, _ = make_recipe(tmp_path)
+    cache = tmp_path / "cache"
+    tideforge_cache.store(cache, PAYLOAD)
+
+    def refuse(*args, **kwargs):
+        raise AssertionError("network touched on a cache hit")
+
+    monkeypatch.setattr(fetch_sources, "urlopen", refuse)
+    destination = tmp_path / "SOURCES"
+    monkeypatch.setattr(
+        "sys.argv",
+        ["fetch", str(recipe_path), str(destination), "--cache-dir", str(cache)],
+    )
+    fetch_sources.main()
+    assert (destination / "demo-1.0.tar.gz").read_bytes() == PAYLOAD
+
+
+def test_fetch_miss_downloads_and_populates_cache(tmp_path, monkeypatch):
+    recipe_path, _ = make_recipe(tmp_path)
+    cache = tmp_path / "cache"
+
+    class Response:
+        def read(self):
+            return PAYLOAD
+
+    monkeypatch.setattr(fetch_sources, "urlopen", lambda request: Response())
+    destination = tmp_path / "SOURCES"
+    monkeypatch.setattr(
+        "sys.argv",
+        ["fetch", str(recipe_path), str(destination), "--cache-dir", str(cache)],
+    )
+    fetch_sources.main()
+    assert (destination / "demo-1.0.tar.gz").read_bytes() == PAYLOAD
+    assert tideforge_cache.lookup(cache, DIGEST) == PAYLOAD
+
+
+def test_fetch_checksum_mismatch_still_fails_and_stores_nothing(tmp_path, monkeypatch):
+    recipe_path, _ = make_recipe(tmp_path)
+    cache = tmp_path / "cache"
+
+    class Response:
+        def read(self):
+            return b"tampered bytes"
+
+    monkeypatch.setattr(fetch_sources, "urlopen", lambda request: Response())
+    monkeypatch.setattr(
+        "sys.argv",
+        ["fetch", str(recipe_path), str(tmp_path / "SOURCES"), "--cache-dir", str(cache)],
+    )
+    with pytest.raises(SystemExit, match="checksum mismatch"):
+        fetch_sources.main()
+    assert tideforge_cache.lookup(cache, hashlib.sha256(b"tampered bytes").hexdigest()) is None
+
+
+def test_verify_hit_passes_without_network(tmp_path, monkeypatch):
+    recipe_path, _ = make_recipe(tmp_path)
+    cache = tmp_path / "cache"
+    tideforge_cache.store(cache, PAYLOAD)
+
+    def refuse(*args, **kwargs):
+        raise AssertionError("network touched on a cache hit")
+
+    monkeypatch.setattr(verify_source, "urlopen", refuse)
+    monkeypatch.setattr("sys.argv", ["verify", str(recipe_path), "--cache-dir", str(cache)])
+    verify_source.main()
+
+
+def test_verify_miss_downloads_and_populates_cache(tmp_path, monkeypatch):
+    recipe_path, _ = make_recipe(tmp_path)
+    cache = tmp_path / "cache"
+
+    class Response:
+        def read(self):
+            return PAYLOAD
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    monkeypatch.setattr(verify_source, "urlopen", lambda request: Response())
+    monkeypatch.setattr("sys.argv", ["verify", str(recipe_path), "--cache-dir", str(cache)])
+    verify_source.main()
+    assert tideforge_cache.lookup(cache, DIGEST) == PAYLOAD


### PR DESCRIPTION
## Design note

**What is cached (this PR: the source layer only).** Every upstream source archive a Tideforge job downloads, stored content-addressed at `~/.cache/tideforge/sources/<sha256>` and persisted per recipe via `actions/cache`.

**The key.** `tideforge-src-v1-<sha256 over the recipe's sorted source digests>` (computed by `scripts/tideforge_cache.py key <recipe>`). It hashes *only* the pinned `sha256` values — no branch, no run number, no date, no target — so:

- it is **identical on el10, Fedora, Debian, Ubuntu and Arch**: one save serves every target and both Tideforge workflows;
- it changes **exactly** when a source pin changes, and never otherwise (spec tweaks don't churn it; source-list reordering doesn't either).

**Why a hit is correct.** The pinned checksum is both the lookup key and the integrity proof. Every blob read from the store is re-hashed against the recipe's pin before use; a corrupted or tampered entry hashes wrong, is deleted, and reads as a miss. A hit is therefore *provably* the same bytes the existing checksum check would have accepted from the network. Nothing downstream is skipped: render, builddep, build, lint, clean-install and smoke all still run — this caches bytes, not results.

**What happens on miss.** The normal, silent path: download, verify sha256, write to the store, proceed. A cold cache is byte-for-byte the pre-PR behavior plus a local write. Cache save conflicts between same-key jobs are actions/cache warnings, never failures. Every source logs `source cache hit:` / `source cache miss, downloaded:` so hit rate is grep-able per job.

**Scope population.** PR branches read main's cache scope but cannot write it, so a new workflow (`seed-tideforge-source-cache.yml`, push-to-main on `packages/**` + dispatch) populates one entry per recipe. Re-runs are idempotent: a restore-hit means zero downloads and a skipped save. Until it runs on main, a PR's first gate run is cold and populates its own scope; re-runs and later pushes hit.

**Mechanics.** A composite action (`.github/actions/tideforge-source-cache`) computes the key and restores; jobs gain one step plus `--cache-dir` on the existing `verify-tideforge-source.py` / `fetch-tideforge-sources.py` calls. Both scripts consult the store before the network (additive flag, default off). This also removes a hidden 2× cost: verify previously streamed the full archive and fetch downloaded it *again* — with the store, verify's download is reused by fetch, so even a fully cold job downloads each source once instead of twice.

Drive-by within cache scope: the four inline `urlretrieve` heredocs (cpptrace, quickshell, niri, iio-niri) are replaced with `fetch-tideforge-sources.py`. All four recipes are single-source with no custom `filename`, so this is behavior-identical — except the download is now checksum-verified, which the inline copies never did.

**Not in this PR (follow-ups, in the brief's priority order):** ORAS/ghcr.io fallback for evicted entries, cargo/go dependency caches, per-target builddep caches, built-artifact reuse. Landing one proven layer first, per the brief.

**Contention.** Touches `build-tideforge-supported.yml` only in step bodies (one inserted step per job + flags), not the matrix `include:` lists or gate paths that #145/#142/#149/#146 are editing — rebase surface is minimal, and this should land **after** those settle. No use of upload/download-artifact, so #155 is orthogonal.

**~10 GB budget & eviction.** One entry per recipe (43 recipes), each holding just that recipe's archives — well under the limit; 7-day-idle eviction is refilled by the next seed run or cold gate run, silently.

## Measurement

Baseline (run 30609929996, last green gate): 54 render+fetch steps totalling ~142 s, and every job downloads each of its sources **twice** (verify, then fetch). Per-tarball across targets: e.g. the `dms` archive is fetched 6× per run (el10 payload 2×, ubuntu deb 2×, debian deb 2×).

**Measured** (see comment below for full tables): warm run = **0 upstream downloads** (was ~150 per run), cold run = 50; arch 9/9 from cache warm; render+fetch step time 142 s → 37 s; 37 entries, ~1.04 GB cached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->
