### PR TITLE
fix(input-remapper): add gate matrix cell and verify block

### DIFF
--- a/.github/workflows/build-tideforge-supported.yml
+++ b/.github/workflows/build-tideforge-supported.yml
@@ -581,9 +581,17 @@ jobs:
           if-no-files-found: warn
 
   input-remapper-rpm:
-    name: input-remapper (el10 staged closure RPM)
+    name: ${{ matrix.package }} (el10 staged closure RPM)
     needs: rpm
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: input-remapper
+            target: el10
+            install_name: input-remapper
+            smoke: test -x /usr/bin/input-remapper-gtk && test -x /usr/bin/input-remapper-service && test -x /usr/bin/input-remapper-control && test -f /usr/lib/udev/rules.d/99-input-remapper.rules && test -f /usr/lib/systemd/system/input-remapper.service && test -f /usr/share/polkit-1/actions/input-remapper.policy && test -f /usr/share/dbus-1/system.d/inputremapper.Control.conf
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -593,12 +601,12 @@ jobs:
       - uses: actions/download-artifact@v7
         with:
           name: python3-evdev-el10-rpm
-          path: .tideforge/input-remapper/prerequisite
+          path: .tideforge/${{ matrix.package }}/prerequisite
       - name: Render and fetch the exact input-remapper source archive
         run: |
           set -euo pipefail
-          recipe=packages/input-remapper/package.yaml
-          root="$PWD/.tideforge/input-remapper"
+          recipe=packages/${{ matrix.package }}/package.yaml
+          root="$PWD/.tideforge/${{ matrix.package }}"
           python3 scripts/tideforge.py validate "$recipe"
           python3 scripts/verify-tideforge-source.py "$recipe"
           python3 scripts/tideforge.py render "$recipe" --target el10 --output "$root/rpmbuild/SPECS"
@@ -609,7 +617,7 @@ jobs:
       - name: Build input-remapper with staged python3-evdev
         run: |
           set -euo pipefail
-          root="$PWD/.tideforge/input-remapper"
+          root="$PWD/.tideforge/${{ matrix.package }}"
           docker run --rm --volume "$root:/work" quay.io/centos/centos:stream10 bash -lc '
             set -euo pipefail
             dnf -y install dnf-plugins-core epel-release rpm-build createrepo_c
@@ -624,7 +632,7 @@ jobs:
       - name: Clean-install input-remapper with the full closure
         run: |
           set -euo pipefail
-          root="$PWD/.tideforge/input-remapper"
+          root="$PWD/.tideforge/${{ matrix.package }}"
           docker run --rm --volume "$root:/work:ro" quay.io/centos/centos:stream10 bash -lc '
             set -euo pipefail
             dnf -y install epel-release createrepo_c
@@ -645,7 +653,7 @@ jobs:
       - uses: actions/upload-artifact@v6
         if: always()
         with:
-          name: input-remapper-el10-staged-closure-rpm
+          name: ${{ matrix.package }}-el10-staged-closure-rpm
           path: .tideforge/input-remapper/rpmbuild/RPMS/
           if-no-files-found: warn
 

--- a/packages/input-remapper/package.yaml
+++ b/packages/input-remapper/package.yaml
@@ -128,6 +128,14 @@ files:
     # Version-globbed: install/module.py picks the interpreter's own
     # site-packages, so pinning a minor version here would break on rebase.
     - usr/lib/python3*/site-packages/inputremapper/
+    # install/module.py installs the python module with
+    # `pip install . --target <site-packages> --no-deps`, which also writes the
+    # metadata directory next to it (INSTALLER, METADATA, WHEEL, RECORD,
+    # licenses/LICENSE, ...).  Leaving it out fails the build with "Installed
+    # (but unpackaged) file(s) found".  The name is pip's normalised
+    # distribution name (underscore), not the module name, and the {dist,egg}
+    # brace matches whichever metadata flavour upstream's installer produces.
+    - usr/lib/python3*/site-packages/input_remapper-*.{dist,egg}-info/
 verify:
   install_name: input-remapper
   smoke: test -x /usr/bin/input-remapper-gtk && test -x /usr/bin/input-remapper-service && test -x /usr/bin/input-remapper-control && test -f /usr/lib/udev/rules.d/99-input-remapper.rules && test -f /usr/lib/systemd/system/input-remapper.service && test -f /usr/share/polkit-1/actions/input-remapper.policy && test -f /usr/share/dbus-1/system.d/inputremapper.Control.conf

