### PR TITLE
fix(tideforge): keep dh_clean away from vendored cargo trees

### DIFF
--- a/scripts/tideforge.py
+++ b/scripts/tideforge.py
@@ -715,11 +715,11 @@ Rules-Requires-Root: no
         prelude = "\n".join(f"\t{command}" for command in prelude.splitlines())
         if prelude:
             prelude += "\n"
-        rules = f"#!/usr/bin/make -f\n\n%:\n\tdh $@\n\noverride_dh_auto_build:\n\tcd {workdir} && :\n{prelude}\tcd {workdir} && {environment} cargo build --release{cargo_lock_flag(recipe)}{cargo_build_flags(recipe)}{selector}\n\noverride_dh_auto_install:\n\tinstall -Dm0755 {workdir}/target/release/{binary} debian/{recipe['name']}/usr/bin/{binary}\n\noverride_dh_dwz:\n\t:\n"
+        rules = f"#!/usr/bin/make -f\n\n%:\n\tdh $@\n\noverride_dh_auto_build:\n\tcd {workdir} && :\n{prelude}\tcd {workdir} && {environment} cargo build --release{cargo_lock_flag(recipe)}{cargo_build_flags(recipe)}{selector}\n\noverride_dh_auto_install:\n\tinstall -Dm0755 {workdir}/target/release/{binary} debian/{recipe['name']}/usr/bin/{binary}\n\noverride_dh_dwz:\n\t:\n\n# dh_clean deletes *.orig as patch cruft, which strips Cargo.toml.orig out\n# of every vendored crate and breaks cargo's checksum verification.\noverride_dh_clean:\n\tdh_clean -Xvendor/\n"
     elif recipe["build_system"] == "custom":
         build = "\n".join(filter(None, [prepare_commands(recipe), build_environment_exports(recipe), cargo_config_commands(recipe), custom_commands(recipe, "build")]))
         install = custom_commands(recipe, "install", f"debian/{recipe['name']}")
-        rules = f"#!/usr/bin/make -f\n\n%:\n\tdh $@\n\noverride_dh_auto_build:\n\t{build.replace(chr(10), chr(10) + chr(9))}\n\noverride_dh_auto_install:\n\t{install.replace(chr(10), chr(10) + chr(9))}\n"
+        rules = f"#!/usr/bin/make -f\n\n%:\n\tdh $@\n\noverride_dh_auto_build:\n\t{build.replace(chr(10), chr(10) + chr(9))}\n\noverride_dh_auto_install:\n\t{install.replace(chr(10), chr(10) + chr(9))}\n\n# dh_clean deletes *.orig as patch cruft, which strips Cargo.toml.orig out\n# of every vendored crate and breaks cargo's checksum verification.\noverride_dh_clean:\n\tdh_clean -Xvendor/\n"
     elif recipe["build_system"] == "go":
         workdir = build_option(recipe, "working_directory", ".")
         binary = build_option(recipe, "binary", recipe["name"])


### PR DESCRIPTION
cosmic-randr's deb cells (run 30696441716 — which merged anyway; third lint-only-required incident, #206's flip is ready whenever James is) failed with `failed to calculate checksum of: vendor/bitflags/Cargo.toml.orig`. Forensics: the file is present after assembly (cache payload sha-verified, extraction reproduced byte-identical locally), and the build log timeline shows `dh_clean` running in the clean cycle immediately before the cargo error — **dh_clean deletes `*.orig` as patch cruft**, gutting every vendored crate of a file its `.cargo-checksum.json` requires. el10 builds the same recipe fine because rpm never touches debhelper.

Fix: cargo and custom rules templates gain `override_dh_clean: dh_clean -Xvendor/`. Harmless without a vendor tree; load-bearing for every vendored-cargo COSMIC deb (tunaOS#964). 319 tests pass. This PR's run re-exercises the cosmic-randr cells and is their proving run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->