### PR TITLE
feat(tideforge): let recipes declare how they prove themselves installed

### DIFF
--- a/packages/_template/package.yaml
+++ b/packages/_template/package.yaml
@@ -35,4 +35,26 @@ dependencies:
 files:
   common:
     - usr/bin/example-tool
+# How the gate proves this package actually installed and works. These used to
+# be hand-written matrix keys in build-tideforge-supported.yml, which is how a
+# target could be declared with no cell asserting it at all (#139) -- nothing
+# connected the recipe to the job. State it here and the cell follows the
+# recipe instead of being remembered separately.
+#
+# `smoke` runs inside a clean container after the built package is installed
+# from an ephemeral repository. It must fail loudly if the package is broken;
+# prefer asserting a real behaviour over the file merely existing.
+verify:
+  smoke: example-tool --version
+  # Defaults to the recipe name. Set it when the installable binary package is
+  # named differently -- libseat builds `libseat-devel`, gtk-layer-shell builds
+  # `gtk-layer-shell-devel`.
+  # install_name: example-tool-devel
+  #
+  # Override per target only where the rendered binary package genuinely
+  # differs. xfconf is the worked example: `xfconf` on el10, `libxfconf-0-4` on
+  # the deb targets. Every other package today is identical across targets.
+  # targets:
+  #   ubuntu:
+  #     install_name: libexample-tool0
 targets: [el10, ubuntu, debian]

--- a/packages/bazaar/package.yaml
+++ b/packages/bazaar/package.yaml
@@ -34,4 +34,6 @@ files:
     - usr/lib*/systemd/user/io.github.kolunmi.Bazaar.service
     - usr/share/dbus-1/services/io.github.kolunmi.Bazaar.service
     - usr/share/gnome-shell/search-providers/io.github.kolunmi.Bazaar.search-provider.ini
+verify:
+  smoke: "test -x /usr/bin/bazaar && test -x /usr/bin/bazaar-dl-worker && test -x /usr/bin/bazaar-refresh-worker"
 targets: [ubuntu, debian, arch]

--- a/packages/cli11-devel/package.yaml
+++ b/packages/cli11-devel/package.yaml
@@ -33,4 +33,6 @@ outputs:
         summary: Header-only C++ command-line parser development files
         description: CMake package metadata and headers for CLI11.
         files: [usr/include/CLI, usr/share/cmake/CLI11, usr/share/pkgconfig/CLI11.pc]
+verify:
+  smoke: test -f /usr/include/CLI/CLI.hpp
 targets: [el10, ubuntu, debian, opensuse-tumbleweed, arch]

--- a/packages/dankcalendar/package.yaml
+++ b/packages/dankcalendar/package.yaml
@@ -42,4 +42,6 @@ install:
     - {source: assets/com.danklinux.dankcalendar.desktop, destination: usr/share/applications/com.danklinux.dankcalendar.desktop}
     - {source: assets/com.danklinux.dankcalendar.svg, destination: usr/share/icons/hicolor/scalable/apps/com.danklinux.dankcalendar.svg}
     - {source: assets/com.danklinux.dankcalendar.metainfo.xml, destination: usr/share/metainfo/com.danklinux.dankcalendar.metainfo.xml}
+verify:
+  smoke: "test -x /usr/bin/dcal && test -f /usr/lib/systemd/user/dcal.service"
 targets: [arch]

--- a/packages/danksearch/package.yaml
+++ b/packages/danksearch/package.yaml
@@ -18,4 +18,6 @@ dependencies:
     capabilities: [go]
 files:
   common: [usr/bin/dsearch]
+verify:
+  smoke: dsearch --help
 targets: [el10, ubuntu, debian, opensuse-tumbleweed, arch]

--- a/packages/dgop/package.yaml
+++ b/packages/dgop/package.yaml
@@ -18,4 +18,6 @@ dependencies:
     capabilities: [go]
 files:
   common: [usr/bin/dgop]
+verify:
+  smoke: dgop --help
 targets: [el10, ubuntu, debian, opensuse-tumbleweed, arch]

--- a/packages/greetd/package.yaml
+++ b/packages/greetd/package.yaml
@@ -25,4 +25,6 @@ files:
 install:
   files:
     - {source: greetd.service, destination: usr/lib/systemd/system/greetd.service}
+verify:
+  smoke: greetd --help
 targets: [el10, ubuntu, debian, opensuse-tumbleweed, arch]

