### PR TITLE
feat(ci): gate the library/tool recipes on ubuntu and debian

### DIFF
--- a/.github/workflows/build-tideforge-supported.yml
+++ b/.github/workflows/build-tideforge-supported.yml
@@ -829,6 +829,70 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Library/tool wave (#139 follow-up): all five are green on el10
+          # with the byte-identical contract. Their deb outputs render distro
+          # package names (libcli11-dev, libunwind-dev, libseat-dev), matched
+          # by verify.targets overrides in each recipe.
+          - package: cli11-devel
+            target: ubuntu
+            image: docker.io/library/ubuntu:26.04
+            install_name: libcli11-dev
+            smoke: test -f /usr/include/CLI/CLI.hpp
+            clean_install: true
+          - package: cli11-devel
+            target: debian
+            image: docker.io/library/debian:sid
+            install_name: libcli11-dev
+            smoke: test -f /usr/include/CLI/CLI.hpp
+            clean_install: true
+          - package: libunwind-devel
+            target: ubuntu
+            image: docker.io/library/ubuntu:26.04
+            install_name: libunwind-dev
+            smoke: test -f /usr/include/libunwind.h && test -f /usr/include/unwind.h
+            clean_install: true
+          - package: libunwind-devel
+            target: debian
+            image: docker.io/library/debian:sid
+            install_name: libunwind-dev
+            smoke: test -f /usr/include/libunwind.h && test -f /usr/include/unwind.h
+            clean_install: true
+          - package: ninja-build
+            target: ubuntu
+            image: docker.io/library/ubuntu:26.04
+            install_name: ninja-build
+            smoke: ninja --version
+            clean_install: true
+          - package: ninja-build
+            target: debian
+            image: docker.io/library/debian:sid
+            install_name: ninja-build
+            smoke: ninja --version
+            clean_install: true
+          - package: wayland-protocols
+            target: ubuntu
+            image: docker.io/library/ubuntu:26.04
+            install_name: wayland-protocols
+            smoke: pkg-config --atleast-version=1.41 wayland-protocols && test -f /usr/share/wayland-protocols/staging/ext-session-lock/ext-session-lock-v1.xml
+            clean_install: true
+          - package: wayland-protocols
+            target: debian
+            image: docker.io/library/debian:sid
+            install_name: wayland-protocols
+            smoke: pkg-config --atleast-version=1.41 wayland-protocols && test -f /usr/share/wayland-protocols/staging/ext-session-lock/ext-session-lock-v1.xml
+            clean_install: true
+          - package: libseat
+            target: ubuntu
+            image: docker.io/library/ubuntu:26.04
+            install_name: libseat-dev
+            smoke: pkg-config --modversion libseat && seatd -h
+            clean_install: true
+          - package: libseat
+            target: debian
+            image: docker.io/library/debian:sid
+            install_name: libseat-dev
+            smoke: pkg-config --modversion libseat && seatd -h
+            clean_install: true
           - package: uupd
             target: ubuntu
             image: docker.io/library/ubuntu:26.04
@@ -1059,7 +1123,11 @@ jobs:
             set -euo pipefail
             export DEBIAN_FRONTEND=noninteractive
             apt-get update -qq
-            apt-get install -y --no-install-recommends dpkg-dev
+            # pkg-config is part of the smoke environment, not the package
+            # under test: the libseat and wayland-protocols contracts query it,
+            # and unlike RPM (whose pkgconfig() generator pulls pkgconf in),
+            # dpkg gives -dev packages no such automatic dependency.
+            apt-get install -y --no-install-recommends dpkg-dev pkg-config
             mkdir -p /var/lib/tideforge
             cp /work/artifacts/*.deb /var/lib/tideforge/
             cd /var/lib/tideforge

--- a/packages/cli11-devel/package.yaml
+++ b/packages/cli11-devel/package.yaml
@@ -16,8 +16,11 @@ build:
   debug_package: false
 dependencies:
   build:
-    common: [cmake, gcc-c++]
+    # No common list: it held RPM names (gcc-c++) that leaked into the deb
+    # Build-Depends, where no such package exists. Each target already names
+    # its own complete toolchain.
     targets:
+      el10: [cmake, gcc-c++]
       ubuntu: [cmake, g++]
       debian: [cmake, g++]
       opensuse-tumbleweed: [cmake, gcc-c++]
@@ -35,4 +38,8 @@ outputs:
         files: [usr/include/CLI, usr/share/cmake/CLI11, usr/share/pkgconfig/CLI11.pc]
 verify:
   smoke: test -f /usr/include/CLI/CLI.hpp
+  # The deb output renders a package named libcli11-dev, not the recipe name.
+  targets:
+    ubuntu: {install_name: libcli11-dev}
+    debian: {install_name: libcli11-dev}
 targets: [el10, ubuntu, debian, opensuse-tumbleweed, arch]

--- a/packages/libseat/package.yaml
+++ b/packages/libseat/package.yaml
@@ -47,4 +47,9 @@ outputs:
 verify:
   smoke: "pkg-config --modversion libseat && seatd -h"
   install_name: libseat-devel
+  # The deb output renders libseat-dev (which depends on libseat1, carrying
+  # seatd), not the RPM subpackage name.
+  targets:
+    ubuntu: {install_name: libseat-dev}
+    debian: {install_name: libseat-dev}
 targets: [el10, ubuntu, debian, opensuse-tumbleweed, arch]

--- a/packages/libunwind-devel/package.yaml
+++ b/packages/libunwind-devel/package.yaml
@@ -15,8 +15,11 @@ build:
   configure_options: [--disable-tests]
 dependencies:
   build:
-    common: [gcc-c++, autoconf, automake, libtool]
+    # No common list: it held RPM names (gcc-c++) that leaked into the deb
+    # Build-Depends, where no such package exists. Each target already names
+    # its own complete toolchain.
     targets:
+      el10: [gcc-c++, autoconf, automake, libtool]
       ubuntu: [build-essential, autoconf, automake, libtool]
       debian: [build-essential, autoconf, automake, libtool]
       opensuse-tumbleweed: [gcc-c++, autoconf, automake, libtool]
@@ -34,4 +37,8 @@ outputs:
         files: [usr/include/libunwind*.h, usr/include/unwind.h, usr/lib/*/libunwind*.so*, usr/lib/*/libunwind*.a, usr/lib/*/pkgconfig/libunwind*.pc]
 verify:
   smoke: "test -f /usr/include/libunwind.h && test -f /usr/include/unwind.h"
