### PR TITLE
feat(ci): gate uupd and greetd on Arch

### DIFF
--- a/.github/workflows/build-tideforge-arch.yml
+++ b/.github/workflows/build-tideforge-arch.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - packages/niri/package.yaml
+      - packages/uupd/package.yaml
+      - packages/greetd/package.yaml
       - packages/kairpods/package.yaml
       - packages/krunner-bazaar/package.yaml
       - packages/dgop/package.yaml
@@ -50,6 +52,13 @@ jobs:
         include:
           - package: niri
             smoke: niri --help
+          # uupd and greetd are green on every other declared target with the
+          # byte-identical contract; arch was the last declared-but-never-
+          # exercised pair for both (#139 defect class).
+          - package: uupd
+            smoke: uupd --help
+          - package: greetd
+            smoke: greetd --help
           - package: kairpods
             smoke: test -x /usr/bin/kairpodsd && test -f /usr/lib/systemd/user/kairpodsd.service
           - package: krunner-bazaar


### PR DESCRIPTION
Continues the declared-but-never-exercised cleanup in `build-tideforge-arch.yml` — a different file from the supported-targets gate, so it queues without conflicting with #166/#167/#168.

Adds arch cells (plus path filters) for **uupd** and **greetd**, both green on el10+ubuntu+debian with the byte-identical contract per the #157 ratchet.

Deliberately excluded from this wave:
- `cli11-devel`, `libunwind-devel`, `ninja-build`: their rendered arch PKGBUILDs currently inherit `gcc-c++` from the common lists — the fix lands in #168; arch cells follow after it merges.
- `libseat`, `wayland-protocols`: their contracts query `pkg-config`, which the bare `archlinux:latest` install container does not carry (unlike el10, where the pkgconfig() generator pulls it in). Needs a smoke-environment decision first.

Gate coverage: **45 → 47** of 122 on top of main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->