### PR TITLE
fix(ci): exclude _template from the source-cache seed matrix

### DIFF
--- a/.github/workflows/seed-tideforge-source-cache.yml
+++ b/.github/workflows/seed-tideforge-source-cache.yml
@@ -37,7 +37,9 @@ jobs:
       - id: list
         run: |
           set -euo pipefail
-          packages=$(ls packages/*/package.yaml | xargs -n1 dirname | xargs -n1 basename | jq -R . | jq -cs .)
+          # _template is a placeholder recipe whose source URL is not real;
+          # seeding it can only ever fail the run (it did, first seed run).
+          packages=$(ls packages/*/package.yaml | xargs -n1 dirname | xargs -n1 basename | grep -v '^_template$' | jq -R . | jq -cs .)
           echo "packages=$packages" >> "$GITHUB_OUTPUT"
 
   seed:


### PR DESCRIPTION
First seed run (30637980897) populated main's scope for all 41 real recipes (~1.4 GB) but the run concluded `failure` because `packages/_template/package.yaml` — a placeholder with no real source URL — was in the matrix. Skip it; a seed run that is red by construction hides real seeding failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->