--- a/packages/input-remapper/package.yaml
+++ b/packages/input-remapper/package.yaml
@@ -118,4 +118,7 @@ files:
     # Version-globbed: install/module.py picks the interpreter's own
     # site-packages, so pinning a minor version here would break on rebase.
     - usr/lib/python3*/site-packages/inputremapper/
+verify:
+  install_name: input-remapper
+  smoke: test -x /usr/bin/input-remapper-gtk && test -x /usr/bin/input-remapper-service && test -x /usr/bin/input-remapper-control && test -f /usr/lib/udev/rules.d/99-input-remapper.rules && test -f /usr/lib/systemd/system/input-remapper.service && test -f /usr/share/polkit-1/actions/input-remapper.policy && test -f /usr/share/dbus-1/system.d/inputremapper.Control.conf
 targets: [el10, arch]

--- a/packages/input-remapper/package.yaml
+++ b/packages/input-remapper/package.yaml
@@ -38,9 +38,19 @@ source:
   directory: input-remapper-2.2.1
 build_system: custom
 build:
-  # Everything happens in the install step.  Upstream's installer compiles the
-  # translations itself (install.language.make_lang), so there is no separate
-  # build phase to run.
+  # install/module.py bakes the build's commit into installation_info.py via
+  # `subprocess.check_output(["git", "rev-parse", "HEAD"])`, with no fallback:
+  # missing git raises FileNotFoundError and a release tarball is not a git
+  # checkout, so `git rev-parse HEAD` would raise CalledProcessError even with
+  # git installed.  Either way %install dies.  Substituting the commit the
+  # 2.2.1 tag points at records the same value a git build would, without
+  # needing git or a repository.  The grep fails the build loudly if a rebase
+  # moves that call, rather than silently shipping COMMIT_HASH unset.
+  prepare:
+    - sed -i 's|subprocess.check_output(.*rev-parse.*)|b"e9a87d13480c3b1dee654b296578a8f4e2cd31d6"|' install/module.py
+    - grep -q 'git_call = b"e9a87d13480c3b1dee654b296578a8f4e2cd31d6"' install/module.py
+  # Nothing else to do here: upstream's installer compiles the translations
+  # itself (install.language.make_lang), so there is no separate build phase.
   commands:
     - ':'
 install:


### PR DESCRIPTION
## What

input-remapper-rpm was a standalone job with no `strategy.matrix.include`
entry, so `test_gate_verify_consistency.py` could not count it.

Changes:
1. Converted `input-remapper-rpm` to a matrix job with one `include:` entry
   containing `install_name` and `smoke` matching the actual assertions
2. Added `verify:` block to `packages/input-remapper/package.yaml` matching
   the gate cell byte-for-byte
3. Fixed the pre-existing `%install` failure that kept the cell red: upstream's
   `install/module.py` stamps `installation_info.py` with the output of
   `git rev-parse HEAD` and has no fallback, so the build died with
   `FileNotFoundError: 'git'`. Installing git would not help either, since a
   release tarball is not a checkout and `rev-parse` would then raise
   `CalledProcessError`. The recipe now substitutes the commit the `2.2.1` tag
   points at during `build.prepare`:

```yaml
  prepare:
    - sed -i 's|subprocess.check_output(.*rev-parse.*)|b"e9a87d13480c3b1dee654b296578a8f4e2cd31d6"|' install/module.py
    - grep -q 'git_call = b"e9a87d13480c3b1dee654b296578a8f4e2cd31d6"' install/module.py
```

The `grep` is the guard: if a version bump moves that call, the build fails
loudly instead of silently shipping `COMMIT_HASH` unset.

## What this does NOT do

input-remapper still needs python3-evdev as a staged prerequisite, so it stays
its own staged-closure job rather than joining the plain `rpm` matrix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->
