### PR TITLE
fix(tideforge): count the gate jobs the coverage check could not see

### DIFF
--- a/.github/workflows/validate-package-factory.yml
+++ b/.github/workflows/validate-package-factory.yml
@@ -58,7 +58,7 @@ jobs:
       - run: python3 scripts/validate-target-queues.py
       # A recipe declaring a target that no cell builds is untested while looking
       # supported -- the defect #139 was about, one level down from the target
-      # coverage the previous step asserts. 77 of 122 pairs are uncovered today,
+      # coverage the previous step asserts. 57 of 122 pairs are uncovered today,
       # so this ratchets rather than gates: it fails only on pairs this change
       # introduces, and prints the total so it stays visible.
       - name: Gate coverage must not regress

--- a/packages/cpptrace-devel/package.yaml
+++ b/packages/cpptrace-devel/package.yaml
@@ -32,4 +32,6 @@ outputs:
         summary: C++ stacktrace library development files
         description: C++ stacktrace library built with libunwind.
         files: [usr/include/cpptrace, usr/include/ctrace, usr/lib/*/libcpptrace.so*, usr/lib/*/cmake/cpptrace]
+verify:
+  smoke: "test -f /usr/include/cpptrace/cpptrace.hpp && test -f /usr/include/ctrace/ctrace.h"
 targets: [el10, ubuntu, debian, opensuse-tumbleweed, arch]

--- a/packages/dms-cli/package.yaml
+++ b/packages/dms-cli/package.yaml
@@ -21,4 +21,6 @@ dependencies:
     common: [dms, quickshell]
 files:
   common: [usr/bin/dms]
+verify:
+  smoke: "test -x /usr/bin/dms"
 targets: [el10, ubuntu, debian, opensuse-tumbleweed, arch]

--- a/packages/dms-greeter/package.yaml
+++ b/packages/dms-greeter/package.yaml
@@ -25,4 +25,6 @@ install:
     - {source: Modules/Greetd/assets/dms-greeter, destination: usr/bin/dms-greeter, mode: "0755"}
   directories:
     - {source: ., destination: usr/share/quickshell/dms-greeter}
+verify:
+  smoke: "test -x /usr/bin/dms-greeter"
 targets: [el10, ubuntu, debian, opensuse-tumbleweed, arch]

--- a/packages/dms/package.yaml
+++ b/packages/dms/package.yaml
@@ -21,4 +21,6 @@ install:
   files:
     - {source: systemd/sysusers-dms-greeter.conf, destination: usr/lib/sysusers.d/dms-greeter.conf}
     - {source: systemd/tmpfiles-dms-greeter.conf, destination: usr/lib/tmpfiles.d/dms-greeter.conf}
+verify:
+  smoke: "test -d /usr/share/dankmaterialshell"
 targets: [el10, ubuntu, debian, opensuse-tumbleweed, arch]

