### PR TITLE
feat(tideforge): emit debian/copyright and drop libtool archives from debs

### DIFF
--- a/scripts/tideforge.py
+++ b/scripts/tideforge.py
@@ -763,11 +763,34 @@ Rules-Requires-Root: no
     # not auto-detect a testable build system, so they need no override.
     if recipe["build_system"] in {"meson", "cmake", "autotools"}:
         rules = rules.rstrip() + "\n\noverride_dh_auto_test:\n\t:\n"
+    # Delete libtool archives after staging, mirroring the rpm renderer's
+    # cleanup after %make_install. A libtool build ships .la files whose
+    # dependency_libs lintian flags as a policy error
+    # (non-empty-dependency_libs-in-la-file — libunwind-dev carried five of
+    # them), and Debian's answer is to not ship .la at all. Only autotools
+    # uses libtool; the other build systems never emit them.
+    if recipe["build_system"] == "autotools":
+        rules = rules.rstrip() + "\n\nexecute_after_dh_auto_install:\n\tfind debian -name '*.la' -delete\n"
     changelog = f"{recipe['name']} ({recipe['version']}-{recipe.get('release', 1)}) {target}; urgency=medium\n\n  * Generated from package.yaml.\n\n -- TunaOS Package Factory <packages@tunaos.org>  Thu, 01 Jan 1970 00:00:00 +0000\n"
+    # DEP-5 machine-readable copyright, derived from the recipe. dh_installdocs
+    # installs it into every binary package, which is what clears lintian's
+    # no-copyright-file error on the generated debs. The full license text
+    # lives in the upstream source distribution; the recipe's SPDX identifier
+    # names it.
+    copyright_file = f"""Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: {recipe['name']}
+Source: {recipe['source']['url']}
+
+Files: *
+Copyright: the {recipe['name']} upstream authors
+License: {recipe['license']}
+ See the upstream source distribution for the full license text.
+"""
     rendered = {
         "debian/control": control,
         "debian/rules": rules,
         "debian/changelog": changelog,
+        "debian/copyright": copyright_file,
         "debian/source/format": "3.0 (quilt)\n",
     }
     # Tideforge's Go, Cargo, and data renderers install directly into

--- a/tests/test_tideforge.py
+++ b/tests/test_tideforge.py
@@ -640,3 +640,31 @@ def test_data_deb_disables_debhelper_build_system_autodetection(recipe: dict) ->
     recipe["build_system"] = "data"
     rules = tideforge.render(recipe, "ubuntu")["debian/rules"]
     assert "dh $@ --buildsystem=none" in rules
+
+
+def test_deb_render_emits_machine_readable_copyright(recipe: dict) -> None:
+    # lintian: no-copyright-file was an error on every generated deb --
+    # nothing emitted debian/copyright. dh_installdocs installs this one into
+    # each binary package.
+    rendered = tideforge.render(recipe, "ubuntu")
+    copyright_file = rendered["debian/copyright"]
+    assert "Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/" in copyright_file
+    assert "Upstream-Name: hello-tuna" in copyright_file
+    assert "Source: https://example.com/hello-tuna-1.2.3.tar.gz" in copyright_file
+    assert "License: Apache-2.0" in copyright_file
+
+
+def test_autotools_deb_rules_delete_libtool_archives(recipe: dict) -> None:
+    # Mirrors the rpm renderer's post-%make_install cleanup: shipped .la files
+    # carry dependency_libs lintian rejects as a policy error
+    # (non-empty-dependency_libs-in-la-file, libunwind-dev x5). Only libtool
+    # emits them, so only the autotools rules carry the hook.
+    recipe["build_system"] = "autotools"
+    rules = tideforge.render(recipe, "ubuntu")["debian/rules"]
+    assert "execute_after_dh_auto_install:" in rules
+    assert "find debian -name '*.la' -delete" in rules
+
+
+def test_non_autotools_deb_rules_carry_no_libtool_cleanup(recipe: dict) -> None:
+    rules = tideforge.render(recipe, "ubuntu")["debian/rules"]
+    assert "*.la" not in rules


### PR DESCRIPTION
The held quality follow-up from the #172 triage (split out per review scope — it touches every generated deb).

Two renderer gaps, both visible as lintian **E** on every deb the factory produces (non-fatal today under the curated set, but policy errors nonetheless):

- **no-copyright-file** — nothing emitted `debian/copyright`. Now rendered as DEP-5 machine-readable from the recipe's name, `source.url`, and SPDX `license`; `dh_installdocs` installs it into every binary package.
- **non-empty-dependency_libs-in-la-file** (libunwind-dev ×5) — killed at the root: the autotools rules gain `execute_after_dh_auto_install: find debian -name '*.la' -delete`, the deb spelling of the rpm renderer's post-`%make_install` cleanup. Only libtool emits `.la`, so only autotools carries the hook.

Verification: 302 tests pass including three new ones; libunwind-devel's ubuntu render shows the copyright file and the hook (job artifacts will show the lintian report clean of both tags).

Once this is in, the two tags are candidates for `lint-generated-deb.sh`'s fatal set — deliberately not added here so the ratchet tightens on green, not red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->