### PR TITLE
fix(build-chain): fetch dist-git lookaside sources the spec cannot name

### DIFF
--- a/scripts/build-chain.sh
+++ b/scripts/build-chain.sh
@@ -235,6 +235,38 @@ prepare_sources() {
         echo "ERROR: spectool failed for ${pkg_name}" >&2
         return 1
     }
+
+    # Fetch dist-git lookaside sources. A package imported from Fedora dist-git
+    # can list artifacts in its `sources` file that have no URL in the spec at
+    # all (selinux-policy's container-selinux.tgz is a repacked git snapshot) —
+    # spectool cannot download those, and they are not loose files in the
+    # package directory. COPR's rpkg tooling fetched them from the lookaside
+    # cache natively, which is why this gap only surfaced on the first full
+    # GitHub-side chain build (run 30662870608, tier base-tools). Fetch any
+    # sources-file entry still missing after the copy and spectool steps, and
+    # verify it against the recorded checksum before trusting it.
+    local sources_file="${abs_pkg_dir}/sources"
+    if [[ -f "$sources_file" ]]; then
+        local lookaside_name entry_name entry_hash
+        lookaside_name="$(basename "$abs_pkg_dir")"
+        while IFS= read -r line; do
+            [[ "$line" =~ ^SHA512\ \((.+)\)\ =\ ([0-9a-f]{128})$ ]] || continue
+            entry_name="${BASH_REMATCH[1]}"
+            entry_hash="${BASH_REMATCH[2]}"
+            [[ -f "${builddir}/SOURCES/${entry_name}" ]] && continue
+            echo "==> [${pkg_name}] Fetching ${entry_name} from the Fedora lookaside cache..."
+            curl -fsSL --retry 3 \
+                -o "${builddir}/SOURCES/${entry_name}" \
+                "https://src.fedoraproject.org/lookaside/pkgs/rpms/${lookaside_name}/${entry_name}/sha512/${entry_hash}/${entry_name}" || {
+                err "lookaside fetch failed for ${entry_name} (${pkg_name})"
+                return 1
+            }
+            echo "${entry_hash}  ${builddir}/SOURCES/${entry_name}" | sha512sum --check --quiet - || {
+                err "lookaside checksum mismatch for ${entry_name} (${pkg_name})"
+                return 1
+            }
+        done < "$sources_file"
+    fi
 }
 
 # Check if the package already exists in the local repo with the same NVR


### PR DESCRIPTION
Round-1 find from the GNOME 50 seeding run (30662870608, tier base-tools): `selinux-policy` failed with `Bad file: /builddir/SOURCES/container-selinux.tgz`. The artifact is a dist-git **lookaside** source — listed in the `sources` file with a SHA512, no URL in the spec, no loose copy in the package dir. `spectool` can't fetch what has no URL; COPR's rpkg fetched lookaside natively, so the gap was invisible until the first full GitHub-side chain build.

Fix in `prepare_sources()`: after the loose-file copy and spectool steps, fetch any `sources`-file entry still missing from `https://src.fedoraproject.org/lookaside/pkgs/rpms/<name>/<file>/sha512/<hash>/<file>` and verify the recorded SHA512 before trusting it. Verified live against the exact artifact (Fedora's lookaside retains old hashes; the 43.1-era `dfad7fc9…` tgz is there). General fix — covers every dist-git-imported package in the chain, not just selinux-policy.

Six of seven tier-1 packages built before the failure; re-dispatch after this lands resumes from local-repo (no --force).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->