### PR TITLE
fix(ci): clear upstream in-tree debian/ before rendering deb packaging

### DIFF
--- a/.github/workflows/build-tideforge-supported.yml
+++ b/.github/workflows/build-tideforge-supported.yml
@@ -1401,6 +1401,14 @@ jobs:
                       members.append(member)
                   tar.extractall(destination, members=members, filter="data")
           (root / "source-dir").write_text("/work/" + source.relative_to(root).as_posix() + "\n")
+          # Tideforge owns the packaging. pop-os sources ship their own
+          # in-tree debian/ directory, and overlaying rendered files onto it
+          # mixes two packagings: upstream's debian/compat collided with our
+          # debhelper-compat build-dependency and dh refused to run at all
+          # ("compat level specified both in debian/compat and in
+          # debian/control" -- pop-icon-theme's first deb cells, run
+          # 30692954918). Clear it before rendering.
+          shutil.rmtree(source / "debian", ignore_errors=True)
           (source / "debian").mkdir(parents=True, exist_ok=True)
           for path in (root / "rendered" / "debian").rglob("*"):
               if path.is_file():


### PR DESCRIPTION
pop-icon-theme's first deb cells (run 30692954918) failed with `dh: error: debhelper compat level specified both in debian/compat and in debian/control` — pop-os sources ship an in-tree `debian/` and the assembly step overlaid rendered files onto it, mixing upstream's packaging with ours. Tideforge owns the packaging: `shutil.rmtree` the upstream tree before rendering.

Load-bearing for tunaOS#964 — every COSMIC repo carries in-tree `debian/`, so all 13 pending deb widenings would hit this identically.

Also worth noting: #199 merged with both its new cells red, because only lint is required — the #173 aggregator (next PR) exists precisely for this, and this incident is its motivating example from my own work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->