--- a/packages/gtk-layer-shell/package.yaml
+++ b/packages/gtk-layer-shell/package.yaml
@@ -19,6 +19,9 @@ dependencies:
       el10: [gcc, gtk3-devel, wayland-devel, wayland-protocols-devel, gobject-introspection-devel, vala]
 files:
   common: [usr/lib64/libgtk-layer-shell.so.*]
+verify:
+  smoke: "pkg-config --modversion gtk-layer-shell-0 && test -f /usr/include/gtk-layer-shell/gtk-layer-shell.h"
+  install_name: gtk-layer-shell-devel
 targets: [el10]
 outputs:
   rpm:

--- a/packages/kairpods/package.yaml
+++ b/packages/kairpods/package.yaml
@@ -32,4 +32,6 @@ install:
   directories:
     - source: plasmoid
       destination: usr/share/plasma/plasmoids/org.kairpods.plasma
+verify:
+  smoke: "test -x /usr/bin/kairpodsd && test -f /usr/lib/systemd/user/kairpodsd.service"
 targets: [el10, ubuntu, debian, opensuse-tumbleweed, arch]

--- a/packages/krunner-bazaar/package.yaml
+++ b/packages/krunner-bazaar/package.yaml
@@ -28,4 +28,6 @@ files:
     - usr/bin/bazaar-dbus-tool
     - usr/lib*/qt6/plugins/kf6/krunner/bazaarrunner.so
     - usr/share/locale/*/LC_MESSAGES/plasma_runner_bazaarrunner.mo
+verify:
+  smoke: test -x /usr/bin/bazaar-dbus-tool
 targets: [el10, ubuntu, debian, opensuse-tumbleweed, arch]

--- a/packages/labwc/package.yaml
+++ b/packages/labwc/package.yaml
@@ -101,4 +101,6 @@ files:
 # Debian, Arch and openSUSE; labwc is already packaged natively on most of
 # those, so this recipe exists to fill the EL10 hole rather than to replace
 # a distribution's own package.
+verify:
+  smoke: labwc --help
 targets: [el10]

--- a/packages/libseat/package.yaml
+++ b/packages/libseat/package.yaml
@@ -44,4 +44,7 @@ outputs:
         description: Headers and pkg-config metadata for building against libseat.
         depends: ["libseat1 (= ${binary:Version})"]
         files: [usr/include/libseat.h, usr/lib/*/libseat.so, usr/lib/*/pkgconfig/libseat.pc]
+verify:
+  smoke: "pkg-config --modversion libseat && seatd -h"
+  install_name: libseat-devel
 targets: [el10, ubuntu, debian, opensuse-tumbleweed, arch]

--- a/packages/libunwind-devel/package.yaml
+++ b/packages/libunwind-devel/package.yaml
@@ -32,4 +32,6 @@ outputs:
         summary: Portable stack-unwinding library development files
         description: Headers and shared libraries for libunwind.
         files: [usr/include/libunwind*.h, usr/include/unwind.h, usr/lib/*/libunwind*.so*, usr/lib/*/libunwind*.a, usr/lib/*/pkgconfig/libunwind*.pc]
+verify:
+  smoke: "test -f /usr/include/libunwind.h && test -f /usr/include/unwind.h"
 targets: [el10, ubuntu, debian, opensuse-tumbleweed, arch]

--- a/packages/ninja-build/package.yaml
+++ b/packages/ninja-build/package.yaml
@@ -23,4 +23,6 @@ dependencies:
       arch: [cmake, gcc]
 files:
   common: [usr/bin/ninja]
+verify:
+  smoke: ninja --version
 targets: [el10, ubuntu, debian, opensuse-tumbleweed, arch]

--- a/packages/niri/package.yaml
+++ b/packages/niri/package.yaml
@@ -47,4 +47,6 @@ files:
     - usr/share/xdg-desktop-portal/niri-portals.conf
     - usr/lib/systemd/user/niri.service
     - usr/lib/systemd/user/niri-shutdown.target
+verify:
+  smoke: niri --help
 targets: [el10, ubuntu, debian, opensuse-tumbleweed, arch]

--- a/packages/oversteer-udev/package.yaml
+++ b/packages/oversteer-udev/package.yaml
@@ -15,4 +15,6 @@ files:
 install:
   directories:
     - {source: data/udev, destination: usr/lib/udev/rules.d}
+verify:
+  smoke: "test -f /usr/lib/udev/rules.d/99-logitech-wheel-perms.rules && test -f /usr/lib/udev/rules.d/99-fanatec-wheel-perms.rules && test -f /usr/lib/udev/rules.d/99-thrustmaster-wheel-perms.rules"
 targets: [el10, ubuntu, debian, opensuse-tumbleweed, arch]

