### PR TITLE
feat(ci): widen niri to the ubuntu and debian gate targets

### DIFF
--- a/.github/workflows/build-tideforge-supported.yml
+++ b/.github/workflows/build-tideforge-supported.yml
@@ -947,6 +947,22 @@ jobs:
             # correctly and the assertion failed anyway. Assert the real filenames.
             smoke: test -f /usr/lib/udev/rules.d/99-logitech-wheel-perms.rules && test -f /usr/lib/udev/rules.d/99-fanatec-wheel-perms.rules && test -f /usr/lib/udev/rules.d/99-thrustmaster-wheel-perms.rules
             clean_install: true
+          # Same contract the niri-rpm job asserts by hand: compositor,
+          # session launcher, wayland-session entry, portal config, and both
+          # user units (#161). libseat needs no prerequisite artifact here --
+          # libseat-dev/libseat1 are in the Ubuntu and Debian archives.
+          - package: niri
+            target: ubuntu
+            image: docker.io/library/ubuntu:26.04
+            install_name: niri
+            smoke: niri --help && test -x /usr/bin/niri-session && test -f /usr/share/wayland-sessions/niri.desktop && test -f /usr/share/xdg-desktop-portal/niri-portals.conf && test -f /usr/lib/systemd/user/niri.service && test -f /usr/lib/systemd/user/niri-shutdown.target
+            clean_install: true
+          - package: niri
+            target: debian
+            image: docker.io/library/debian:sid
+            install_name: niri
+            smoke: niri --help && test -x /usr/bin/niri-session && test -f /usr/share/wayland-sessions/niri.desktop && test -f /usr/share/xdg-desktop-portal/niri-portals.conf && test -f /usr/lib/systemd/user/niri.service && test -f /usr/lib/systemd/user/niri-shutdown.target
+            clean_install: true
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7

--- a/packages/niri/package.yaml
+++ b/packages/niri/package.yaml
@@ -12,11 +12,18 @@ source:
 build_system: cargo
 dependencies:
   build:
-    common: [cargo, rust]
+    # The rust capability renders the right toolchain name per target --
+    # Debian and Ubuntu call the compiler rustc, and a literal `rust` in
+    # Build-Depends is unsatisfiable there.
+    capabilities: [rust]
     targets:
       el10: [gcc, clang-devel, pkgconfig, glib2-devel, cairo-devel, cairo-gobject-devel, pango-devel, pipewire-devel, libdrm-devel, mesa-libgbm-devel, libdisplay-info-devel, libxkbcommon-devel, libinput-devel, libseat-devel, wayland-protocols-devel]
-      ubuntu: [debhelper-compat, pkg-config, libxkbcommon-dev, libinput-dev, libseat-dev, libwayland-dev]
-      debian: [debhelper-compat, pkg-config, libxkbcommon-dev, libinput-dev, libseat-dev, libwayland-dev]
+      # Upstream's documented Ubuntu build dependencies (Getting-Started wiki),
+      # plus debhelper-compat and pkg-config for the generated packaging. The
+      # previous list had never been exercised and was missing the pango,
+      # pipewire, gbm, dbus, systemd, and display-info stacks entirely.
+      ubuntu: [debhelper-compat, pkg-config, clang, libudev-dev, libgbm-dev, libxkbcommon-dev, libegl1-mesa-dev, libwayland-dev, libinput-dev, libdbus-1-dev, libsystemd-dev, libseat-dev, libpipewire-0.3-dev, libpango1.0-dev, libdisplay-info-dev]
+      debian: [debhelper-compat, pkg-config, clang, libudev-dev, libgbm-dev, libxkbcommon-dev, libegl1-mesa-dev, libwayland-dev, libinput-dev, libdbus-1-dev, libsystemd-dev, libseat-dev, libpipewire-0.3-dev, libpango1.0-dev, libdisplay-info-dev]
       opensuse-tumbleweed: [gcc, pkg-config, libxkbcommon-devel, libinput-devel, libseat-devel, wayland-protocols-devel]
       # Match Arch's official package build tools. Runtime libraries belong in
       # runtime dependencies and are not copied here merely because another
@@ -49,4 +56,13 @@ files:
     - usr/lib/systemd/user/niri-shutdown.target
 verify:
   smoke: niri --help
+  # The deb cells carry the same contract the niri-rpm job asserts by hand:
+  # compositor runs, session launcher, wayland-session entry, portal config,
+  # and both user units. Installing only the binary leaves display managers
+  # unable to discover a Niri session, which `niri --help` alone cannot catch.
+  targets:
+    ubuntu:
+      smoke: niri --help && test -x /usr/bin/niri-session && test -f /usr/share/wayland-sessions/niri.desktop && test -f /usr/share/xdg-desktop-portal/niri-portals.conf && test -f /usr/lib/systemd/user/niri.service && test -f /usr/lib/systemd/user/niri-shutdown.target
+    debian:
+      smoke: niri --help && test -x /usr/bin/niri-session && test -f /usr/share/wayland-sessions/niri.desktop && test -f /usr/share/xdg-desktop-portal/niri-portals.conf && test -f /usr/lib/systemd/user/niri.service && test -f /usr/lib/systemd/user/niri-shutdown.target
 targets: [el10, ubuntu, debian, opensuse-tumbleweed, arch]


### PR DESCRIPTION
Closes #161.

The recipe has declared `ubuntu` and `debian` since it landed, but no gate cell ever exercised them. This adds both deb cells to `build-tideforge-supported.yml` with the **same contract the `niri-rpm` job asserts by hand**: `niri --help`, `/usr/bin/niri-session`, the wayland-session entry, the portal config, and both `niri.service` / `niri-shutdown.target` user units — matched byte-for-byte by `verify.targets` overrides in the recipe, per the #157 ratchet.

The declared deb build dependencies had never been exercised and could not work:
- `Build-Depends: rust` is unsatisfiable on Debian/Ubuntu (the compiler package is `rustc`) — switched `common: [cargo, rust]` to `capabilities: [rust]`, which renders the right toolchain name per target and is a no-op for the el10/openSUSE/arch package sets.
- The lists omitted the pango, pipewire, gbm, dbus, systemd, and display-info stacks — replaced with upstream's documented Ubuntu build dependencies plus `debhelper-compat`/`pkg-config`.

Gate coverage: **45 → 47** of 122 declared (recipe, target) pairs (`scripts/check-gate-coverage.py`).

Local verification: `pytest tests/` 238 passed (including `test_gate_verify_consistency.py`), `tideforge.py validate` clean, ubuntu render now emits `Build-Depends: debhelper-compat (= 13), rustc, cargo, ...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->