### PR TITLE
feat(ci): add the GNOME 50 distributed build, the missing R2 seeding path

### DIFF
--- a/.github/workflows/build-gnome50-distributed.yml
+++ b/.github/workflows/build-gnome50-distributed.yml
@@ -1,0 +1,1536 @@
+name: GNOME 50 Distributed Build
+'on':
+  workflow_dispatch:
+    inputs:
+      force:
+        description: Force rebuild even if package exists in repo
+        type: boolean
+        default: false
+env:
+  R2_BUCKET: bluefin
+  LOCAL_REPO: ${{ github.workspace }}/local-repo
+  MOCK_RUNNER_IMAGE: ghcr.io/tuna-os/mock-runner:centos-stream-10
+jobs:
+  seed-repo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Configure rclone
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+
+          EOF
+
+          '
+      - name: Seed local repo from R2
+        run: 'mkdir -p local-repo
+
+          echo "Downloading existing repo from R2..."
+
+          rclone sync "r2:${R2_BUCKET}/gnome50/10-stream-x86_64/" "local-repo/" --exclude "repodata/**" || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Upload initial repo
+        uses: actions/upload-artifact@v4
+        with:
+          name: repo-0
+          path: local-repo
+          retention-days: 1
+  build-base-tools:
+    needs: seed-repo
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/deps/meson
+          - src/deps/autoconf
+          - src/deps/libldac
+          - src/deps/python-smartypants
+          - src/deps/python-typogrify
+          - src/deps/gnome50-el10-compat
+          - src/deps/selinux-policy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v4
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-0
+          path: local-repo
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v4
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/centos-stream-10-ci-gnome50.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier base-tools --package ${{ matrix.package }} --mock-config centos-stream-10-ci-gnome50)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpms-base-tools-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-base-tools:
+    needs: build-base-tools
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-0
+          path: local-repo
+      - name: Download new RPMs
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: rpms-base-tools-*
+          path: local-repo
+          merge-multiple: true
+      - name: Update repo
+        run: createrepo_c --update local-repo
+      - name: Upload updated repo
+        uses: actions/upload-artifact@v4
+        with:
+          name: repo-1
+          path: local-repo
+          retention-days: 1
+  build-build-tools:
+    needs: consolidate-base-tools
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/deps/wayland-protocols
+          - src/deps/harfbuzz
+          - src/deps/libxcvt
+          - src/deps/shaderc
+          - src/deps/gi-docgen
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v4
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-1
+          path: local-repo
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v4
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/centos-stream-10-ci-gnome50.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier build-tools --package ${{ matrix.package }} --mock-config centos-stream-10-ci-gnome50)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpms-build-tools-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-build-tools:
+    needs: build-build-tools
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-1
+          path: local-repo
+      - name: Download new RPMs
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: rpms-build-tools-*
+          path: local-repo
+          merge-multiple: true
+      - name: Update repo
+        run: createrepo_c --update local-repo
+      - name: Upload updated repo
+        uses: actions/upload-artifact@v4
+        with:
+          name: repo-2
+          path: local-repo
+          retention-days: 1
+  build-glib2-bootstrap:
+    needs: consolidate-build-tools
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/gnome-50/glib2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v4
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-2
+          path: local-repo
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v4
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/centos-stream-10-ci-gnome50.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier glib2-bootstrap --package ${{ matrix.package }} --mock-config centos-stream-10-ci-gnome50)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpms-glib2-bootstrap-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-glib2-bootstrap:
+    needs: build-glib2-bootstrap
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-2
+          path: local-repo
+      - name: Download new RPMs
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: rpms-glib2-bootstrap-*
+          path: local-repo
+          merge-multiple: true
+      - name: Update repo
+        run: createrepo_c --update local-repo
+      - name: Upload updated repo
+        uses: actions/upload-artifact@v4
+        with:
+          name: repo-3
+          path: local-repo
+          retention-days: 1
+  build-bootstrap-libs:
+    needs: consolidate-glib2-bootstrap
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/deps/libei
+          - src/deps/mozjs140
+          - src/deps/libzip
+          - src/deps/fontconfig
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v4
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-3
+          path: local-repo
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v4
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/centos-stream-10-ci-gnome50.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier bootstrap-libs --package ${{ matrix.package }} --mock-config centos-stream-10-ci-gnome50)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpms-bootstrap-libs-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-bootstrap-libs:
+    needs: build-bootstrap-libs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-3
+          path: local-repo
+      - name: Download new RPMs
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: rpms-bootstrap-libs-*
+          path: local-repo
+          merge-multiple: true
+      - name: Update repo
+        run: createrepo_c --update local-repo
+      - name: Upload updated repo
+        uses: actions/upload-artifact@v4
+        with:
+          name: repo-4
+          path: local-repo
+          retention-days: 1
+  build-cairo-layer:
+    needs: consolidate-bootstrap-libs
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/deps/cairo
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v4
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-4
+          path: local-repo
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v4
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/centos-stream-10-ci-gnome50.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier cairo-layer --package ${{ matrix.package }} --mock-config centos-stream-10-ci-gnome50)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpms-cairo-layer-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-cairo-layer:
+    needs: build-cairo-layer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-4
+          path: local-repo
+      - name: Download new RPMs
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: rpms-cairo-layer-*
+          path: local-repo
+          merge-multiple: true
+      - name: Update repo
+        run: createrepo_c --update local-repo
+      - name: Upload updated repo
+        uses: actions/upload-artifact@v4
+        with:
+          name: repo-5
+          path: local-repo
+          retention-days: 1
+  build-gi-bootstrap:
+    needs: consolidate-cairo-layer
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/gnome-50/gobject-introspection
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v4
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-5
+          path: local-repo
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v4
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/centos-stream-10-ci-gnome50.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier gi-bootstrap --package ${{ matrix.package }} --mock-config centos-stream-10-ci-gnome50)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpms-gi-bootstrap-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-gi-bootstrap:
+    needs: build-gi-bootstrap
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-5
+          path: local-repo
+      - name: Download new RPMs
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: rpms-gi-bootstrap-*
+          path: local-repo
+          merge-multiple: true
+      - name: Update repo
+        run: createrepo_c --update local-repo
+      - name: Upload updated repo
+        uses: actions/upload-artifact@v4
+        with:
+          name: repo-6
+          path: local-repo
+          retention-days: 1
+  build-glib2-full:
+    needs: consolidate-gi-bootstrap
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/gnome-50/glib2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v4
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-6
+          path: local-repo
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v4
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/centos-stream-10-ci-gnome50.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier glib2-full --package ${{ matrix.package }} --mock-config centos-stream-10-ci-gnome50)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpms-glib2-full-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-glib2-full:
+    needs: build-glib2-full
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-6
+          path: local-repo
+      - name: Download new RPMs
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: rpms-glib2-full-*
+          path: local-repo
+          merge-multiple: true
+      - name: Update repo
+        run: createrepo_c --update local-repo
+      - name: Upload updated repo
+        uses: actions/upload-artifact@v4
+        with:
+          name: repo-7
+          path: local-repo
+          retention-days: 1
+  build-gi-full:
+    needs: consolidate-glib2-full
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/gnome-50/gobject-introspection
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v4
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-7
+          path: local-repo
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v4
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/centos-stream-10-ci-gnome50.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier gi-full --package ${{ matrix.package }} --mock-config centos-stream-10-ci-gnome50)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpms-gi-full-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-gi-full:
+    needs: build-gi-full
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-7
+          path: local-repo
+      - name: Download new RPMs
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: rpms-gi-full-*
+          path: local-repo
+          merge-multiple: true
+      - name: Update repo
+        run: createrepo_c --update local-repo
+      - name: Upload updated repo
+        uses: actions/upload-artifact@v4
+        with:
+          name: repo-8
+          path: local-repo
+          retention-days: 1
+  build-core-libraries:
+    needs: consolidate-gi-full
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/deps/pango
+          - src/deps/tinysparql
+          - src/deps/pipewire
+          - src/deps/libglib-testing
+          - src/deps/libsoup
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v4
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-8
+          path: local-repo
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v4
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/centos-stream-10-ci-gnome50.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier core-libraries --package ${{ matrix.package }} --mock-config centos-stream-10-ci-gnome50)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpms-core-libraries-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-core-libraries:
+    needs: build-core-libraries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-8
+          path: local-repo
+      - name: Download new RPMs
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: rpms-core-libraries-*
+          path: local-repo
+          merge-multiple: true
+      - name: Update repo
+        run: createrepo_c --update local-repo
+      - name: Upload updated repo
+        uses: actions/upload-artifact@v4
+        with:
+          name: repo-9
+          path: local-repo
+          retention-days: 1
+  build-system-tools:
+    needs: consolidate-core-libraries
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/deps/umockdev
+          - src/deps/python-dbusmock
+          - src/deps/avahi
+          - src/gnome-50/gjs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v4
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-9
+          path: local-repo
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v4
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/centos-stream-10-ci-gnome50.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier system-tools --package ${{ matrix.package }} --mock-config centos-stream-10-ci-gnome50)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpms-system-tools-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-system-tools:
+    needs: build-system-tools
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-9
+          path: local-repo
+      - name: Download new RPMs
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: rpms-system-tools-*
+          path: local-repo
+          merge-multiple: true
+      - name: Update repo
+        run: createrepo_c --update local-repo
+      - name: Upload updated repo
+        uses: actions/upload-artifact@v4
+        with:
+          name: repo-10
+          path: local-repo
+          retention-days: 1
+  build-gtk-core:
+    needs: consolidate-system-tools
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/gnome-50/gsettings-desktop-schemas
+          - src/gnome-50/gnome-desktop3
+          - src/deps/gtk4
+          - src/deps/glycin
+          - src/deps/libgda
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v4
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-10
+          path: local-repo
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v4
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/centos-stream-10-ci-gnome50.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier gtk-core --package ${{ matrix.package }} --mock-config centos-stream-10-ci-gnome50)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpms-gtk-core-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-gtk-core:
+    needs: build-gtk-core
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-10
+          path: local-repo
+      - name: Download new RPMs
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: rpms-gtk-core-*
+          path: local-repo
+          merge-multiple: true
+      - name: Update repo
+        run: createrepo_c --update local-repo
+      - name: Upload updated repo
+        uses: actions/upload-artifact@v4
+        with:
+          name: repo-11
+          path: local-repo
+          retention-days: 1
+  build-desktop-foundations:
+    needs: consolidate-gtk-core
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/gnome-50/libadwaita
+          - src/gnome-50/xdg-desktop-portal
+          - src/deps/localsearch
+          - src/deps/vte291
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v4
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-11
+          path: local-repo
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v4
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/centos-stream-10-ci-gnome50.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier desktop-foundations --package ${{ matrix.package }} --mock-config centos-stream-10-ci-gnome50)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpms-desktop-foundations-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-desktop-foundations:
+    needs: build-desktop-foundations
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-11
+          path: local-repo
+      - name: Download new RPMs
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: rpms-desktop-foundations-*
+          path: local-repo
+          merge-multiple: true
+      - name: Update repo
+        run: createrepo_c --update local-repo
+      - name: Upload updated repo
+        uses: actions/upload-artifact@v4
+        with:
+          name: repo-12
+          path: local-repo
+          retention-days: 1
+  build-parental-controls:
+    needs: consolidate-desktop-foundations
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/deps/malcontent
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v4
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-12
+          path: local-repo
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v4
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/centos-stream-10-ci-gnome50.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier parental-controls --package ${{ matrix.package }} --mock-config centos-stream-10-ci-gnome50)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpms-parental-controls-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-parental-controls:
+    needs: build-parental-controls
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-12
+          path: local-repo
+      - name: Download new RPMs
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: rpms-parental-controls-*
+          path: local-repo
+          merge-multiple: true
+      - name: Update repo
+        run: createrepo_c --update local-repo
+      - name: Upload updated repo
+        uses: actions/upload-artifact@v4
+        with:
+          name: repo-13
+          path: local-repo
+          retention-days: 1
+  build-shell-foundations:
+    needs: consolidate-parental-controls
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/gnome-50/gnome-settings-daemon
+          - src/gnome-50/mutter
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v4
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-13
+          path: local-repo
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v4
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/centos-stream-10-ci-gnome50.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier shell-foundations --package ${{ matrix.package }} --mock-config centos-stream-10-ci-gnome50)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpms-shell-foundations-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-shell-foundations:
+    needs: build-shell-foundations
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-13
+          path: local-repo
+      - name: Download new RPMs
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: rpms-shell-foundations-*
+          path: local-repo
+          merge-multiple: true
+      - name: Update repo
+        run: createrepo_c --update local-repo
+      - name: Upload updated repo
+        uses: actions/upload-artifact@v4
+        with:
+          name: repo-14
+          path: local-repo
+          retention-days: 1
+  build-gnome-shell:
+    needs: consolidate-shell-foundations
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/gnome-50/gnome-shell
+          - src/gnome-50/xdg-desktop-portal-gnome
+          - src/gnome-50/nautilus
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v4
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-14
+          path: local-repo
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v4
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/centos-stream-10-ci-gnome50.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier gnome-shell --package ${{ matrix.package }} --mock-config centos-stream-10-ci-gnome50)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpms-gnome-shell-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-gnome-shell:
+    needs: build-gnome-shell
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-14
+          path: local-repo
+      - name: Download new RPMs
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: rpms-gnome-shell-*
+          path: local-repo
+          merge-multiple: true
+      - name: Update repo
+        run: createrepo_c --update local-repo
+      - name: Upload updated repo
+        uses: actions/upload-artifact@v4
+        with:
+          name: repo-15
+          path: local-repo
+          retention-days: 1
+  build-session-layer:
+    needs: consolidate-gnome-shell
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/gnome-50/gnome-session
+          - src/gnome-50/gnome-control-center
+          - src/gnome-50/gdm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v4
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-15
+          path: local-repo
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v4
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/centos-stream-10-ci-gnome50.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier session-layer --package ${{ matrix.package }} --mock-config centos-stream-10-ci-gnome50)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpms-session-layer-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-session-layer:
+    needs: build-session-layer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-15
+          path: local-repo
+      - name: Download new RPMs
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: rpms-session-layer-*
+          path: local-repo
+          merge-multiple: true
+      - name: Update repo
+        run: createrepo_c --update local-repo
+      - name: Upload updated repo
+        uses: actions/upload-artifact@v4
+        with:
+          name: repo-16
+          path: local-repo
+          retention-days: 1
+  build-post-session:
+    needs: consolidate-session-layer
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/gnome-50/gnome-initial-setup
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v4
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-16
+          path: local-repo
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v4
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/centos-stream-10-ci-gnome50.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/centos-stream-10-ci-gnome50.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier post-session --package ${{ matrix.package }} --mock-config centos-stream-10-ci-gnome50)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpms-post-session-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-post-session:
+    needs: build-post-session
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download previous repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-16
+          path: local-repo
+      - name: Download new RPMs
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: rpms-post-session-*
+          path: local-repo
+          merge-multiple: true
+      - name: Update repo
+        run: createrepo_c --update local-repo
+      - name: Upload updated repo
+        uses: actions/upload-artifact@v4
+        with:
+          name: repo-17
+          path: local-repo
+          retention-days: 1
+  publish:
+    needs: consolidate-post-session
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: 'sudo apt-get update -q && sudo apt-get install -y -q rpm createrepo-c gpg gpgconf
+
+          curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          '
+      - name: Download final repo
+        uses: actions/download-artifact@v4
+        with:
+          name: repo-17
+          path: local-repo
+      - name: Import GPG key
+        id: import-gpg
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_committer_name: RPM Builder
+          git_committer_email: rpm-signing@tunaos.org
+      - name: Configure RPM macros
+        run: 'echo "%_signature gpg" > ~/.rpmmacros
+
+          echo "%_gpg_name ${{ steps.import-gpg.outputs.keyid }}" >> ~/.rpmmacros
+
+          echo "%__gpg_sign_cmd %{__gpg} gpg --batch --no-verbose --no-armor --use-agent --no-secmem-warning -u \"%{_gpg_name}\" -sbo %{__signature_filename} %{__plaintext_filename}" >> ~/.rpmmacros
+
+          '
+      - name: Sign RPMs
+        run: 'find local-repo -name "*.rpm" -exec rpmsign --addsign {} \;
+
+          createrepo_c --update local-repo
+
+          '
+      - name: Configure rclone
+        run: 'mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+
+          EOF
+
+          '
+      - name: Upload to R2
+        run: 'echo "Uploading to 10-stream-x86_64..."
+
+          rclone sync local-repo/ "r2:${R2_BUCKET}/gnome50/10-stream-x86_64/"
+
+          rclone copyto public.gpg "r2:${R2_BUCKET}/public.gpg"
+
+          rclone copyto contrib/install.sh "r2:${R2_BUCKET}/install.sh"
+
+          '