--- a/packages/plasma-setup/package.yaml
+++ b/packages/plasma-setup/package.yaml
@@ -40,4 +40,6 @@ files:
     - usr/share/plasma-setup/plasma-setup.desktop
     - usr/share/plasma-setup/kglobalaccelrc
     - etc/xdg/plasmasetuprc
+verify:
+  smoke: "test -e /usr/lib/plasma-setup && test -f /usr/lib/systemd/system/plasma-setup.service"
 targets: [arch]

--- a/packages/uupd/package.yaml
+++ b/packages/uupd/package.yaml
@@ -20,4 +20,6 @@ install:
     - {source: uupd.service, destination: usr/lib/systemd/system/uupd.service}
     - {source: uupd-manual.service, destination: usr/lib/systemd/system/uupd-manual.service}
     - {source: uupd.rules, destination: usr/lib/udev/rules.d/uupd.rules}
+verify:
+  smoke: uupd --help
 targets: [el10, ubuntu, debian, opensuse-tumbleweed, arch]

--- a/packages/wayland-protocols/package.yaml
+++ b/packages/wayland-protocols/package.yaml
@@ -39,4 +39,6 @@ outputs:
         summary: Wayland protocol definitions
         description: Current Wayland protocol XML definitions.
         files: [usr/share/wayland-protocols, usr/share/pkgconfig/wayland-protocols.pc]
+verify:
+  smoke: "pkg-config --atleast-version=1.41 wayland-protocols && test -f /usr/share/wayland-protocols/staging/ext-session-lock/ext-session-lock-v1.xml"
 targets: [el10, ubuntu, debian, opensuse-tumbleweed, arch]

--- a/packages/xfconf/package.yaml
+++ b/packages/xfconf/package.yaml
@@ -19,6 +19,14 @@ dependencies:
       debian: [debhelper-compat, libglib2.0-dev, libdbus-1-dev, libxfce4util-dev, gobject-introspection, libgirepository1.0-dev]
 files:
   common: [usr/bin/xfconf-query]
+verify:
+  smoke: xfconf-query --version
+  install_name: xfconf
+  targets:
+    debian:
+      install_name: libxfconf-0-4
+    ubuntu:
+      install_name: libxfconf-0-4
 targets: [el10, ubuntu, debian]
 outputs:
   rpm:

--- a/scripts/tideforge.py
+++ b/scripts/tideforge.py
@@ -378,6 +378,65 @@ def validate_deb_packages(recipe: dict) -> None:
             )
 
 
+def verify_metadata(recipe: dict, target: str) -> dict[str, str]:
+    """Return how this recipe proves itself installed, for one target.
+
+    The gate used to carry `smoke` and `install_name` as hand-written matrix
+    keys, which is why a recipe could declare a target that no cell ever built
+    (#139): nothing tied the two together. A recipe now states how to verify
+    itself, so the cell can be derived rather than remembered.
+
+    `install_name` defaults to the recipe name. A target may override it where
+    the rendered binary package genuinely differs -- xfconf produces `xfconf`
+    on el10 and `libxfconf-0-4` on ubuntu and debian.
+    """
+    block = recipe.get("verify") or {}
+    resolved = {
+        "smoke": block.get("smoke"),
+        "install_name": block.get("install_name", recipe["name"]),
+    }
+    resolved.update(
+        {
+            key: value
+            for key, value in (block.get("targets") or {}).get(target, {}).items()
+            if key in {"smoke", "install_name"}
+        }
+    )
+    return resolved
+
+
+def validate_verify(recipe: dict) -> None:
+    """Schema-check the `verify` block.
+
+    Nothing rejected unknown top-level keys, so a mistyped block would simply
+    be ignored -- a silently absent assertion, which is the same defect class
+    #139 was about. Check it explicitly instead.
+    """
+    block = recipe.get("verify")
+    if block is None:
+        return
+    if not isinstance(block, dict):
+        fail("verify must be a mapping")
+    unknown = set(block) - {"smoke", "install_name", "targets"}
+    if unknown:
+        fail(f"unknown verify key(s): {sorted(unknown)}")
+    if not isinstance(block.get("smoke", ""), str) or not block.get("smoke", "").strip():
+        fail("verify.smoke must be a non-empty string")
+    if "install_name" in block and not isinstance(block["install_name"], str):
+        fail("verify.install_name must be a string")
+    overrides = block.get("targets", {})
+    if not isinstance(overrides, dict):
+        fail("verify.targets must be a mapping of target to overrides")
+    for name, override in overrides.items():
+        if name not in recipe["targets"]:
+            fail(f"verify.targets names {name!r}, which the recipe does not enable")
+        if not isinstance(override, dict):
+            fail(f"verify.targets.{name} must be a mapping")
+        unknown = set(override) - {"smoke", "install_name"}
+        if unknown:
+            fail(f"unknown verify.targets.{name} key(s): {sorted(unknown)}")
+
+
 def validate(recipe: dict, target: str | None = None) -> None:
     if recipe.get("schema") != 1:
         fail("schema must be 1")
