### PR TITLE
feat(ci): widen pop-icon-theme to ubuntu and debian

### DIFF
--- a/.github/workflows/build-tideforge-supported.yml
+++ b/.github/workflows/build-tideforge-supported.yml
@@ -1181,6 +1181,21 @@ jobs:
             install_name: libseat-dev
             smoke: pkg-config --modversion libseat && seatd -h
             clean_install: true
+          # First cosmic deb widening slice (#169, deb-first directive):
+          # pop-icon-theme proves the shape; the other four follow one at a
+          # time as their capability-based deps land.
+          - package: pop-icon-theme
+            target: ubuntu
+            image: docker.io/library/ubuntu:26.04
+            install_name: pop-icon-theme
+            smoke: test -d /usr/share/icons/Pop
+            clean_install: true
+          - package: pop-icon-theme
+            target: debian
+            image: docker.io/library/debian:sid
+            install_name: pop-icon-theme
+            smoke: test -d /usr/share/icons/Pop
+            clean_install: true
           - package: uupd
             target: ubuntu
             image: docker.io/library/ubuntu:26.04

--- a/packages/pop-icon-theme/package.yaml
+++ b/packages/pop-icon-theme/package.yaml
@@ -23,8 +23,10 @@ dependencies:
   runtime:
     targets:
       el10: [gnome-icon-theme]
+      ubuntu: [gnome-icon-theme]
+      debian: [gnome-icon-theme]
 files:
   common: [usr/share/icons/Pop]
 verify:
   smoke: test -d /usr/share/icons/Pop
-targets: [el10]
+targets: [el10, ubuntu, debian]


### PR DESCRIPTION
First cosmic deb-widening slice (#169), per the deb-first directive — one recipe, two cells, prove, then widen the next. pop-icon-theme is the deliberate opener: meson data package, no compiled deps, `gnome-icon-theme` runtime dep exists under the same name on both deb targets, contract byte-identical across all three targets per the #157 ratchet (verified ubuntu render: `Build-Depends: debhelper-compat (= 13), meson`).

Coverage: **95/126 → 97/128** (denominator +2 from the widened declaration, both immediately covered — no new declared-but-unexercised pairs, ratchet confirms).

Next slices in order: cosmic-randr, cosmic-panel, cosmic-icon-theme, cosmic-comp — the compiled ones consuming #197's new capabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/199"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->