--- a/scripts/generate-distributed-workflow.py
+++ b/scripts/generate-distributed-workflow.py
@@ -6,7 +6,7 @@ import os
 def generate_workflow(manifest_path, output_path, workflow_name='Distributed Build and Publish RPMs',
                       r2_path='repo/10-stream-x86_64', secondary_r2_path='repo/10-x86_64',
                       install_script='contrib/install.sh', install_r2_dest='install.sh',
-                      submodules=True):
+                      submodules=True, mock_config=None):
     with open(manifest_path, 'r') as f:
         manifest = yaml.safe_load(f)
 
@@ -58,6 +58,13 @@ def generate_workflow(manifest_path, output_path, workflow_name='Distributed Bui
     
     # Build --manifest flag for build-chain.sh (only needed for non-default manifest)
     manifest_flag = f' --manifest {manifest_filename}' if manifest_filename != 'build-order.yml' else ''
+    # Chroot selection. GNOME 49 builds in build-chain.sh's default chroot,
+    # but GNOME 50 has its own mock config (extra repos, tmpfs opts), and a
+    # generated workflow that silently built in the wrong chroot would only
+    # fail once a package needed one of those repos. The cache keys hash the
+    # SELECTED config, not the default one, for the same reason.
+    mock_flag = f' --mock-config {mock_config}' if mock_config else ''
+    mock_cfg_file = f'mock/{mock_config}.cfg' if mock_config else 'mock/centos-stream-10-ci.cfg'
 
     for i, tier in enumerate(tiers):
         tier_name = tier['name']
@@ -80,11 +87,11 @@ def generate_workflow(manifest_path, output_path, workflow_name='Distributed Bui
             'steps': [
                 {'name': 'Checkout', 'uses': 'actions/checkout@v4', **({'with': {'submodules': 'recursive'}} if submodules else {})},
                 {'name': 'Install host dependencies', 'run': 'sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm'},
-                {'name': 'Cache CentOS Stream 10 image', 'uses': 'actions/cache@v4', 'with': {'path': '/tmp/cs10-image.tar', 'key': "cs10-image-${{ hashFiles('mock/centos-stream-10-ci.cfg') }}"}},
+                {'name': 'Cache CentOS Stream 10 image', 'uses': 'actions/cache@v4', 'with': {'path': '/tmp/cs10-image.tar', 'key': f"cs10-image-${{{{ hashFiles('{mock_cfg_file}') }}}}"}},
                 {'name': 'Load or pull image', 'run': 'if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n'},
                 {'name': 'Download previous repo', 'uses': 'actions/download-artifact@v4', 'with': {'name': prev_tier_repo, 'path': 'local-repo'}},
-                {'name': 'Cache mock chroot (dnf downloads)', 'uses': 'actions/cache@v4', 'with': {'path': '.mock-cache', 'key': "mock-cache-${{ matrix.package }}-${{ hashFiles('mock/centos-stream-10-ci.cfg') }}-${{ github.run_id }}", 'restore-keys': "mock-cache-${{ matrix.package }}-${{ hashFiles('mock/centos-stream-10-ci.cfg') }}-\nmock-cache-${{ matrix.package }}-"}},
-                {'name': 'Build package', 'env': {'MOCK_CACHE_DIR': '${{ github.workspace }}/.mock-cache'}, 'run': f'touch .build-marker\nARGS=(--backend podman --tier {tier_name} --package ${{{{ matrix.package }}}}{manifest_flag})\nif [[ "${{{{ github.event.inputs.force }}}}" == "true" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh "${{ARGS[@]}}"\n'},
+                {'name': 'Cache mock chroot (dnf downloads)', 'uses': 'actions/cache@v4', 'with': {'path': '.mock-cache', 'key': f"mock-cache-${{{{ matrix.package }}}}-${{{{ hashFiles('{mock_cfg_file}') }}}}-${{{{ github.run_id }}}}", 'restore-keys': f"mock-cache-${{{{ matrix.package }}}}-${{{{ hashFiles('{mock_cfg_file}') }}}}-\nmock-cache-${{{{ matrix.package }}}}-"}},
+                {'name': 'Build package', 'env': {'MOCK_CACHE_DIR': '${{ github.workspace }}/.mock-cache'}, 'run': f'touch .build-marker\nARGS=(--backend podman --tier {tier_name} --package ${{{{ matrix.package }}}}{manifest_flag}{mock_flag})\nif [[ "${{{{ github.event.inputs.force }}}}" == "true" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh "${{ARGS[@]}}"\n'},
                 {'name': 'Find new RPMs', 'id': 'find-rpms', 'run': 'mkdir -p new-rpms\nfind local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \\;\ncount=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)\necho "count=$count" >> $GITHUB_OUTPUT\n'},
                 {'name': 'Upload RPMs', 'if': "steps.find-rpms.outputs.count > '0'", 'uses': 'actions/upload-artifact@v4', 'with': {'name': f'rpms-{tier_name}-${{{{ strategy.job-index }}}}', 'path': 'new-rpms/*.rpm', 'retention-days': 1}}
             ]
@@ -166,6 +173,8 @@ if __name__ == '__main__':
                         help='R2 destination key for install script')
     parser.add_argument('--no-submodules', action='store_true',
                         help='Skip submodules: recursive in checkout steps')
+    parser.add_argument('--mock-config', default=None,
+                        help='Mock config name passed to build-chain.sh (e.g. centos-stream-10-ci-gnome50); also keys the image/chroot caches on that config file')
     args = parser.parse_args()
     secondary = args.secondary_r2_path if args.secondary_r2_path else None
     generate_workflow(args.manifest, args.output,
@@ -174,5 +183,6 @@ if __name__ == '__main__':
                       secondary_r2_path=secondary,
                       install_script=args.install_script,
                       install_r2_dest=args.install_r2_dest,
-                      submodules=not args.no_submodules)
+                      submodules=not args.no_submodules,
+                      mock_config=args.mock_config)
     print(f"Generated {args.output}")