@@ -408,6 +467,7 @@ def validate(recipe: dict, target: str | None = None) -> None:
         cargo_config_commands(recipe)
     prepare_commands(recipe)
     build_environment(recipe)
+    validate_verify(recipe)
     debug_package_enabled(recipe)
     autoreconf_enabled(recipe)
     configure_options(recipe)

--- a/tests/test_gate_verify_consistency.py
+++ b/tests/test_gate_verify_consistency.py
@@ -1,0 +1,127 @@
+"""Cross-check the gate's hand-written verification against the recipes.
+
+Every gate cell today carries `smoke` and `install_name` as matrix keys. The
+recipes now carry the same values in a `verify:` block. Until the gate is
+switched over to read them, the two must agree exactly -- otherwise the
+switchover would silently change what is asserted, which is the failure mode
+this whole line of work exists to prevent (#139).
+
+These tests are what make the switchover a pure deletion: when the matrix keys
+go away, this file proves nothing was lost in the move.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("tideforge", ROOT / "scripts" / "tideforge.py")
+assert SPEC and SPEC.loader
+tideforge = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(tideforge)
+
+GATES = [
+    ROOT / ".github" / "workflows" / "build-tideforge-supported.yml",
+    ROOT / ".github" / "workflows" / "build-tideforge-arch.yml",
+]
+
+
+def gate_cells() -> list[dict]:
+    """Every matrix cell that asserts something, with the target it asserts on."""
+    cells = []
+    for gate in GATES:
+        workflow = yaml.safe_load(gate.read_text())
+        for job_name, job in workflow["jobs"].items():
+            for cell in job.get("strategy", {}).get("matrix", {}).get("include", []):
+                if "smoke" not in cell and "install_name" not in cell:
+                    continue
+                # The Arch gate has one target by construction; the openSUSE job
+                # pins its target in the step body rather than the matrix.
+                target = cell.get("target")
+                if target is None:
+                    target = "opensuse-tumbleweed" if "opensuse" in job_name else "arch"
+                cells.append({**cell, "target": target, "job": job_name})
+    return cells
+
+
+def recipe_for(package: str) -> dict:
+    return yaml.safe_load((ROOT / "packages" / package / "package.yaml").read_text())
+
+
+CELLS = gate_cells()
+
+
+def test_the_gate_actually_has_cells() -> None:
+    """A zero-length cell list would make every test below vacuously pass."""
+    assert len(CELLS) >= 39
+
+
+@pytest.mark.parametrize("cell", CELLS, ids=lambda c: f"{c['package']}-{c['target']}")
+def test_every_gate_cell_matches_its_recipe(cell: dict) -> None:
+    recipe = recipe_for(cell["package"])
+    resolved = tideforge.verify_metadata(recipe, cell["target"])
+
+    if "smoke" in cell:
+        assert resolved["smoke"] == cell["smoke"], (
+            f"{cell['package']} ({cell['target']}): recipe verify.smoke differs from "
+            "the gate cell. Switching the gate over would change what is asserted."
+        )
+    if "install_name" in cell:
+        assert resolved["install_name"] == cell["install_name"], (
+            f"{cell['package']} ({cell['target']}): recipe verify.install_name differs "
+            "from the gate cell."
+        )
+
+
+@pytest.mark.parametrize("cell", CELLS, ids=lambda c: f"{c['package']}-{c['target']}")
+def test_every_gate_cell_has_a_recipe_verify_block(cell: dict) -> None:
+    recipe = recipe_for(cell["package"])
+    assert recipe.get("verify"), (
+        f"{cell['package']} is exercised by the gate but its recipe has no verify: "
+        "block, so the cell could not be derived from the recipe."
+    )
+
+
+def test_xfconf_keeps_its_per_target_install_name() -> None:
+    """The one genuine divergence, asserted by name so it cannot be flattened.
+
+    xfconf renders as `xfconf` on el10 and `libxfconf-0-4` on the deb targets.
+    A refactor that collapsed install_name to a single value would still pass
+    every other test here, because xfconf is the only package that differs.
+    """
+    recipe = recipe_for("xfconf")
+    assert tideforge.verify_metadata(recipe, "el10")["install_name"] == "xfconf"
+    assert tideforge.verify_metadata(recipe, "ubuntu")["install_name"] == "libxfconf-0-4"
+    assert tideforge.verify_metadata(recipe, "debian")["install_name"] == "libxfconf-0-4"
+
+
+def test_install_name_defaults_to_the_recipe_name() -> None:
+    assert tideforge.verify_metadata({"name": "dgop", "verify": {"smoke": "x"}}, "el10")[
+        "install_name"
+    ] == "dgop"
+
+
+def test_validate_rejects_a_mistyped_verify_block() -> None:
+    """A silently-ignored typo is the same defect class as a missing cell."""
+    recipe = {"name": "x", "targets": ["el10"], "verify": {"smoke": "y", "smoek": "z"}}
+    with pytest.raises(SystemExit):
+        tideforge.validate_verify(recipe)
+
+
+def test_validate_rejects_an_override_for_an_unenabled_target() -> None:
+    recipe = {
+        "name": "x",
+        "targets": ["el10"],
+        "verify": {"smoke": "y", "targets": {"ubuntu": {"install_name": "z"}}},
+    }
+    with pytest.raises(SystemExit):
+        tideforge.validate_verify(recipe)
+
+
+def test_validate_rejects_an_empty_smoke() -> None:
+    with pytest.raises(SystemExit):
+        tideforge.validate_verify({"name": "x", "targets": ["el10"], "verify": {"smoke": "  "}})


### PR DESCRIPTION
Step one of the structural half of #139. **Touches no workflow file** — see *Why no gate change* below.

## The problem

Every gate cell carries `smoke` and `install_name` as hand-written matrix keys. Nothing ties them to the recipe. That disconnect is precisely why openSUSE could be declared by 19 recipes and built by zero cells (#139): the recipe said what it wanted, the workflow said what ran, and the two were maintained separately by hand.

## What this adds

A `verify:` block in the recipe, stating the smoke command and — only where it differs from the recipe name — the installable binary package name:

```yaml
verify:
  smoke: dgop --help
```

```yaml
verify:
  smoke: xfconf-query --version
  install_name: xfconf
  targets:
    debian: {install_name: libxfconf-0-4}
    ubuntu: {install_name: libxfconf-0-4}
```

**`xfconf` is the only genuine divergence across all 19 packages.** Four others (`dgop`, `danksearch`, `kairpods`, `oversteer-udev`) look divergent only because the Arch job carries no `install_name` at all — a different install mechanism, not a different name. Their smoke commands are byte-identical everywhere.

## Why no gate change

#142, #145 and #149 are rebasing onto the gate files right now. Rewriting the `include:` lists underneath them would make all three re-conflict for no benefit. This PR adds only the recipe side, so it merges cleanly alongside them. Switching the gate over to *read* these values is a separate change that can wait for a quiet file.

## What makes the switchover safe rather than hopeful

`tests/test_gate_verify_consistency.py` cross-checks **all 39 gate cells** against the recipes and fails on any mismatch — so the values are proven byte-identical *before* anything depends on them. When the matrix keys are eventually deleted, that file is the evidence nothing was lost in the move. It also guards the two things a careless refactor would break:

- `test_xfconf_keeps_its_per_target_install_name` — the one real divergence, asserted by name so it cannot be flattened. Every other test would still pass if it were.
- `test_the_gate_actually_has_cells` — a zero-length cell list would make every parametrised test vacuously pass. A silent linter is not a gate; nor is a silent test.

## Schema validation

`validate` gains a real check for the block. Nothing rejected unknown top-level keys, so a mistyped `verify:` would have been **silently ignored** — a quietly absent assertion, the same defect class as a target with no cells. Rejected now: unknown keys, empty smoke, non-string values, and overrides naming a target the recipe does not enable.

## Verified locally

- 213 tests pass (84 new)
- every recipe validates, and renders for every target it declares — the same loop CI runs
- `validate-package-factory.py`: manifest valid, all 5 declared targets exercised
- yamllint clean
- **0 workflow files touched**

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->