### PR TITLE
fix(ci): repair the ubuntu/debian deb renders merged with #168

### DIFF
--- a/.github/workflows/build-tideforge-supported.yml
+++ b/.github/workflows/build-tideforge-supported.yml
@@ -1181,9 +1181,29 @@ jobs:
             cd /var/lib/tideforge
             dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz
             printf "deb [trusted=yes] file:/var/lib/tideforge ./\\n" > /etc/apt/sources.list.d/tideforge.list
+            # Pin the ephemeral repo above the distro archive -- the apt spelling
+            # of the priority overrides the el10 and Tumbleweed jobs already
+            # carry. apt otherwise installs the highest version it can see, and
+            # Ubuntu resolute ships libunwind-dev 1.8.3-0ubuntu1 against our
+            # 1.8.1-1, so the smoke test exercised the archive package (whose
+            # -dev split omits /usr/include/unwind.h) and failed on a contract
+            # the deb built in this job does satisfy. Empty origin is how apt
+            # names a local file: repository; 1001 also permits a downgrade, so
+            # a package preinstalled in the image is replaced rather than kept.
+            printf "Package: *\\nPin: origin \"\"\\nPin-Priority: 1001\\n" > /etc/apt/preferences.d/tideforge.pref
             apt-get update -qq
             apt-get install -y ${{ matrix.install_name }}
             dpkg-query -W ${{ matrix.install_name }}
+            # Shadowing is silent otherwise: an archive package that happens to
+            # satisfy the contract would report this cell green without the
+            # generated deb ever being installed.
+            set -- /var/lib/tideforge/${{ matrix.install_name }}_*.deb
+            expected=$(dpkg-deb -f "$1" Version)
+            installed=$(dpkg-query -W ${{ matrix.install_name }} | cut -f2)
+            if [ "$installed" != "$expected" ]; then
+              echo "installed $installed did not come from the ephemeral repo (expected $expected)" >&2
+              exit 1
+            fi
             ${{ matrix.smoke }}
           '
       - uses: actions/upload-artifact@v7

--- a/scripts/tideforge.py
+++ b/scripts/tideforge.py
@@ -66,16 +66,37 @@ def target_runtime_dependencies(recipe: dict, target: str) -> list[str]:
     return list(runtime.get("common", [])) + resolve_capabilities(list(runtime.get("capabilities", [])), target) + list(runtime.get("targets", {}).get(target, []))
 
 
-def install_commands(recipe: dict, destination_root: str) -> str:
+def generated_file_content_argument(content: str) -> str:
+    """Return a declared file's content as one-line `printf` arguments.
+
+    Quoting the content as a single literal embeds real newlines in the emitted
+    command. RPM's %install and Arch's package() are shell scripts, so that
+    worked there, but every LINE of a debian/rules recipe is its own /bin/sh
+    invocation: the first line arrived as `printf %s 'prefix=/usr` and the deb
+    build died with "Syntax error: Unterminated quoted string" (wayland-protocols
+    on ubuntu and debian). One argument per line keeps the command on a single
+    line for all three renderers while writing byte-identical content.
+    """
+    lines = content.split("\n")
+    if lines and lines[-1] == "":
+        lines.pop()
+    return " ".join(shlex.quote(line) for line in lines)
+
+
+def install_commands(recipe: dict, destination_root: str, *, make_escape: bool = False) -> str:
     commands: list[str] = []
     for item in recipe.get("install", {}).get("files", []):
         commands.append(f"install -Dm{item.get('mode', '0644')} {item['source']} {destination_root}/{item['destination']}")
     for item in recipe.get("install", {}).get("generated_files", []):
         destination = f"{destination_root}/{item['destination']}"
         commands.append(f"install -d {Path(destination).parent}")
-        commands.append(f"printf %s {shlex.quote(item['content'])} > {destination}")
+        commands.append(f"printf '%s\\n' {generated_file_content_argument(item['content'])} > {destination}")
         commands.append(f"chmod {item.get('mode', '0644')} {destination}")
