### PR TITLE
fix(ci): end the cosmic-greeter / xdg-desktop-portal-cosmic CI blind spot

### DIFF
--- a/.github/workflows/build-tideforge-supported.yml
+++ b/.github/workflows/build-tideforge-supported.yml
@@ -35,6 +35,8 @@ on:
       - packages/cosmic-settings-daemon/package.yaml
       - packages/cosmic-session/package.yaml
       - packages/cosmic-settings/package.yaml
+      - packages/cosmic-greeter/package.yaml
+      - packages/xdg-desktop-portal-cosmic/package.yaml
       - packages/pop-icon-theme/package.yaml
       - packages/labwc/package.yaml
       - packages/evtest/package.yaml
@@ -75,7 +77,7 @@ jobs:
         # requires the remaining runtime closure, which is not all
         # factory-built yet. This still makes every source/vendor/toolchain
         # regression block updates before any of these recipes can be promoted.
-        package: [dms, dms-cli, dms-greeter, pop-icon-theme, cosmic-icon-theme, cosmic-bg, cosmic-comp, cosmic-idle, cosmic-notifications, cosmic-osd, cosmic-panel, cosmic-randr, cosmic-settings-daemon, cosmic-session, cosmic-settings]
+        package: [dms, dms-cli, dms-greeter, pop-icon-theme, cosmic-icon-theme, cosmic-bg, cosmic-comp, cosmic-idle, cosmic-notifications, cosmic-osd, cosmic-panel, cosmic-randr, cosmic-settings-daemon, cosmic-session, cosmic-settings, cosmic-greeter, xdg-desktop-portal-cosmic]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7


### PR DESCRIPTION
First slice of #169: both recipes were absent from the `rpm-payload` matrix **and** the `on: paths` list, so editing either fired no CI at all. This adds them to both — build-only coverage, one runner slot each, same as the rest of the stack. The first real gate cells (with `verify:` blocks, per the issue's sequencing) follow in the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->