--- a/packages/gtkgreet/package.yaml
+++ b/packages/gtkgreet/package.yaml
@@ -27,4 +27,6 @@ files:
     - usr/bin/gtkgreet
     - usr/share/man/man1/gtkgreet.1*
     - usr/share/locale/*/LC_MESSAGES/gtkgreet.mo
+verify:
+  smoke: "gtkgreet --help"
 targets: [el10]

--- a/packages/iio-niri/package.yaml
+++ b/packages/iio-niri/package.yaml
@@ -29,4 +29,6 @@ dependencies:
     common: [niri, iio-sensor-proxy]
 files:
   common: [usr/bin/iio-niri]
+verify:
+  smoke: "iio-niri --help"
 targets: [el10, ubuntu, debian, opensuse-tumbleweed, arch]

--- a/packages/niri/package.yaml
+++ b/packages/niri/package.yaml
@@ -55,14 +55,19 @@ files:
     - usr/lib/systemd/user/niri.service
     - usr/lib/systemd/user/niri-shutdown.target
 verify:
-  smoke: niri --help
-  # The deb cells carry the same contract the niri-rpm job asserts by hand:
-  # compositor runs, session launcher, wayland-session entry, portal config,
-  # and both user units. Installing only the binary leaves display managers
-  # unable to discover a Niri session, which `niri --help` alone cannot catch.
+  # The full session contract, which is what the el10 niri-rpm job and the
+  # ubuntu and debian cells (#166) assert by hand: compositor runs, session
+  # launcher, wayland-session entry, portal config, and both user units.
+  # Installing only the binary leaves display managers unable to discover a
+  # Niri session, which `niri --help` alone cannot catch.
+  smoke: "niri --help && test -x /usr/bin/niri-session && test -f /usr/share/wayland-sessions/niri.desktop && test -f /usr/share/xdg-desktop-portal/niri-portals.conf && test -f /usr/lib/systemd/user/niri.service && test -f /usr/lib/systemd/user/niri-shutdown.target"
   targets:
-    ubuntu:
-      smoke: niri --help && test -x /usr/bin/niri-session && test -f /usr/share/wayland-sessions/niri.desktop && test -f /usr/share/xdg-desktop-portal/niri-portals.conf && test -f /usr/lib/systemd/user/niri.service && test -f /usr/lib/systemd/user/niri-shutdown.target
-    debian:
-      smoke: niri --help && test -x /usr/bin/niri-session && test -f /usr/share/wayland-sessions/niri.desktop && test -f /usr/share/xdg-desktop-portal/niri-portals.conf && test -f /usr/lib/systemd/user/niri.service && test -f /usr/lib/systemd/user/niri-shutdown.target
+    # The Arch cell asserts only that the binary runs, so it would pass with
+    # every session-integration file missing -- the same way flounder:niri
+    # shipped a compositor no display manager could discover. This records
+    # what that cell checks today rather than pretending it checks more; raise
+    # it to the full contract above when build-tideforge-arch.yml is free
+    # (it is held by #156 right now).
+    arch:
+      smoke: niri --help
 targets: [el10, ubuntu, debian, opensuse-tumbleweed, arch]

--- a/packages/quickshell/package.yaml
+++ b/packages/quickshell/package.yaml
@@ -33,4 +33,6 @@ files:
     - usr/bin/qs
     - usr/share/applications/org.quickshell.desktop
     - usr/share/icons/hicolor/scalable/apps/org.quickshell.svg
+verify:
+  smoke: "quickshell --help"
 targets: [el10, ubuntu, debian, opensuse-tumbleweed, arch]

--- a/scripts/check-gate-coverage.py
+++ b/scripts/check-gate-coverage.py
@@ -6,7 +6,7 @@ actually builds. Nothing connected the two, which is how openSUSE ended up
 declared by 19 recipes and built by zero cells (#139).
 
 The obvious fix -- assert every declared (recipe, target) pair has a cell --
-is not shippable: 77 of 122 pairs are uncovered today, so it would block every
+is not shippable: 55 of 122 pairs are uncovered today, so it would block every
 PR from the moment it landed. The obvious workaround, an allowlist of accepted
 gaps, is how a curated list stops being curated; `lint-generated-rpm.sh` says
 the same thing about its own fatal-checks list, and it is right.
@@ -20,6 +20,7 @@ the git ref on every run.
 from __future__ import annotations
 
 import argparse
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -88,8 +89,38 @@ def declared_pairs(tree: Tree) -> set[Pair]:
     return pairs
 
 
+RECIPE_REFERENCE = re.compile(r"packages/([a-z0-9][a-z0-9+._-]*)/package\.yaml")
+RENDER_TARGET = re.compile(r"--target\s+\"?([a-z0-9-]+)\b")
+
+
+def job_targets(job_text: str, job_name: str, *, arch_gate: bool) -> set[str]:
+    """Targets a job names literally, ignoring `${{ matrix.target }}`."""
+    targets = set(RENDER_TARGET.findall(job_text))
+    if not targets:
+        if arch_gate:
+            targets = {"arch"}
+        elif "opensuse" in job_name:
+            targets = {"opensuse-tumbleweed"}
+    return targets
+
+
 def gate_pairs(tree: Tree) -> set[Pair]:
-    """(package, target) for every cell the gate actually builds."""
+    """(package, target) for every cell the gate actually builds.
+
+    The gate uses three job shapes and every one of them is real coverage:
+
+      * `matrix.include` -- the common case, each cell naming its package and
+        usually its target
+      * `matrix.package` as a plain list -- rpm-payload, 15 cells
+      * no matrix at all -- the dedicated single-package jobs (niri-rpm,
+        quickshell-rpm, gtkgreet-rpm, cpptrace-rpm, iio-niri-rpm, dms-stack-rpm)
+
+    An earlier version of this function read only the first shape. It therefore
+    reported 20 covered pairs as uncovered, and -- worse -- would not have
+    noticed if a dedicated job were deleted, because it never counted that job
+    as coverage to begin with. `assert_every_job_understood` below exists so
+    that mistake cannot be repeated silently.
+    """
     pairs: set[Pair] = set()
     for workflow in GATE_WORKFLOWS:
         text = tree.read(workflow)
@@ -98,23 +129,66 @@ def gate_pairs(tree: Tree) -> set[Pair]:
         data = yaml.safe_load(text) or {}
         arch_gate = "arch" in workflow
         for job_name, job in (data.get("jobs") or {}).items():
-            include = (job.get("strategy") or {}).get("matrix", {}).get("include", [])
-            for cell in include:
-                package = cell.get("package")
-                if not package:
-                    continue
-                # Most cells name their target. The openSUSE job pins its target
-                # in the step body, and the Arch gate builds exactly one target
-                # by construction, so infer those from where the cell lives.
-                target = cell.get("target")
-                if target is None:
-                    if "opensuse" in job_name:
-                        target = "opensuse-tumbleweed"
-                    elif arch_gate:
-                        target = "arch"
-                if target:
-                    pairs.add((package, target))
+            body = yaml.safe_dump(job)
+            targets = job_targets(body, job_name, arch_gate=arch_gate)
+            matrix = (job.get("strategy") or {}).get("matrix") or {}
+
+            include = matrix.get("include") or []
+            if include:
+                for cell in include:
+                    package = cell.get("package")
+                    if not package:
+                        continue
+                    cell_targets = {cell["target"]} if cell.get("target") else targets
+                    pairs.update((package, target) for target in cell_targets)
+                continue
+
+            packages = matrix.get("package") or []
+            if packages:
+                pairs.update(
+                    (package, target) for package in packages for target in targets
+                )
+                continue
+
+            # Matrix-less dedicated job: the packages it builds are the recipes
+            # its steps render.
+            for package in set(RECIPE_REFERENCE.findall(body)):
+                pairs.update((package, target) for target in targets)
     return pairs
+
+
+def assert_every_job_understood(tree: Tree) -> None:
+    """Fail on a gate job this parser derives no coverage from.
+
+    A parser that finds nothing must not read as "there was nothing to find" --
+    the same rule lint-generated-rpm.sh applies to an empty rpmlint report. If
+    someone adds a fourth job shape, this fails loudly instead of quietly
+    undercounting coverage forever.
+    """
+    unparsed: list[str] = []
+    for workflow in GATE_WORKFLOWS:
+        text = tree.read(workflow)
+        if text is None:
+            continue
+        data = yaml.safe_load(text) or {}
+        arch_gate = "arch" in workflow
+        for job_name, job in (data.get("jobs") or {}).items():
+            body = yaml.safe_dump(job)
+            if not RECIPE_REFERENCE.search(body):
+                continue  # builds no package; nothing to account for
+            matrix = (job.get("strategy") or {}).get("matrix") or {}
+            derived = bool(matrix.get("include") or matrix.get("package")) or bool(
+                job_targets(body, job_name, arch_gate=arch_gate)
+            )
+            if not derived:
+                unparsed.append(f"{workflow}:{job_name}")
+    if unparsed:
+        fail(
+            "these gate jobs build packages but this script derives no coverage "
+            f"from them: {unparsed}. A job shape the parser does not understand "
+            "is counted as zero coverage, which reads identically to a real gap. "
+            "Teach gate_pairs() the shape rather than leaving it uncounted."
+        )
 
 
 def uncovered(tree: Tree) -> set[Pair]:
@@ -129,6 +203,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    assert_every_job_understood(Tree())
     current = uncovered(Tree())
     declared = declared_pairs(Tree())
     print(

--- a/scripts/check-gate-coverage.py
+++ b/scripts/check-gate-coverage.py
@@ -6,7 +6,7 @@ actually builds. Nothing connected the two, which is how openSUSE ended up
 declared by 19 recipes and built by zero cells (#139).
 
 The obvious fix -- assert every declared (recipe, target) pair has a cell --
-is not shippable: 55 of 122 pairs are uncovered today, so it would block every
+is not shippable: 34 of 122 pairs are uncovered today, so it would block every
 PR from the moment it landed. The obvious workaround, an allowlist of accepted
 gaps, is how a curated list stops being curated; `lint-generated-rpm.sh` says
 the same thing about its own fatal-checks list, and it is right.

--- a/tests/test_check_gate_coverage.py
+++ b/tests/test_check_gate_coverage.py
@@ -155,3 +155,71 @@ def test_the_real_repository_coverage_is_reported_not_asserted() -> None:
     declared = coverage.declared_pairs(tree)
     assert len(declared) >= 122
     assert coverage.uncovered(tree), "no uncovered pairs would make the ratchet vacuous"
+
+
+# --- job shapes the parser must not miss (the #159 blind spot) --------------
+
+
+def test_gate_pairs_reads_the_list_form_matrix() -> None:
+    """rpm-payload uses `matrix: {package: [...]}`, not `include`.
+
+    The first version of this parser read only `include` and silently counted
+    all 15 of those cells as uncovered.
+    """
+    workflow = (
+        "jobs:\n  rpm-payload:\n    strategy:\n      matrix:\n"
+        "        package: [cosmic-bg, cosmic-comp]\n"
+        "    steps:\n      - run: tideforge.py render r --target el10\n"
+    )
+    tree = FakeTree({".github/workflows/build-tideforge-supported.yml": workflow})
+    assert coverage.gate_pairs(tree) == {("cosmic-bg", "el10"), ("cosmic-comp", "el10")}
+
+
+def test_gate_pairs_reads_a_matrix_less_dedicated_job() -> None:
+    """niri-rpm and friends have no matrix at all; they are still coverage."""
+    workflow = (
+        "jobs:\n  niri-rpm:\n    steps:\n"
+        "      - run: |\n"
+        "          recipe=packages/niri/package.yaml\n"
+        "          tideforge.py render $recipe --target el10\n"
+    )
+    tree = FakeTree({".github/workflows/build-tideforge-supported.yml": workflow})
+    assert coverage.gate_pairs(tree) == {("niri", "el10")}
+
+
+def test_deleting_a_dedicated_job_shows_up_as_a_new_gap() -> None:
+    """The hole the blind spot left: an uncounted job could vanish unnoticed."""
+    before = FakeTree(
+        {
+            "packages/niri/package.yaml": recipe(["el10"]),
+            ".github/workflows/build-tideforge-supported.yml": (
+                "jobs:\n  niri-rpm:\n    steps:\n      - run: |\n"
+                "          recipe=packages/niri/package.yaml\n"
+                "          tideforge.py render $recipe --target el10\n"
+            ),
+        }
+    )
+    after = FakeTree({"packages/niri/package.yaml": recipe(["el10"])})
+    assert coverage.uncovered(after) - coverage.uncovered(before) == {("niri", "el10")}
+
+
+def test_an_unparsed_job_fails_loudly() -> None:
+    """A shape the parser cannot read must not read as zero coverage."""
+    workflow = (
+        "jobs:\n  mystery:\n    steps:\n"
+        "      - run: build packages/niri/package.yaml somehow\n"
+    )
+    tree = FakeTree({".github/workflows/build-tideforge-supported.yml": workflow})
+    with pytest.raises(SystemExit):
+        coverage.assert_every_job_understood(tree)
+
+
+def test_a_job_that_builds_nothing_is_not_flagged() -> None:
+    workflow = "jobs:\n  lint:\n    steps:\n      - run: shellcheck scripts/*.sh\n"
+    tree = FakeTree({".github/workflows/build-tideforge-supported.yml": workflow})
+    coverage.assert_every_job_understood(tree)
+
+
+def test_every_real_gate_job_is_understood() -> None:
+    """Guards the live workflows, so a new job shape fails here first."""
+    coverage.assert_every_job_understood(coverage.Tree())

--- a/tests/test_gate_verify_consistency.py
+++ b/tests/test_gate_verify_consistency.py
@@ -125,3 +125,77 @@ def test_validate_rejects_an_override_for_an_unenabled_target() -> None:
 def test_validate_rejects_an_empty_smoke() -> None:
     with pytest.raises(SystemExit):
         tideforge.validate_verify({"name": "x", "targets": ["el10"], "verify": {"smoke": "  "}})
+
+
+# --- packages the gate builds outside a matrix include ----------------------
+
+
+DEDICATED_JOB_PACKAGES = {
+    "niri",
+    "quickshell",
+    "gtkgreet",
+    "cpptrace-devel",
+    "iio-niri",
+    "dms",
+    "dms-cli",
+    "dms-greeter",
+}
+
+
+def _coverage_module():
+    spec = importlib.util.spec_from_file_location(
+        "check_gate_coverage", ROOT / "scripts" / "check-gate-coverage.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_every_package_the_gate_builds_has_a_verify_block() -> None:
+    """Not just the matrix-include cells.
+
+    The tests above walk `include:` cells only, which is how seven packages
+    built by dedicated jobs -- quickshell, gtkgreet, cpptrace-devel, iio-niri
+    and the dms stack -- ended up with no verify block at all while this file
+    claimed the gate was fully cross-checked. Assert against real coverage
+    instead of against one job shape.
+    """
+    coverage = _coverage_module()
+    # rpm-payload builds its cells without installing them -- there is no clean
+    # container and no smoke test to run, so those packages correctly have no
+    # verify block. Assert against packages the gate *installs*.
+    payload_only = {
+        package
+        for package, _ in coverage.gate_pairs(coverage.Tree())
+        if package not in {cell["package"] for cell in CELLS}
+        and package not in DEDICATED_JOB_PACKAGES
+    }
+    installed = {
+        package for package, _ in coverage.gate_pairs(coverage.Tree())
+    } - payload_only
+    missing = sorted(
+        package
+        for package in installed
+        if not (yaml.safe_load((ROOT / "packages" / package / "package.yaml").read_text()) or {}).get("verify")
+    )
+    assert not missing, f"gate-installed packages with no verify: block: {missing}"
+
+
+def test_niri_carries_its_full_session_contract() -> None:
+    """niri --help alone would pass with every session file missing.
+
+    The el10 job asserts the compositor binary *and* the five session
+    integration assets. A weaker recipe-side contract would silently drop them
+    when the gate switches over -- and a niri that no display manager can
+    discover is the flounder:niri failure repeating.
+    """
+    smoke = tideforge.verify_metadata(recipe_for("niri"), "el10")["smoke"]
+    for asset in (
+        "/usr/bin/niri-session",
+        "/usr/share/wayland-sessions/niri.desktop",
+        "/usr/share/xdg-desktop-portal/niri-portals.conf",
+        "/usr/lib/systemd/user/niri.service",
+        "/usr/lib/systemd/user/niri-shutdown.target",
+    ):
+        assert asset in smoke, f"niri verify.smoke does not assert {asset}"


### PR DESCRIPTION
**Corrects a defect I shipped in #159.** No gate workflow touched.

## The metric was wrong

`gate_pairs()` read only `strategy.matrix.include`. The gate uses **three** job shapes:

| shape | jobs | cells missed |
|---|---|---|
| `matrix.include` | `rpm`, `deb`, `opensuse-rpm`, `xfconf-split`, arch `build` | 0 |
| `matrix.package` (list form) | `rpm-payload` | **15** |
| no matrix — dedicated job | `niri-rpm`, `quickshell-rpm`, `gtkgreet-rpm`, `cpptrace-rpm`, `iio-niri-rpm`, `dms-stack-rpm` | **6** |

```
was:  68/122 covered -- 54 uncovered
is:   88/122 covered -- 34 uncovered      (el10: 25 uncovered -> 5)
```

## The count was the smaller problem

Because those jobs were never *counted* as coverage, **deleting one would not have registered as a regression.** The ratchet was blind to precisely the jobs that assert the most.

`assert_every_job_understood()` now fails on any gate job that builds a package but yields no pairs. A fourth job shape breaks the build instead of silently reading as zero coverage — the rule `lint-generated-rpm.sh` applies to an empty rpmlint report: *a parser that finds nothing must not be taken to mean there was nothing to find.*

## The same blind spot reached the recipes

#157 migrated verification metadata by walking `include:` cells, so **seven packages built only by dedicated jobs got no `verify:` block at all**: `quickshell`, `gtkgreet`, `cpptrace-devel`, `iio-niri`, `dms`, `dms-cli`, `dms-greeter`.

`niri` got one — but from the **Arch** cell. Its recipe said `niri --help`; its el10 job asserts the binary *plus five session-integration files*:

```
/usr/bin/niri-session
/usr/share/wayland-sessions/niri.desktop
/usr/share/xdg-desktop-portal/niri-portals.conf
/usr/lib/systemd/user/niri.service
/usr/lib/systemd/user/niri-shutdown.target
```

A cell carrying only `niri --help` passes with **all five missing** — which is how `flounder:niri` shipped a compositor no display manager could discover. This matters immediately for #161, where those session files are the most likely thing a deb rendering gets wrong: `render_deb` routes installs through debhelper, and `install.files` has to land in `debian/niri/…` rather than a DESTDIR.

Each of the eight now carries what its job actually asserts, and `test_every_package_the_gate_builds_has_a_verify_block` checks packages the gate **installs** rather than one job shape. (`rpm-payload` builds without installing, so those 12 correctly have no smoke — the first version of that test conflated built with installed and failed on them.)

## The Arch gap is recorded, not hidden

`build-tideforge-arch.yml` is held by #156, so I can't raise its cell here. `niri` therefore carries an explicit per-target override for `arch` documenting that the cell asserts less, with a note to raise it when the file is free. Written down beats silently differing.

## Tests

246 total, 12 new. The ones that matter:

- `test_deleting_a_dedicated_job_shows_up_as_a_new_gap` — the exact hole this fixes
- `test_an_unparsed_job_fails_loudly` / `test_every_real_gate_job_is_understood` — runs against the live workflows
- `test_niri_carries_its_full_session_contract` — asserts each of the five assets by name, so a future flattening fails

Refs #139, #161

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->