-    return "\n".join(commands)
+    rendered = "\n".join(commands)
+    # debian/rules is a Makefile, so make expands $ before /bin/sh ever sees it:
+    # the `${prefix}` and `${pc_sysrootdir}` references in a generated pkg-config
+    # file would reach the shell empty. Doubling restores the literal $.
+    return rendered.replace("$", "$$") if make_escape else rendered
 
 
 def install_directories(recipe: dict, destination_root: str, *, exclude_generated_debian: bool = False) -> str:
@@ -729,7 +750,7 @@ Rules-Requires-Root: no
         else:
             configure = ""
         rules = f"#!/usr/bin/make -f\n\n%:\n\tdh $@ --buildsystem={buildsystem}\n{configure}"
-    extra_install = "\n".join(filter(None, [install_commands(recipe, f"debian/{recipe['name']}"), install_directories(recipe, f"debian/{recipe['name']}", exclude_generated_debian=True)]))
+    extra_install = "\n".join(filter(None, [install_commands(recipe, f"debian/{recipe['name']}", make_escape=True), install_directories(recipe, f"debian/{recipe['name']}", exclude_generated_debian=True)]))
     if extra_install:
         rules = rules.rstrip() + "\n\t" + extra_install.replace("\n", "\n\t") + "\n"
     # For native build systems debhelper auto-runs the upstream test suite via

--- a/scripts/tideforge.py
+++ b/scripts/tideforge.py
@@ -753,7 +753,25 @@ Rules-Requires-Root: no
     # debian/<binary-package>.  A .install file would make dh_install search
     # debian/tmp for those same files and fail the package build.  Native
     # build-system packages retain .install metadata for dh_auto_install.
-    direct_install = recipe["build_system"] in {"cargo", "go", "data", "custom"} or bool(recipe.get("install"))
+    #
+    # debhelper's dh_auto_install only stages into debian/tmp when the source
+    # produces MORE THAN ONE binary package; with a single one it installs
+    # straight into debian/<that package>.  So a single-package native recipe
+    # is in the same position as the direct-install renderers above, and its
+    # .install file sends dh_install looking for files that are already in
+    # place:
+    #   dh_install: warning: Cannot find (any matches for) "usr/bin/ninja"
+    #     (tried in ., debian/tmp)
+    #   dh_install: error: missing files, aborting
+    # ninja-build (cmake, one binary package) failed exactly this way on
+    # ubuntu and debian while building fine on el10.  Split recipes such as
+    # xfconf and libseat do stage through debian/tmp, so they keep their
+    # .install lists to carve it up between the binary packages.
+    direct_install = (
+        recipe["build_system"] in {"cargo", "go", "data", "custom"}
+        or bool(recipe.get("install"))
+        or len(binary_packages) == 1
+    )
     if not direct_install:
         for package in binary_packages:
             rendered[f"debian/{package['name']}.install"] = "\n".join(package.get("files", recipe["files"]["common"])) + "\n"

--- a/tests/test_tideforge.py
+++ b/tests/test_tideforge.py
@@ -353,9 +353,37 @@ def test_recipe_installs_generated_files(recipe: dict) -> None:
     rpm = tideforge.render(recipe, "el10")["hello-tuna.spec"]
     deb = tideforge.render(recipe, "ubuntu")["debian/rules"]
     arch = tideforge.render(recipe, "arch")["PKGBUILD"]
-    assert "printf %s 'Name: demo" in rpm
+    assert "printf '%s\\n' 'Name: demo\\n'" in rpm
     assert "debian/hello-tuna/usr/lib/pkgconfig/demo.pc" in deb
     assert "$pkgdir/usr/lib/pkgconfig/demo.pc" in arch
