### PR TITLE
fix(glycin): fetch the vendor tarball from a release asset

### DIFF
--- a/src/deps/glycin/glycin.spec
+++ b/src/deps/glycin/glycin.spec
@@ -55,7 +55,7 @@ License:        %{shrink:
 
 URL:            https://gitlab.gnome.org/GNOME/glycin
 Source0:        https://download.gnome.org/sources/%{name}/2.0/%{name}-%{tarball_version}.tar.xz
-Source1:        glycin-2.0.8-vendor.tar.xz
+Source1:        https://github.com/tuna-os/tunaos-packages/releases/download/glycin-vendor-2.0.8/glycin-2.0.8-vendor.tar.xz
 # Bundled libjxl 0.11.1 (private copy to avoid conflict with EPEL libjxl-0.10)
 Source2:        https://github.com/libjxl/libjxl/archive/refs/tags/v0.11.1.tar.gz#/libjxl-0.11.1.tar.gz
 


### PR DESCRIPTION
Last of round 4's three finds (seeding run 30676231208). `Source1` was a bare filename for a locally-generated vendor tarball that existed nowhere obtainable. Regenerated per the spec's own documented recipe (329 crates) and published as [glycin-vendor-2.0.8](https://github.com/tuna-os/tunaos-packages/releases/tag/glycin-vendor-2.0.8); Source1 now points at the release URL so spectool fetches it — the xfwl4-vendor precedent. One line in the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->