### PR TITLE
fix(ci): repair both breaks keeping the XFCE Wayland gates red

### DIFF
--- a/.github/workflows/build-xfce-arch-validation.yml
+++ b/.github/workflows/build-xfce-arch-validation.yml
@@ -33,21 +33,32 @@ jobs:
           set -euo pipefail
           mkdir -p "${{ github.workspace }}/arch-out"
 
-          cat > /tmp/run.sh <<'SCRIPT'
+          mkdir -p /tmp/arch-build/xfconf /tmp/arch-build/libxfce4ui /tmp/arch-build/xfwl4
+          cp src/xfce-wayland/xfconf/packaging/arch/PKGBUILD /tmp/arch-build/xfconf/
+          cp src/xfce-wayland/libxfce4ui/packaging/arch/PKGBUILD /tmp/arch-build/libxfce4ui/
+          cp src/xfce-wayland/xfwl4/packaging/arch/PKGBUILD /tmp/arch-build/xfwl4/
+          find src/xfce-wayland/xfwl4 -iname "*.patch" -exec cp {} /tmp/arch-build/xfwl4/ \;
+
+          # The script has to live inside the bind mount: /tmp/arch-build is the
+          # only thing the container sees, so a runner-side /tmp/run.sh is not
+          # there when bash goes looking for it.
+          cat > /tmp/arch-build/run.sh <<'SCRIPT'
           set -euo pipefail
-          pacman -Sy --noconfirm --needed base-devel git \
-            libdrm libinput mesa seatd libxkbcommon pixman wayland gtk3 gdk-pixbuf2 \
-            libdisplay-info libsm startup-notification systemd-libs cargo rust pkgconf \
-            wayland-protocols gettext glib2-devel
+          pacman -Syu --noconfirm --needed base-devel git sudo
 
           useradd -m builder
