### PR TITLE
feat(ci): gate cli11-devel on Arch

### DIFF
--- a/.github/workflows/build-tideforge-arch.yml
+++ b/.github/workflows/build-tideforge-arch.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - packages/niri/package.yaml
+      - packages/cli11-devel/package.yaml
       - packages/uupd/package.yaml
       - packages/greetd/package.yaml
       - packages/kairpods/package.yaml
@@ -57,6 +58,12 @@ jobs:
           # exercised pair for both (#139 defect class).
           - package: uupd
             smoke: uupd --help
+          # First of the library/tool recipes on arch, held until the deb
+          # library wave landed the common-list gcc-c++ fix its PKGBUILD
+          # needed; libunwind-devel and ninja-build follow once this cell
+          # proves the shape (stagger: small wave, green, then widen).
+          - package: cli11-devel
+            smoke: test -f /usr/include/CLI/CLI.hpp
           - package: greetd
             smoke: greetd --help
           - package: kairpods


### PR DESCRIPTION
The staggered arch follow-up from the buildout: ONE cell (per the capacity rule — small wave, green, then widen). cli11-devel's PKGBUILD needed #168's common-list `gcc-c++` fix, which is on main; its arch render now declares `cmake, gcc` only. Smoke is byte-identical to the el10/openSUSE/deb cells per the #157 ratchet. `libunwind-devel` and `ninja-build` follow in a widening push once this proves the shape (`wayland-protocols`/`libseat` stay excluded — their contracts query pkg-config, absent from the bare arch install container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->