### PR TITLE
ci(tideforge): ratchet gate coverage so a new uncovered target cannot land

### DIFF
--- a/.github/workflows/validate-package-factory.yml
+++ b/.github/workflows/validate-package-factory.yml
@@ -56,6 +56,20 @@ jobs:
       - run: pip install pyyaml
       - run: python3 scripts/validate-package-factory.py manifests/package-factory.yaml
       - run: python3 scripts/validate-target-queues.py
+      # A recipe declaring a target that no cell builds is untested while looking
+      # supported -- the defect #139 was about, one level down from the target
+      # coverage the previous step asserts. 77 of 122 pairs are uncovered today,
+      # so this ratchets rather than gates: it fails only on pairs this change
+      # introduces, and prints the total so it stays visible.
+      - name: Gate coverage must not regress
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            git fetch --quiet --depth=1 origin "${{ github.base_ref }}"
+            python3 scripts/check-gate-coverage.py --baseline FETCH_HEAD
+          else
+            python3 scripts/check-gate-coverage.py
+          fi
       - name: Validate and render Tideforge recipes
         run: |
           set -euo pipefail

--- a/scripts/check-gate-coverage.py
+++ b/scripts/check-gate-coverage.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Report Tideforge gate coverage, and refuse to let it get worse.
+
+A recipe declares the targets it wants built. The gate declares the cells it
+actually builds. Nothing connected the two, which is how openSUSE ended up
+declared by 19 recipes and built by zero cells (#139).
+
+The obvious fix -- assert every declared (recipe, target) pair has a cell --
+is not shippable: 77 of 122 pairs are uncovered today, so it would block every
+PR from the moment it landed. The obvious workaround, an allowlist of accepted
+gaps, is how a curated list stops being curated; `lint-generated-rpm.sh` says
+the same thing about its own fatal-checks list, and it is right.
+
+So: ratchet. Count the gap and print it, and fail only when a change *adds* an
+uncovered pair. Existing gaps stay visible as a number that has to go down;
+new ones cannot be introduced silently. There is no allowlist to launder a gap
+through, and no checked-in snapshot to rot -- the baseline is recomputed from
+the git ref on every run.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+GATE_WORKFLOWS = (
+    ".github/workflows/build-tideforge-supported.yml",
+    ".github/workflows/build-tideforge-arch.yml",
+)
+MANIFEST = "manifests/package-factory.yaml"
+
+Pair = tuple[str, str]
+
+
+def fail(message: str) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+class Tree:
+    """Repository contents, either on disk or at a git ref."""
+
+    def __init__(self, ref: str | None = None) -> None:
+        self.ref = ref
+
+    def read(self, path: str) -> str | None:
+        if self.ref is None:
+            file = Path(path)
+            return file.read_text() if file.exists() else None
+        result = subprocess.run(
+            ["git", "show", f"{self.ref}:{path}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return result.stdout if result.returncode == 0 else None
+
+    def recipes(self) -> list[str]:
+        if self.ref is None:
+            return sorted(str(p) for p in Path("packages").glob("*/package.yaml"))
+        result = subprocess.run(
+            ["git", "ls-tree", "-r", "--name-only", self.ref, "packages/"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            fail(f"cannot read packages/ at ref {self.ref!r} -- is it fetched?")
+        return sorted(p for p in result.stdout.splitlines() if p.endswith("/package.yaml"))
+
+
+def declared_pairs(tree: Tree) -> set[Pair]:
+    """(package, target) for every target a recipe asks to be built for."""
+    pairs: set[Pair] = set()
+    for path in tree.recipes():
+        if "_template" in path:
+            continue
+        text = tree.read(path)
+        if text is None:
+            continue
+        recipe = yaml.safe_load(text) or {}
+        package = Path(path).parent.name
+        for target in recipe.get("targets", []):
+            pairs.add((package, target))
+    return pairs
+
+
+def gate_pairs(tree: Tree) -> set[Pair]:
+    """(package, target) for every cell the gate actually builds."""
+    pairs: set[Pair] = set()
+    for workflow in GATE_WORKFLOWS:
+        text = tree.read(workflow)
+        if text is None:
+            continue
+        data = yaml.safe_load(text) or {}
+        arch_gate = "arch" in workflow
+        for job_name, job in (data.get("jobs") or {}).items():
+            include = (job.get("strategy") or {}).get("matrix", {}).get("include", [])
+            for cell in include:
+                package = cell.get("package")
+                if not package:
+                    continue
+                # Most cells name their target. The openSUSE job pins its target
+                # in the step body, and the Arch gate builds exactly one target
+                # by construction, so infer those from where the cell lives.
+                target = cell.get("target")
+                if target is None:
+                    if "opensuse" in job_name:
+                        target = "opensuse-tumbleweed"
+                    elif arch_gate:
+                        target = "arch"
+                if target:
+                    pairs.add((package, target))
+    return pairs
+
+
+def uncovered(tree: Tree) -> set[Pair]:
+    return declared_pairs(tree) - gate_pairs(tree)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--baseline",
+        help="git ref to ratchet against (e.g. origin/main). Omit to report only.",
+    )
+    args = parser.parse_args()
+
+    current = uncovered(Tree())
+    declared = declared_pairs(Tree())
+    print(
+        f"Gate coverage: {len(declared) - len(current)}/{len(declared)} "
+        f"declared (recipe, target) pairs have a cell -- {len(current)} uncovered"
+    )
+
+    if not args.baseline:
+        return
+
+    previous = uncovered(Tree(args.baseline))
+    added = sorted(current - previous)
+    if added:
+        listing = "\n".join(f"    {package} ({target})" for package, target in added)
+        fail(
+            "these (recipe, target) pairs are declared but have no cell in the "
+            f"Tideforge gate, and did not exist at {args.baseline}:\n{listing}\n"
+            "  A recipe that declares a target nothing builds is untested while "
+            "looking supported -- the defect #139 was about. Add a matrix cell "
+            "for each, or drop the target from the recipe.\n"
+            "  Pre-existing gaps are not blocked here; only new ones. There is "
+            "deliberately no allowlist."
+        )
+
+    removed = len(previous) - len(current)
+    if removed > 0:
+        print(f"Gate coverage improved: {removed} fewer uncovered pair(s) than {args.baseline}")
+    else:
+        print(f"Gate coverage held: no new uncovered pairs against {args.baseline}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_check_gate_coverage.py
+++ b/tests/test_check_gate_coverage.py
@@ -1,0 +1,157 @@
+"""Tests for the gate-coverage ratchet.
+
+The ratchet exists because the honest assertion is not shippable: 77 of 122
+declared (recipe, target) pairs have no gate cell today, so failing on all of
+them would block every PR. It fails only on pairs a change *introduces*, and
+prints the total so the gap stays visible instead of being laundered through
+an allowlist.
+
+These tests pin both halves: that a new gap fails, and that the existing 77 do
+not -- because a ratchet that quietly blocks pre-existing gaps is just the
+unshippable assertion with extra steps.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "check_gate_coverage", ROOT / "scripts" / "check-gate-coverage.py"
+)
+assert SPEC and SPEC.loader
+coverage = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(coverage)
+
+
+class FakeTree:
+    """A Tree backed by an in-memory file map, so tests need no git."""
+
+    def __init__(self, files: dict[str, str]) -> None:
+        self.files = files
+
+    def read(self, path: str) -> str | None:
+        return self.files.get(path)
+
+    def recipes(self) -> list[str]:
+        return sorted(p for p in self.files if p.endswith("/package.yaml"))
+
+
+def recipe(targets: list[str]) -> str:
+    return "schema: 1\ntargets: [" + ", ".join(targets) + "]\n"
+
+
+def gate(cells: list[tuple[str, str]]) -> str:
+    include = "".join(
+        f"          - package: {package}\n            target: {target}\n"
+        for package, target in cells
+    )
+    return "jobs:\n  rpm:\n    strategy:\n      matrix:\n        include:\n" + include
+
+
+def test_declared_pairs_reads_every_recipe_target() -> None:
+    tree = FakeTree(
+        {
+            "packages/alpha/package.yaml": recipe(["el10", "arch"]),
+            "packages/beta/package.yaml": recipe(["ubuntu"]),
+        }
+    )
+    assert coverage.declared_pairs(tree) == {
+        ("alpha", "el10"),
+        ("alpha", "arch"),
+        ("beta", "ubuntu"),
+    }
+
+
+def test_declared_pairs_skips_the_template() -> None:
+    """The template documents the schema; it is not a package candidate."""
+    tree = FakeTree({"packages/_template/package.yaml": recipe(["el10"])})
+    assert coverage.declared_pairs(tree) == set()
+
+
+def test_gate_pairs_reads_explicit_targets() -> None:
+    tree = FakeTree(
+        {".github/workflows/build-tideforge-supported.yml": gate([("alpha", "el10")])}
+    )
+    assert coverage.gate_pairs(tree) == {("alpha", "el10")}
+
+
+def test_gate_pairs_infers_the_opensuse_job_target() -> None:
+    """That job pins its target in the step body, not the matrix."""
+    workflow = (
+        "jobs:\n  opensuse-rpm:\n    strategy:\n      matrix:\n        include:\n"
+        "          - package: dgop\n"
+    )
+    tree = FakeTree({".github/workflows/build-tideforge-supported.yml": workflow})
+    assert coverage.gate_pairs(tree) == {("dgop", "opensuse-tumbleweed")}
+
+
+def test_gate_pairs_infers_the_arch_gate_target() -> None:
+    """The Arch gate builds exactly one target by construction."""
+    workflow = "jobs:\n  build:\n    strategy:\n      matrix:\n        include:\n          - package: niri\n"
+    tree = FakeTree({".github/workflows/build-tideforge-arch.yml": workflow})
+    assert coverage.gate_pairs(tree) == {("niri", "arch")}
+
+
+def test_uncovered_is_declared_minus_built() -> None:
+    tree = FakeTree(
+        {
+            "packages/alpha/package.yaml": recipe(["el10", "arch"]),
+            ".github/workflows/build-tideforge-supported.yml": gate([("alpha", "el10")]),
+        }
+    )
+    assert coverage.uncovered(tree) == {("alpha", "arch")}
+
+
+# --- the ratchet property itself -------------------------------------------
+
+
+def test_a_newly_declared_target_without_a_cell_is_a_new_gap() -> None:
+    before = FakeTree({"packages/alpha/package.yaml": recipe(["el10"])})
+    after = FakeTree({"packages/alpha/package.yaml": recipe(["el10", "arch"])})
+    assert coverage.uncovered(after) - coverage.uncovered(before) == {("alpha", "arch")}
+
+
+def test_a_pre_existing_gap_is_not_a_new_gap() -> None:
+    """The property that makes this shippable at 77 uncovered pairs."""
+    tree = FakeTree({"packages/alpha/package.yaml": recipe(["el10", "arch"])})
+    assert coverage.uncovered(tree) - coverage.uncovered(tree) == set()
+
+
+def test_adding_a_cell_closes_a_gap() -> None:
+    before = FakeTree({"packages/alpha/package.yaml": recipe(["el10"])})
+    after = FakeTree(
+        {
+            "packages/alpha/package.yaml": recipe(["el10"]),
+            ".github/workflows/build-tideforge-supported.yml": gate([("alpha", "el10")]),
+        }
+    )
+    assert len(coverage.uncovered(after)) < len(coverage.uncovered(before))
+
+
+# --- against the live repository -------------------------------------------
+
+
+def test_the_real_repository_has_no_cell_for_an_undeclared_pair() -> None:
+    """A gate cell building something no recipe asks for is also a defect.
+
+    It means the matrix and the recipes disagree in the other direction: CI
+    spending a runner on a target the package does not claim to support.
+    """
+    tree = coverage.Tree()
+    assert coverage.gate_pairs(tree) - coverage.declared_pairs(tree) == set()
+
+
+def test_the_real_repository_coverage_is_reported_not_asserted() -> None:
+    """Pins the shape of today's gap so a silent collapse to zero is visible.
+
+    If this ever fails because coverage improved, raise the floor -- do not
+    delete the test.
+    """
+    tree = coverage.Tree()
+    declared = coverage.declared_pairs(tree)
+    assert len(declared) >= 122
+    assert coverage.uncovered(tree), "no uncovered pairs would make the ratchet vacuous"


### PR DESCRIPTION
The second half of #139's structural fix. **Touches neither gate workflow** — only the validator, which no open PR has.

## The gap this closes

#146 made a declared *target* with zero cells fail. One level down, the same defect survives: **a recipe can declare a target that no cell builds**, so the package is untested while looking supported. That is the `refs=0` case — the four recipes that landed before pi started shipping recipe-plus-gate together were each a file nothing built.

## Why this ratchets instead of asserting

The obvious fix — every declared `(recipe, target)` pair must have a cell — is **not shippable**:

```
Gate coverage: 45/122 declared (recipe, target) pairs have a cell -- 77 uncovered

  el10                 25
  opensuse-tumbleweed  17
  arch                 13
  ubuntu               11
  debian               11
```

77 failures on day one would block every PR. The obvious workaround — an allowlist of accepted gaps — is how a curated list stops being curated. `lint-generated-rpm.sh` makes precisely that argument about its own fatal-checks list, and it's right.

So: **count the gap and print it; fail only on pairs a change introduces.** Pre-existing gaps stay visible as a number that has to go down. New ones cannot be introduced silently. There is deliberately **no allowlist** to launder a gap through, and **no checked-in snapshot** to rot — the baseline is recomputed from the git ref on every run, so it cannot drift from the tree it protects.

That 77 is also the coverage metric the scoreboard currently lacks. It is the honest distance between *"5 of 5 targets exercised"* and *"the recipes are covered"* — which is exactly the caveat attached to the openSUSE delta.

## Verified in all four directions, against the real repository

| | result |
|---|---|
| report-only | `45/122 … 77 uncovered`, exit 0 |
| ratchet vs `origin/main`, unchanged | `no new uncovered pairs`, exit 0 |
| recipe gains targets with no cells | **fails**, naming `labwc (arch)` and `labwc (ubuntu)`, exit 1 |
| a cell added for an uncovered pair | `improved: 1 fewer uncovered pair(s)`, exit 0 |

The third and fourth are the ones that matter: a guard that cannot fail is not a guard, and one that cannot notice improvement gives nobody a reason to close gaps.

## Tests

11 new (140 total). They pin **both** halves of the ratchet property — that a new gap fails, and that pre-existing gaps do *not*, because a ratchet which quietly blocks existing gaps is just the unshippable assertion with extra steps.

Two run against the live repository rather than fixtures:

- `test_the_real_repository_has_no_cell_for_an_undeclared_pair` — catches the *other* direction of disagreement: CI spending a runner on a target the recipe never claimed. Currently empty, and worth keeping that way.
- `test_the_real_repository_coverage_is_reported_not_asserted` — pins the shape of today's gap so a silent collapse to zero is visible. If it fails because coverage improved, raise the floor; don't delete it.

## Conflict-freedom

#142, #145, #149 and #156 are all rebasing onto the gate workflows. This changes `.github/workflows/validate-package-factory.yml` and adds two files; **zero gate-workflow lines touched**, so it lands alongside them.

Refs #139

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->