+          # makepkg --syncdeps installs each PKGBUILD's declared
+          # depends/makedepends through sudo pacman, so the gate validates those
+          # lists too instead of a hand-maintained copy of them drifting here.
+          echo 'builder ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/builder
+          chmod 0440 /etc/sudoers.d/builder
           chown -R builder:builder /work
 
           build_one() {
             local dir="$1"
             cd "/work/$dir"
             chown -R builder:builder .
-            su builder -c "makepkg --noconfirm --skippgpcheck --nodeps"
+            su builder -c "makepkg --noconfirm --skippgpcheck --syncdeps"
             pacman -U --noconfirm ./*.pkg.tar.zst --overwrite '*'
           }
 
@@ -56,19 +67,14 @@ jobs:
           build_one xfwl4
 
           mkdir -p /work/arch-out
-          find /work -maxdepth 2 -name '*.pkg.tar.zst' -exec cp {} /work/arch-out/ \;
+          find /work -maxdepth 2 -name '*.pkg.tar.zst' \
+            -not -path '/work/arch-out/*' -exec cp {} /work/arch-out/ \;
           SCRIPT
-
-          mkdir -p /tmp/arch-build/xfconf /tmp/arch-build/libxfce4ui /tmp/arch-build/xfwl4
-          cp src/xfce-wayland/xfconf/packaging/arch/PKGBUILD /tmp/arch-build/xfconf/
-          cp src/xfce-wayland/libxfce4ui/packaging/arch/PKGBUILD /tmp/arch-build/libxfce4ui/
-          cp src/xfce-wayland/xfwl4/packaging/arch/PKGBUILD /tmp/arch-build/xfwl4/
-          find src/xfce-wayland/xfwl4 -iname "*.patch" -exec cp {} /tmp/arch-build/xfwl4/ \;
 
           podman run --rm \
             -v /tmp/arch-build:/work:Z \
             archlinux:latest \
-            bash /tmp/run.sh 2>&1 | tee /tmp/build.log || {
+            bash /work/run.sh 2>&1 | tee /tmp/build.log || {
             echo "::error::Arch validation build failed — see log above"
             exit 1
           }

--- a/.github/workflows/build-xfce-fedora.yml
+++ b/.github/workflows/build-xfce-fedora.yml
@@ -25,6 +25,7 @@ on:
       - 'src/xfce-wayland/libxfce4ui/libxfce4ui.spec'
       - 'build-order-xfce-fedora.yml'
       - 'mock/fedora-44-ci.cfg'
+      - 'scripts/build-chain.sh'
   push:
     branches:
       - main
@@ -34,6 +35,7 @@ on:
       - 'src/xfce-wayland/libxfce4ui/libxfce4ui.spec'
       - 'build-order-xfce-fedora.yml'
       - 'mock/fedora-44-ci.cfg'
+      - 'scripts/build-chain.sh'
   workflow_dispatch:
 
 env:

--- a/mock/fedora-44-ci.cfg
+++ b/mock/fedora-44-ci.cfg
@@ -34,3 +34,15 @@ gpgcheck=0
 priority=1
 cost=1
 """
+
+# mock <= 6.7 queries the chroot rpmdb as
+#   rpm -qa --qf '%{nevra} %{buildtime} %{size} %{pkgid} installed\n'
+# in the package_state plugin, and Fedora 44's rpm 6 removed the md5-based
+# pkgid tag, so every build died at "error: incorrect format: unknown tag:
+# pkgid" before compiling anything (run 30651060582; red on main since
+# 14:08 across three unrelated renovate merges). Upstream removed the tag in
+# mock commit edec6023 (2026-04-21) but no release since 6.7 (2026-03-03)
+# carries it. The plugin only writes installed_pkgs.log/available_pkgs.log,
+# so disable it here until a fixed mock ships in the runner image.
+config_opts.setdefault('plugin_conf', {})
+config_opts['plugin_conf']['package_state_enable'] = False

--- a/scripts/build-chain.sh
+++ b/scripts/build-chain.sh
@@ -315,9 +315,14 @@ build_package_podman() {
     local resultdir="${builddir}/results"
     mkdir -p "$resultdir"
 
-    # The mock config is baked into the mock-runner image at /etc/mock/centos-stream-10-ci.cfg
-    # (see mock/centos-stream-10-ci.cfg and mock/Containerfile). It mirrors the COPR
-    # epel-10-x86_64 environment exactly — same base config, same additional repos, same options.
+    # The mock-runner image bakes copies of the mock configs into /etc/mock
+    # (see mock/Containerfile), but the copies are ONLY a fallback for running
+    # the image by hand: the invocation below mounts this checkout's mock/
+    # directory and passes --configdir, so the repo's config always wins. It
+    # used to be the other way around — the baked copy won — and a fix
+    # committed to mock/fedora-44-ci.cfg changed nothing in CI until someone
+    # rebuilt the image (#176, run 30652383636). A config present in the repo
+    # but read from an image is a trap; do not remove the --configdir wiring.
 
     # Ensure the local repo metadata is up-to-date before mock starts,
     # locked to prevent parallel jobs from corrupting it.
@@ -340,6 +345,7 @@ build_package_podman() {
         --pull=always \
         -v "${builddir}:/builddir:Z" \
         -v "${LOCAL_REPO}:/local-repo:Z" \
+        -v "${REPO_ROOT}/mock:/repo-mock:ro,Z" \
         "${MOCK_CACHE_ARGS[@]}" \
         "${BUILD_IMAGE}" \
         bash -exc "
@@ -364,11 +370,23 @@ build_package_podman() {
             # everything after the break. A quoted phrase in this very comment
             # did that and turned the whole container step into a no-op.
             chown -R builder /builddir 2>/dev/null || true
+            # Assemble a config directory where the checked-out mock/ configs
+            # override the copies baked into this image. mock requires
+            # site-defaults.cfg and logging.ini to exist in a custom
+            # --configdir, so take those two from the image; every profile
+            # .cfg comes from the repo mount. include() of absolute
+            # /etc/mock/... paths inside the profiles still resolves to the
+            # image, which is right — base chroot definitions belong to
+            # mock-core-configs, only the ci overlays belong to the repo.
+            mkdir -p /tmp/mock-configdir
+            cp /etc/mock/site-defaults.cfg /etc/mock/logging.ini /tmp/mock-configdir/
+            cp /repo-mock/*.cfg /tmp/mock-configdir/
+            chmod -R a+rX /tmp/mock-configdir
             # Use flock to ensure only one process runs mock at a time
             # because they share mock chroot initialization.
             flock /local-repo/repo.lock -c \"
                 setpriv --reuid=builder --regid=mock --init-groups \\
-                mock -r '${MOCK_CONFIG}' \\
+                mock --configdir /tmp/mock-configdir -r '${MOCK_CONFIG}' \\
                     --uniqueext='${pkg_name}' \\
                     --rebuild /builddir/SRPMS/*.src.rpm \\
                     --resultdir=/builddir/results \\

--- a/scripts/build-chain.sh
+++ b/scripts/build-chain.sh
@@ -371,15 +371,20 @@ build_package_podman() {
             # did that and turned the whole container step into a no-op.
             chown -R builder /builddir 2>/dev/null || true
             # Assemble a config directory where the checked-out mock/ configs
-            # override the copies baked into this image. mock requires
-            # site-defaults.cfg and logging.ini to exist in a custom
-            # --configdir, so take those two from the image; every profile
-            # .cfg comes from the repo mount. include() of absolute
-            # /etc/mock/... paths inside the profiles still resolves to the
-            # image, which is right — base chroot definitions belong to
-            # mock-core-configs, only the ci overlays belong to the repo.
+            # override the copies baked into this image: copy the WHOLE
+            # /etc/mock tree, then overlay the repo profiles on top.
+            #
+            # The whole tree, not just site-defaults.cfg and logging.ini. An
+            # include() of an ABSOLUTE path such as /etc/mock/fedora-44-x86_64.cfg
+            # resolves to the image, but that distro config then does a
+            # RELATIVE include of templates/fedora-branched.tpl, and relative
+            # includes resolve against --configdir, not /etc/mock — a
+            # configdir carrying only .cfg files orphans the templates
+            # directory and mock dies with: Could not find included config
+            # file: /tmp/mock-configdir/templates/fedora-branched.tpl
+            # (run 30654065913).
             mkdir -p /tmp/mock-configdir
-            cp /etc/mock/site-defaults.cfg /etc/mock/logging.ini /tmp/mock-configdir/
+            cp -a /etc/mock/. /tmp/mock-configdir/
             cp /repo-mock/*.cfg /tmp/mock-configdir/
             chmod -R a+rX /tmp/mock-configdir
             # Use flock to ensure only one process runs mock at a time

--- a/src/xfce-wayland/libxfce4ui/libxfce4ui.spec
+++ b/src/xfce-wayland/libxfce4ui/libxfce4ui.spec
@@ -13,6 +13,9 @@ BuildRequires: libSM-devel
 BuildRequires: startup-notification-devel
 BuildRequires: libgtop2-devel, libepoxy-devel, libgudev-devel
 BuildRequires: gobject-introspection-devel, vala, intltool, gettext
+# Same as xfconf: meson.build does find_program('xdt-gen-visibility',
+# required: true), and that script ships in xfce4-dev-tools.
+BuildRequires: xfce4-dev-tools
 %description
 Common UI library for Xfce desktop environment.
 

--- a/src/xfce-wayland/libxfce4ui/packaging/arch/PKGBUILD
+++ b/src/xfce-wayland/libxfce4ui/packaging/arch/PKGBUILD
@@ -16,7 +16,10 @@ depends=('gtk3' 'libxfce4util' 'xfconf' 'libsm' 'startup-notification'
          'libgtop' 'libepoxy' 'libgudev')
 # glib2-devel: glib-genmarshal, needed by meson's glib-2.0 probe at
 # configure time (see xfconf's PKGBUILD — same upstream meson.build pattern).
-makedepends=('meson' 'ninja' 'gobject-introspection' 'vala' 'intltool' 'gettext' 'glib2-devel')
+# xfce4-dev-tools: meson.build does find_program('xdt-gen-visibility',
+# required: true) at configure time; it is not in Arch's meson package.
+makedepends=('meson' 'ninja' 'gobject-introspection' 'vala' 'intltool' 'gettext' 'glib2-devel'
+             'xfce4-dev-tools')
 provides=('libxfce4ui-2.so' 'libxfce4kbd-private-3.so')
 source=("libxfce4ui-${_commit}.tar.gz::${url}/-/archive/${_commit}/libxfce4ui-${_commit}.tar.gz")
 sha256sums=('SKIP')

--- a/src/xfce-wayland/xfconf/packaging/arch/PKGBUILD
+++ b/src/xfce-wayland/xfconf/packaging/arch/PKGBUILD
@@ -23,7 +23,10 @@ depends=('glib2' 'dbus' 'libxfce4util')
 # glib-genmarshal lives in glib2-devel, not glib2 itself — meson's
 # glib-2.0 dependency probe needs it at configure time even though it is
 # never linked into the final binary.
-makedepends=('meson' 'ninja' 'gobject-introspection' 'vala' 'intltool' 'gettext' 'glib2-devel')
+# xfce4-dev-tools: meson.build does find_program('xdt-gen-visibility',
+# required: true) at configure time; it is not in Arch's meson package.
+makedepends=('meson' 'ninja' 'gobject-introspection' 'vala' 'intltool' 'gettext' 'glib2-devel'
+             'xfce4-dev-tools')
 provides=('libxfconf-0.so')
 source=("xfconf-${_commit}.tar.gz::${url}/-/archive/${_commit}/xfconf-${_commit}.tar.gz")
 # SKIP is a scaffold placeholder — fill in before this is trusted.

--- a/src/xfce-wayland/xfconf/xfconf.spec
+++ b/src/xfce-wayland/xfconf/xfconf.spec
@@ -10,6 +10,13 @@ Source0: https://gitlab.xfce.org/xfce/xfconf/-/archive/%{commit}/xfconf-%{commit
 BuildRequires: gcc, meson, ninja-build
 BuildRequires: glib2-devel, dbus-devel, libxfce4util-devel
 BuildRequires: gobject-introspection-devel, vala, intltool, gettext
+# xdt-gen-visibility (from xfce4-dev-tools) generates the symbol visibility
+# header; meson.build calls find_program(..., required: true) for it, so
+# meson setup fails before compiling anything without it. Required even
+# though this commit has no autotools left: the script is independent of
+# xdt-autogen. Fedora 44 ships xfce4-dev-tools-4.20.0; the EL10 chain builds
+# it in the xfce-build-tools tier ahead of the core libs.
+BuildRequires: xfce4-dev-tools
 %description
 Xfce configuration daemon and library. Required by all Xfce components.
 
@@ -25,8 +32,9 @@ building against xfconf.
 %autosetup -n xfconf-%{commit}
 
 # This commit has fully migrated to meson (no configure.ac/autogen.sh at
-# all) — xfce4-dev-tools/autotools BuildRequires from the old spec are
-# gone; gtk-doc defaults to false in meson_options.txt already.
+# all), so nothing here runs xdt-autogen; gtk-doc defaults to false in
+# meson_options.txt already. xfce4-dev-tools is still a BuildRequires for
+# xdt-gen-visibility alone (see above).
 %build
 %meson
 %meson_build

--- a/src/xfce-wayland/xfwl4/packaging/arch/PKGBUILD
+++ b/src/xfce-wayland/xfwl4/packaging/arch/PKGBUILD
@@ -12,7 +12,7 @@ pkgver=4.21.0
 pkgrel=1
 _commit=6b38df6562e52bdb3d3c827c25e713d9f71d0fe8
 # Custom XFCE Wayland protocol XML — a git submodule, absent from the archive.
-_protocols_commit=6082cfa492154aec266527193bf8f6142ab14977
+_protocols_commit=55dbf3e3d2a91b525c528c0dd4c1a7805a99364b
 pkgdesc="Wayland compositor for Xfce4"
 arch=('x86_64')
 url="https://gitlab.xfce.org/xfce/xfwl4"

--- a/src/xfce-wayland/xfwl4/xfwl4.spec
+++ b/src/xfce-wayland/xfwl4/xfwl4.spec
@@ -18,7 +18,7 @@ Source0: https://gitlab.xfce.org/xfce/xfwl4/-/archive/%{commit}/xfwl4-%{commit}.
 # Pre-vendored with `cargo vendor` against this exact commit's Cargo.lock
 # (crates.io deps + the smithay git dep); see release notes for how it
 # was generated if it ever needs regenerating after a Cargo.lock bump.
-Source1: https://github.com/tuna-os/tunaos-packages/releases/download/xfwl4-vendor-465880f6/vendor.tar.gz
+Source1: https://github.com/tuna-os/tunaos-packages/releases/download/xfwl4-vendor-6b38df65/vendor.tar.gz
 # resources/xfce-wayland-protocols is a git submodule (custom XFCE Wayland
 # protocol XML: output-management, input-device-list, etc.) — not included
 # in the plain archive tarball, same as any other git submodule. Referenced
@@ -65,9 +65,9 @@ cat > .cargo/config.toml <<'EOF'
 [source.crates-io]
 replace-with = "vendored-sources"
 
-[source."git+https://github.com/smithay/smithay?rev=4645e03d6bd9377aa368de20e91d69951450392d"]
+[source."git+https://github.com/smithay/smithay?rev=0a29aecf9e07a2227712ab470b0ab0ee56752272"]
 git = "https://github.com/smithay/smithay"
-rev = "4645e03d6bd9377aa368de20e91d69951450392d"
+rev = "0a29aecf9e07a2227712ab470b0ab0ee56752272"
 replace-with = "vendored-sources"
 
 [source.vendored-sources]

--- a/src/xfce-wayland/xfwl4/xfwl4.spec
+++ b/src/xfce-wayland/xfwl4/xfwl4.spec
@@ -1,5 +1,9 @@
 %global commit 6b38df6562e52bdb3d3c827c25e713d9f71d0fe8
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
+# resources/xfce-wayland-protocols submodule gitlink at %{commit}. It must be
+# bumped in lockstep with it: the XML defines the interfaces, requests and
+# events src/protocols/*.rs generates its server code from.
+%global protocols_commit 55dbf3e3d2a91b525c528c0dd4c1a7805a99364b
 %global cargo_name xfwl4
 # Rust binaries don't produce the source-file manifest find-debuginfo.sh
 # expects for a separate debugsource subpackage (common across cargo-built
@@ -24,7 +28,7 @@ Source1: https://github.com/tuna-os/tunaos-packages/releases/download/xfwl4-vend
 # in the plain archive tarball, same as any other git submodule. Referenced
 # by relative path in src/protocols/*.rs's wayland_scanner::generate_*!
 # macros, so it just needs to land at resources/xfce-wayland-protocols/.
-Source2: https://gitlab.xfce.org/xfce/xfce-wayland-protocols/-/archive/6082cfa492154aec266527193bf8f6142ab14977/xfce-wayland-protocols-6082cfa492154aec266527193bf8f6142ab14977.tar.gz
+Source2: https://gitlab.xfce.org/xfce/xfce-wayland-protocols/-/archive/%{protocols_commit}/xfce-wayland-protocols-%{protocols_commit}.tar.gz
 # Upstream bug: WlrBufferConstraints.dma's cfg gate doesn't include the
 # udev feature, but three call sites already guard access to it under
 # udev too — a udev-only build (ours) fails to compile as a result.


### PR DESCRIPTION
main has been red on both XFCE Wayland workflows since 14:08, surviving three unrelated renovate merges. Two independent root causes, both needed for either workflow's xfwl4 build to go green (#170 has the automerge-signal context):

**1. mock's package_state plugin vs rpm 6 (toolchain).** mock ≤ 6.7 queries the chroot rpmdb with `--qf '... %{pkgid} ...'`; Fedora 44's rpm 6 removed the md5-based `pkgid` tag, so every fedora-44 build died at `error: incorrect format: unknown tag: "pkgid"` before compiling anything (run 30651060582 — the failing command is mock's own `util.py:558`, not build-chain.sh; nothing in this repo says pkgid). Upstream removed the tag in [edec6023](https://github.com/rpm-software-management/mock/commit/edec6023) (2026-04-21) but no mock release since 6.7 (2026-03-03) carries it. The plugin only writes `installed_pkgs.log`/`available_pkgs.log`, so it is disabled for the fedora-44 chroot until a fixed mock ships in the runner image.

**2. Stale cargo vendor archive (content).** The renovate digest bump moved xfwl4 to commit `6b38df6`, whose Cargo.lock pins smithay at git rev `0a29aecf` — but the vendor archive (`xfwl4-vendor-465880f6`) and the spec's source-replacement config still carried rev `4645e03d`, so the offline EL10 build died in %build with `failed to get 'smithay' as a dependency ... you are in the offline mode` (run 30651061098). Regenerated with `cargo vendor` against the new commit's lockfile and published as [xfwl4-vendor-6b38df65](https://github.com/tuna-os/tunaos-packages/releases/tag/xfwl4-vendor-6b38df65); spec updated to the new archive and rev.

**3. xdt-gen-visibility missing from two specs (content).** With the pkgid break out of the way, the fedora-44 chain got far enough to expose a third regression from the same renovate wave: the xfconf and libxfce4ui digest bumps (#150 to `dd8d87b`, #147 to `76e4d0f`) moved both projects onto commits whose `meson.build` does `find_program('xdt-gen-visibility', required: true)`, and neither spec BuildRequires `xfce4-dev-tools`, which ships that script. Both died at `meson.build:35:21: ERROR: Program 'xdt-gen-visibility' not found or not executable` (run 30652383636), and xfwl4 then probed Fedora's stock 4.20.2 `libxfce4kbd-private-3` instead of our 4.21.7, failing with `Package 'libxfce4kbd-private-3' has version '4.20.2', required version is '>= 4.21.4'`. Fedora 44 ships `xfce4-dev-tools-4.20.0-4.fc44`; the EL10 chain already builds it in the `xfce-build-tools` tier ahead of the core libs, so one BuildRequires per spec covers both workflows.

**4. Stale `xfce-wayland-protocols` submodule pin (content).** With the vendor archive fixed the EL10 build finally reached `cargo build` and died with 40 errors in the generated protocol code (run 30652382389): unresolved `xfce_foreign_toplevel_icon_pixels_v1` and `xfce_output_management_manager_private_v1` modules, missing requests (`Move`/`Resize`/`Highlight`/`GetIconPixels`/`MoveToWorkspace`), missing events (`icon_size`, `workspace_enter`, `edid`, `primary`, `workarea`, `pointer_enter`, `done`), and `WLR_FOREIGN_TOPLEVEL_HANDLE_V1_INTERFACE` / `xdg_ouput` lookups that match nothing the source imports. All of it traces to `Source2`, which still pinned `xfce-wayland-protocols` at `6082cfa4` while xfwl4's own submodule gitlink at commit `6b38df6` is [`55dbf3e3`](https://gitlab.xfce.org/xfce/xfce-wayland-protocols/-/commit/55dbf3e3d2a91b525c528c0dd4c1a7805a99364b): the renovate digest bump moved the Rust source but not the protocol XML the `wayland_scanner::generate_*!` macros read, so the generated server code no longer matched `src/protocols/*.rs`. `55dbf3e3` carries every missing interface and matches the source's imports (`zwlr_foreign_toplevel_handle_v1`, `ext_workspace_handle_v1`, single-arg `icon_name`). It is now pinned via `%global protocols_commit` so the two commits stay visibly coupled, with the same bump applied to the arch PKGBUILD, which pins the same xfwl4 commit.

**5. The Arch gate never ran its build at all (CI plumbing).** `xfce Wayland (Arch, throwaway)` triggers on the arch packaging dirs, so the PKGBUILD bump above woke it up, and it turns out it has failed on every run since it was added: the container script was written to the runner's `/tmp/run.sh`, but only `/tmp/arch-build` is mounted (at `/work`), so each run died at `bash: /tmp/run.sh: No such file or directory` before pacman started (run 30654064655, and identically on every renovate run back to 13:35). Script now lands in the bind mount and is invoked as `/work/run.sh`. With it reachable the build hit `arch-meson: command not found`: makepkg ran `--nodeps` against a hand-written pacman list missing `meson`, `ninja`, `gobject-introspection`, `vala` and `intltool`, so builder now gets NOPASSWD sudo and makepkg runs `--syncdeps`, which installs what the PKGBUILDs actually declare instead of a duplicate list free to drift. That in turn surfaced the Arch counterpart of root cause 3: `xfce4-dev-tools` was missing from xfconf's and libxfce4ui's `makedepends`. Verified end-to-end in an archlinux container using the exact script the workflow now writes: xfconf 4.21.2, libxfce4ui 4.21.7 and xfwl4 4.21.0 all build and install in order, which independently confirms root cause 4's protocol pin.

Note the failure-mode asymmetry: the pkgid break was pure toolchain (no merge caused it — the fedora-44 chroot's rpm moved underneath us); the vendor break *was* caused by a renovate digest merge that platformAutomerge waved through while the gate was already red for reason 1. That is exactly the #170 concern in action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->


