### PR TITLE
feat(ci): publish cosmic-panel debs

### DIFF
--- a/.github/workflows/publish-tideforge-debs.yml
+++ b/.github/workflows/publish-tideforge-debs.yml
@@ -47,6 +47,14 @@ jobs:
             distro: debian-sid
             target: debian
             image: docker.io/library/debian:sid
+          - package: cosmic-panel
+            distro: ubuntu
+            target: ubuntu
+            image: docker.io/library/ubuntu:26.04
+          - package: cosmic-panel
+            distro: debian-sid
+            target: debian
+            image: docker.io/library/debian:sid
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -192,8 +200,9 @@ jobs:
             curl -fsSL https://repo.tunaos.org/tideforge/${{ matrix.distro }}/tideforge.gpg -o /usr/share/keyrings/tideforge.gpg
             echo "deb [signed-by=/usr/share/keyrings/tideforge.gpg] https://repo.tunaos.org/tideforge/${{ matrix.distro }} ./" > /etc/apt/sources.list.d/tideforge.list
             apt-get update
-            apt-get install -y pop-icon-theme cosmic-randr
-            dpkg-query -W pop-icon-theme cosmic-randr
+            apt-get install -y pop-icon-theme cosmic-randr cosmic-panel
+            dpkg-query -W pop-icon-theme cosmic-randr cosmic-panel
             test -d /usr/share/icons/Pop
             cosmic-randr --help
+            test -x /usr/bin/cosmic-panel
           '


### PR DESCRIPTION
cosmic-panel proven on both deb targets in run 30704965049 → joins the publish matrix and the verify job's assertions, per the lockstep rule (nothing publishes that a gate cell hasn't exercised). Second publish dispatch follows the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->