### PR TITLE
ci(lint): run the required checks on merge_group too

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,18 @@ on:
   #
   # push stays filtered: a push to main is already merged, so a missing check
   # there blocks nothing.
+  #
+  # merge_group is here for the same reason pull_request is unfiltered, and it
+  # is not optional once a merge queue exists. The queue builds a candidate
+  # branch and emits merge_group, then waits for main's required checks to
+  # report against it. A workflow that does not listen for merge_group never
+  # runs, the six checks never report, and every queued PR sits in
+  # AWAITING_CHECKS until the queue's 60-minute timeout ejects it — the same
+  # unmergeable-forever state described above, reached by a different route.
+  # Measured: enabling the queue with no merge_group trigger stalled the queue
+  # immediately and blocked all merges until the queue was disabled again.
   pull_request:
+  merge_group:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
## Why

main's six required status checks — YAML Lint, ShellCheck, Workflow Syntax Check, Build Order Schema Validation, BATS Unit Tests, Python Tests — all come from `lint.yml`. It listened for `pull_request` and `push` only.

A merge queue builds a candidate branch and emits `merge_group`, then waits for the required checks to report against *that* branch. With no `merge_group` trigger the workflow never runs, the checks never report, and every queued PR sits in `AWAITING_CHECKS` until the queue's 60-minute timeout ejects it.

This is the same failure this file's own header already warns about for path-filtered required checks — "the workflow never runs, the check never reports, and the PR is unmergeable forever" — reached by a different route.

## Measured, not theorised

A merge queue was enabled on this repo today to fix a separate automerge livelock. It stalled at the first PR (#154, `AWAITING_CHECKS` at position 1 for ~30 minutes with no runs dispatched) and blocked all merges until the queue was disabled again. #154 merged normally the moment it was.

## Sequencing

The queue ruleset is currently `enforcement: disabled` so merges work. This PR must land **before** it is re-enabled — with the queue active, this PR would itself be unmergeable, which is the deadlock the header describes.

1. land this
2. set the `main` ruleset back to `enforcement: active`
3. confirm one PR completes through the queue end to end

## Context

The original problem being solved: branch protection had `strict: true` (require up-to-date) with no queue, so PRs could never stay current long enough to merge — main moves faster than the checks take. `strict` is now `false`, which alone restores automerge; the queue adds back protection against two individually-green PRs breaking main together, which matters here because sessions concurrently edit the same gate workflow files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->