### PR TITLE
feat(ci): widen cosmic-randr to ubuntu and debian

### DIFF
--- a/.github/workflows/build-tideforge-supported.yml
+++ b/.github/workflows/build-tideforge-supported.yml
@@ -1196,6 +1196,18 @@ jobs:
             install_name: pop-icon-theme
             smoke: test -d /usr/share/icons/Pop
             clean_install: true
+          - package: cosmic-randr
+            target: ubuntu
+            image: docker.io/library/ubuntu:26.04
+            install_name: cosmic-randr
+            smoke: cosmic-randr --help
+            clean_install: true
+          - package: cosmic-randr
+            target: debian
+            image: docker.io/library/debian:sid
+            install_name: cosmic-randr
+            smoke: cosmic-randr --help
+            clean_install: true
           - package: uupd
             target: ubuntu
             image: docker.io/library/ubuntu:26.04

--- a/packages/cosmic-randr/package.yaml
+++ b/packages/cosmic-randr/package.yaml
@@ -28,13 +28,17 @@ build:
   commands: [cargo build --release --offline --frozen]
 dependencies:
   build:
-    capabilities: [rust]
+    # wayland-dev resolves the right -dev name per target (#197); the rust
+    # capability already carries cargo.
+    capabilities: [rust, wayland-dev]
     targets:
-      el10: [cargo, lld, just, wayland-devel]
+      el10: [lld, just]
+      ubuntu: [lld, just]
+      debian: [lld, just]
 files:
   common: [usr/bin/cosmic-randr]
 install:
   commands: ["just rootdir={destdir} prefix=/usr install"]
 verify:
   smoke: cosmic-randr --help
-targets: [el10]
+targets: [el10, ubuntu, debian]


### PR DESCRIPTION
Second cosmic deb slice (tunaOS#964): one recipe, two cells, per the congestion rule. Three firsts in one small PR: first vendored-cargo COSMIC package on deb targets, first consumer of #197's `wayland-dev` capability (`Build-Depends: … rustc, cargo, libwayland-dev, lld, just` — verified render), first recipe through #203's upstream-`debian/` clearing. el10 render semantically unchanged. Slices remaining after this proves: cosmic-panel, cosmic-icon-theme, cosmic-comp, then the other nine in closure order, cosmic-session last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->