+
+
+def test_generated_file_content_stays_on_one_shell_line(recipe: dict) -> None:
+    # Every LINE of a debian/rules recipe is its own /bin/sh invocation, so a
+    # quoted literal carrying real newlines reached the shell truncated:
+    #   printf %s 'prefix=/usr
+    #   /bin/sh: 1: Syntax error: Unterminated quoted string
+    # That killed the wayland-protocols deb build while el10 (whose %install is
+    # one shell script) rendered the same recipe fine.
+    recipe["build_system"] = "data"
+    recipe["install"] = {
+        "generated_files": [
+            {
+                "destination": "usr/share/pkgconfig/demo.pc",
+                "content": "prefix=/usr\ndatarootdir=${prefix}/share\n\nName: demo\n",
+            }
+        ]
+    }
+    for rendered in (tideforge.render(recipe, "el10")["hello-tuna.spec"], tideforge.render(recipe, "arch")["PKGBUILD"]):
+        printf = next(line for line in rendered.splitlines() if "printf" in line)
+        assert printf.endswith("demo.pc")
+        assert printf.count("printf") == 1
+    printf = next(line for line in tideforge.render(recipe, "ubuntu")["debian/rules"].splitlines() if "printf" in line)
+    assert printf.endswith("demo.pc")
+    # make expands $ before /bin/sh sees the recipe, so a pkg-config file's
+    # ${prefix} reference has to reach the shell as $${prefix}.
+    assert "$${prefix}" in printf
+    assert "'${prefix}" not in printf
 
 
 def test_custom_recipe_renders_native_install_contract(recipe: dict) -> None:

--- a/tests/test_tideforge.py
+++ b/tests/test_tideforge.py
@@ -44,7 +44,10 @@ def test_recipe_renders_el10_rpm(recipe: dict) -> None:
 def test_recipe_renders_ubuntu_debian_metadata(recipe: dict) -> None:
     rendered = tideforge.render(recipe, "ubuntu")
     assert "Build-Depends: debhelper-compat (= 13), meson, ninja-build" in rendered["debian/control"]
-    assert rendered["debian/hello-tuna.install"] == "usr/bin/hello-tuna\n"
+    # A single binary package stages straight into debian/hello-tuna, so no
+    # .install file is rendered -- see
+    # test_single_binary_package_renders_no_install_file.
+    assert "debian/hello-tuna.install" not in rendered
 
 
 def test_recipe_rejects_unknown_target(recipe: dict) -> None:
@@ -65,7 +68,6 @@ def test_recipe_renders_subpackages(recipe: dict) -> None:
     devel_stanza = rpm.split("%package devel", 1)[1].split("%description devel", 1)[0]
     assert "Requires:" not in devel_stanza
     assert "Package: libdemo0" in deb["debian/control"]
-    assert "debian/libdemo0.install" in deb
 
 
 def test_recipe_subpackage_requires_pulls_in_main_package(recipe: dict) -> None:
@@ -134,6 +136,43 @@ def test_deb_single_package_shipping_headers_needs_no_sibling(recipe: dict) -> N
     # no runtime half for them to depend on, so the split rule must not fire.
     recipe["outputs"] = {"deb": {"packages": [{"name": "libdemo-dev", "files": ["usr/include/demo"]}]}}
     tideforge.validate(recipe, "ubuntu")
+
+
+def test_single_binary_package_renders_no_install_file(recipe: dict) -> None:
+    # dh_auto_install stages into debian/tmp only when the source produces more
+    # than one binary package; with a single one it installs straight into
+    # debian/<that package>. A .install file then makes dh_install search
+    # debian/tmp for files already in place and abort the build:
+    #   dh_install: warning: Cannot find (any matches for) "usr/bin/ninja"
+    #     (tried in ., debian/tmp)
+    #   dh_install: error: missing files, aborting
+    # ninja-build (cmake, one binary package) failed exactly this way on ubuntu
+    # while building fine on el10.
+    recipe["build_system"] = "cmake"
+    assert "debian/hello-tuna.install" not in tideforge.render(recipe, "ubuntu")
+    # Same for a single package the deb output renames, as cli11-devel does.
+    recipe["outputs"] = {"deb": {"packages": [{"name": "libdemo-dev", "files": ["usr/include/demo"]}]}}
+    assert "debian/libdemo-dev.install" not in tideforge.render(recipe, "ubuntu")
+
+
+def test_split_deb_output_keeps_per_package_install_files(recipe: dict) -> None:
+    # Two or more binary packages do stage through debian/tmp, so each keeps the
+    # .install list that carves its share out of it.
+    recipe["outputs"] = {
+        "deb": {
+            "packages": [
+                {"name": "libdemo0", "files": ["usr/lib/*/libdemo.so.0"]},
+                {
+                    "name": "libdemo-dev",
+                    "depends": ["libdemo0 (= ${binary:Version})"],
+                    "files": ["usr/include/demo"],
+                },
+            ]
+        }
+    }
+    rendered = tideforge.render(recipe, "ubuntu")
+    assert rendered["debian/libdemo0.install"] == "usr/lib/*/libdemo.so.0\n"
+    assert rendered["debian/libdemo-dev.install"] == "usr/include/demo\n"
 
 
 def test_recipe_renders_arch_pkgbuild(recipe: dict) -> None:


### PR DESCRIPTION
#168 merged through the queue while two of its new deb cells were red, so `main` is currently failing `ninja-build (ubuntu DEB)` and `wayland-protocols (ubuntu DEB)`. Both are renderer defects, not recipe defects, and the cli11-devel / libunwind-devel cells (which never got to run before the merge) carry the first one too.

**Single-binary-package deb outputs must not carry a `.install` file.** `dh_auto_install` only stages into `debian/tmp` when the source produces more than one binary package; with a single one it installs straight into `debian/<that package>`, so the rendered `.install` file sent `dh_install` hunting through `debian/tmp` for files already in place: `dh_install: warning: Cannot find (any matches for) "usr/bin/ninja" (tried in ., debian/tmp)` then `error: missing files, aborting`. That is the same reason the Go/Cargo/data renderers already skip it, so single-package native recipes join them:

```python
direct_install = (
    recipe["build_system"] in {"cargo", "go", "data", "custom"}
    or bool(recipe.get("install"))
    or len(binary_packages) == 1
)
```

Split recipes (xfconf, libseat, cpptrace-devel) do stage through `debian/tmp` and keep their per-package `.install` lists; a test now pins both halves of that rule.

**Generated file contents have to stay on one shell line.** Quoting the content as a single literal embeds real newlines, which is fine in RPM's `%install` and Arch's `package()` (one shell script each) but fatal in `debian/rules`, where every line is its own `/bin/sh`: the recipe arrived as `printf %s 'prefix=/usr` and died with `Syntax error: Unterminated quoted string`. One `printf` argument per line fixes it, and `$` is doubled on the deb path because make would otherwise expand `${prefix}` and `${pc_sysrootdir}` to nothing before the shell saw them:

```make
override_dh_auto_install:
	install -d debian/wayland-protocols/usr/share/pkgconfig
	printf '%s
' prefix=/usr 'datarootdir=$${prefix}/share' 'pkgdatadir=$${pc_sysrootdir}$${datarootdir}/wayland-protocols' '' 'Name: Wayland Protocols' ... > debian/wayland-protocols/usr/share/pkgconfig/wayland-protocols.pc
```

The written file is byte-identical to the old form on all three renderers: verified by executing the rendered recipe through `make` + `/bin/sh` and diffing against the recipe's declared content. The only rendered change outside wayland-protocols' `debian/rules` is the `printf` line itself in the wayland-protocols and cosmic-session specs (same bytes out).

`pytest tests/` is 261 passed.

**The deb smoke test has to install the deb it just built.** `apt-get install` takes the highest version it can see, and nothing ranked the ephemeral `file:/var/lib/tideforge` repo above the distro archive, so `libunwind-devel (ubuntu DEB)` installed resolute's `libunwind-dev 1.8.3-0ubuntu1` over our `1.8.1-1` and then failed the contract that archive split does not satisfy (`/usr/include/unwind.h` is not in it). The el10 and Tumbleweed jobs already pin their ephemeral repo (`dnf --setopt=tideforge.priority=1`, `zypper --priority 1`); this is the apt spelling of the same override, plus an assertion so a future shadow is loud rather than a mystery contract failure:

```sh
printf "Package: *\\nPin: origin \"\"\\nPin-Priority: 1001\\n" > /etc/apt/preferences.d/tideforge.pref
...
expected=$(dpkg-deb -f "$1" Version)
installed=$(dpkg-query -W libunwind-dev | cut -f2)
```

Verified against a real local repo: with the pin, apt's candidate flips to the file: repo's older version even when a newer one is already installed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->
