### PR TITLE
fix(xdg-desktop-portal-cosmic): the icon install pipeline needs rev

### DIFF
--- a/packages/xdg-desktop-portal-cosmic/package.yaml
+++ b/packages/xdg-desktop-portal-cosmic/package.yaml
@@ -30,7 +30,14 @@ dependencies:
   build:
     capabilities: [rust]
     targets:
-      el10: [cargo, lld, just, libxkbcommon-devel, wayland-devel, pipewire-devel, clang-devel, mesa-libEGL-devel, mesa-libgbm-devel, gstreamer1-devel, glib2-devel]
+      # util-linux is for `rev`: upstream's justfile installs icons through a
+      # `find | rev | cut | rev` pipeline, and the minimal buildroot only
+      # carries util-linux-core, which does not ship rev. The pipeline
+      # swallowed the failure (no pipefail; xargs on empty input exits 0), so
+      # `just install` reported success while installing zero icons and the
+      # build died later at %files with 'File not found' (#169's blind-spot
+      # fix surfaced this on the recipe's first-ever CI run, job 91337045768).
+      el10: [cargo, lld, just, util-linux, libxkbcommon-devel, wayland-devel, pipewire-devel, clang-devel, mesa-libEGL-devel, mesa-libgbm-devel, gstreamer1-devel, glib2-devel]
   runtime:
     targets:
       el10: [cosmic-icon-theme >= 1.4.0]


### PR DESCRIPTION
The #193 blind-spot fix worked as designed: the first CI run this recipe has ever had (job 91337045768) caught a real, previously-invisible defect. Upstream's justfile installs icons via `find | rev | cut -d/ -f-3 | rev`; the minimal mock buildroot carries `util-linux-core`, which lacks `rev`; the pipeline swallowed the failure (`sh: rev: command not found`, no pipefail, `xargs -I` on empty input exits 0) so `just install` exited green having installed **zero icons**, and the build only died at %files. Verified by reproducing the pipeline locally against the epoch-1.4.0 tarball (works where rev exists).

One line: `util-linux` into the el10 build deps, with the story in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->