### PR TITLE
fix(cosmic-panel): pkg-config for the smithay-client-toolkit probe

### DIFF
--- a/packages/cosmic-panel/package.yaml
+++ b/packages/cosmic-panel/package.yaml
@@ -31,7 +31,10 @@ dependencies:
     # wayland-dev / libxkbcommon-dev resolve the right -dev names per target
     # (#197); the rust capability already carries cargo. util-linux is for
     # the justfile's rev pipeline, same story as xdg-desktop-portal-cosmic.
-    capabilities: [rust, wayland-dev, libxkbcommon-dev]
+    # pkg-config: smithay-client-toolkit's build script probes libxkbcommon
+    # through it, and unlike dnf builddep on el10, deb -dev packages do not
+    # pull pkg-config in (both deb cells died in the probe, run 30701973171).
+    capabilities: [rust, pkg-config, wayland-dev, libxkbcommon-dev]
     targets:
       el10: [lld, just, util-linux]
       ubuntu: [lld, just, util-linux]


### PR DESCRIPTION
Both of #210's deb cells failed in `smithay-client-toolkit`'s build script probing libxkbcommon via pkg-config (run 30701973171) — el10 was immune because dnf pulls pkgconf transitively, deb `-dev` packages don't. One capability added; verified render. This PR's run is the proving run for the cosmic-panel cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->