+  # The deb output renders a package named libunwind-dev, not the recipe name.
+  targets:
+    ubuntu: {install_name: libunwind-dev}
+    debian: {install_name: libunwind-dev}
 targets: [el10, ubuntu, debian, opensuse-tumbleweed, arch]

--- a/packages/ninja-build/package.yaml
+++ b/packages/ninja-build/package.yaml
@@ -15,8 +15,11 @@ build:
   cmake_options: [-DBUILD_TESTING=OFF]
 dependencies:
   build:
-    common: [cmake, gcc-c++]
+    # No common list: it held RPM names (gcc-c++) that leaked into the deb
+    # Build-Depends, where no such package exists. Each target already names
+    # its own complete toolchain.
     targets:
+      el10: [cmake, gcc-c++]
       ubuntu: [cmake, g++]
       debian: [cmake, g++]
       opensuse-tumbleweed: [cmake, gcc-c++]


### PR DESCRIPTION
Part of the declared-but-never-exercised cleanup (#139 defect class).

Adds ten deb cells — **cli11-devel, libunwind-devel, ninja-build, wayland-protocols, libseat** on ubuntu 26.04 + debian sid — each carrying the byte-identical el10 contract per the #157 ratchet.

Three recipe defects fixed along the way, none of which could have built:
- `common: [cmake, gcc-c++]` (and friends) leaked the RPM name `gcc-c++` into deb `Build-Depends`; moved into explicit `el10` lists (rendered RPMs unchanged — verified by re-render).
- The deb outputs render distro package names (`libcli11-dev`, `libunwind-dev`, `libseat-dev`); recipes now carry `verify.targets` install_name overrides.
- The clean-install container now provisions `pkg-config`: the libseat and wayland-protocols smokes query it, and dpkg gives -dev packages no automatic pkgconf dependency the way RPM's `pkgconfig()` generator does.

Cells are inserted at the head of the deb include list, deliberately away from #166's tail insertion, so the two queue without textual conflict.

Gate coverage: **45 → 55** of 122 on top of main.

Verification: full `pytest tests/` 254 passed; `check-gate-coverage.py --baseline main` reports 10 fewer uncovered pairs; ubuntu render now emits `Build-Depends: debhelper-compat (= 13), cmake, g++`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->