### PR TITLE
feat(ci): widen cosmic-panel to ubuntu and debian

### DIFF
--- a/.github/workflows/build-tideforge-supported.yml
+++ b/.github/workflows/build-tideforge-supported.yml
@@ -1200,6 +1200,18 @@ jobs:
             install_name: cosmic-randr
             smoke: cosmic-randr --help
             clean_install: true
+          - package: cosmic-panel
+            target: ubuntu
+            image: docker.io/library/ubuntu:26.04
+            install_name: cosmic-panel
+            smoke: test -x /usr/bin/cosmic-panel
+            clean_install: true
+          - package: cosmic-panel
+            target: debian
+            image: docker.io/library/debian:sid
+            install_name: cosmic-panel
+            smoke: test -x /usr/bin/cosmic-panel
+            clean_install: true
           - package: uupd
             target: ubuntu
             image: docker.io/library/ubuntu:26.04

--- a/packages/cosmic-panel/package.yaml
+++ b/packages/cosmic-panel/package.yaml
@@ -28,9 +28,14 @@ build:
   commands: [cargo build --release --offline --frozen]
 dependencies:
   build:
-    capabilities: [rust]
+    # wayland-dev / libxkbcommon-dev resolve the right -dev names per target
+    # (#197); the rust capability already carries cargo. util-linux is for
+    # the justfile's rev pipeline, same story as xdg-desktop-portal-cosmic.
+    capabilities: [rust, wayland-dev, libxkbcommon-dev]
     targets:
-      el10: [cargo, lld, just, libxkbcommon-devel, util-linux, wayland-devel]
+      el10: [lld, just, util-linux]
+      ubuntu: [lld, just, util-linux]
+      debian: [lld, just, util-linux]
 files:
   common:
     - usr/bin/cosmic-panel
@@ -39,4 +44,4 @@ install:
   commands: ["just rootdir={destdir} prefix=/usr install"]
 verify:
   smoke: test -x /usr/bin/cosmic-panel
-targets: [el10]
+targets: [el10, ubuntu, debian]


### PR DESCRIPTION
Third cosmic deb slice (tunaOS#964): one recipe, two cells. Rides the fixes the first two slices proved (#203 upstream-debian/ clearing, #207 dh_clean -Xvendor/) and #197's capabilities — verified renders on both targets (`Build-Depends: … rustc, cargo, libwayland-dev, libxkbcommon-dev, lld, just, util-linux`). Remaining after this proves: cosmic-icon-theme, cosmic-comp, then the other nine in closure order, cosmic-session last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->