--- a/tests/test_generate_distributed_workflow.py
+++ b/tests/test_generate_distributed_workflow.py
@@ -186,3 +186,24 @@ def test_generate_workflow_is_parseable_yaml(tmp_path):
 
     assert workflow is not None
     assert isinstance(workflow, dict)
+
+
+def test_generate_workflow_mock_config(tmp_path):
+    # A generated workflow that silently built in the default chroot would
+    # only fail once a package needed one of the gnome50 config's repos, so
+    # the flag must reach build-chain.sh AND re-key the caches on the
+    # selected config file.
+    manifest = tmp_path / "build-order-test.yml"
+    manifest.write_text(
+        "target: centos-stream-10-x86_64\n"
+        "tiers:\n"
+        "  - name: base\n"
+        "    packages:\n"
+        "      - path: src/demo\n"
+    )
+    output = tmp_path / "workflow.yml"
+    generate_workflow(str(manifest), str(output), mock_config="centos-stream-10-ci-gnome50")
+    text = output.read_text()
+    assert "--mock-config centos-stream-10-ci-gnome50" in text
+    assert "mock/centos-stream-10-ci-gnome50.cfg" in text
+    assert "mock/centos-stream-10-ci.cfg" not in text


### PR DESCRIPTION
Prerequisite for #113 per #179: the published gnome50 repo has **never existed** because gnome50 never had the workflow that created gnome49's — the dispatchable, full-chain, publish-at-the-end distributed build. The incremental workflow publishes only changed packages on main pushes, which cannot seed a repo from nothing.

- `build-gnome50-distributed.yml` is **generated** (17 tiers / 36 jobs from `build-order.yml`), not hand-written, via `scripts/generate-distributed-workflow.py`.
- The generator gains `--mock-config`: gnome49 builds in the default chroot, but gnome50 must build in `centos-stream-10-ci-gnome50` (extra repos, tmpfs opts) — a generated workflow silently using the default chroot would only fail once a package needed one of those repos. Image/chroot cache keys hash the *selected* config file for the same reason. Covered by a new generator test (8 pass).
- Publishes to `gnome50/10-stream-x86_64`, no secondary path, no submodules (gnome50 sources use none).

Sequencing (per James's #113 decision and the proving-run standard):
1. This lands.
2. #113's COPR removal lands, rebased fresh.
3. Dispatch this workflow on main → the full stack builds **with no COPR anywhere in the buildroot** — every intra-stack dep resolved tier-by-tier from local-repo — and publishes to R2.
4. Dispatch Verify GNOME 50 Repo → repomd.xml 200 + container install + GDM boot from the published repo.
That run, not workflow syntax, is the proof R2-as-sole-source actually works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->