### PR TITLE
feat(ci): widen cosmic-icon-theme to ubuntu and debian with a staged deb gate

### DIFF
--- a/.github/workflows/build-tideforge-supported.yml
+++ b/.github/workflows/build-tideforge-supported.yml
@@ -1513,9 +1513,105 @@ jobs:
   # that failed, was cancelled, OR WAS SKIPPED fails it -- a skipped cell is
   # unproven, not passed. Making this required is a deliberate repo-settings
   # step, not something this file can do.
+  # Staged deb closure gate (#169 / tunaOS#964): cosmic-icon-theme Requires
+  # the tideforge-built pop-icon-theme at install time. The gate stays
+  # independent of the PUBLISHED tideforge repo on purpose -- a gate that
+  # installs prerequisites from the repo it feeds would go green or red with
+  # the repo instead of the change under test. Same shape as its rpm
+  # counterpart: prerequisite artifacts into an ephemeral local repository.
+  cosmic-icon-theme-deb:
+    name: cosmic-icon-theme (${{ matrix.target }} DEB)
+    needs: [detect-changes, deb]
+    if: ${{ needs.detect-changes.outputs.relevant == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # The package key is what check-gate-coverage.py counts.
+          - package: cosmic-icon-theme
+            target: ubuntu
+            image: docker.io/library/ubuntu:26.04
+          - package: cosmic-icon-theme
+            target: debian
+            image: docker.io/library/debian:sid
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.14'
+      - run: pip install pyyaml
+      - name: Restore the content-addressed source cache
+        uses: ./.github/actions/tideforge-source-cache
+        with:
+          recipe: packages/cosmic-icon-theme/package.yaml
+      - uses: actions/download-artifact@v8
+        with:
+          name: pop-icon-theme-${{ matrix.target }}-deb
+          path: .tideforge/deb/${{ matrix.target }}-cosmic-icon-theme/prerequisite
+      - name: Render and assemble the Debian source tree
+        run: |
+          set -euo pipefail
+          recipe="packages/cosmic-icon-theme/package.yaml"
+          root="$PWD/.tideforge/deb/${{ matrix.target }}-cosmic-icon-theme"
+          python3 scripts/tideforge.py validate "$recipe"
+          python3 scripts/verify-tideforge-source.py "$recipe" --cache-dir "$HOME/.cache/tideforge/sources"
+          python3 scripts/tideforge.py render "$recipe" --target "${{ matrix.target }}" --output "$root/rendered"
+          python3 scripts/assemble-deb-source-tree.py "$recipe" "$root"
+      - name: Pull the build image, retrying transient registry failures
+        run: scripts/pull-container-image.sh "${{ matrix.image }}"
+      - name: Build the deb with only declared Build-Depends
+        run: |
+          set -euo pipefail
+          root="$PWD/.tideforge/deb/${{ matrix.target }}-cosmic-icon-theme"
+          docker run --rm --volume "$root:/work" "${{ matrix.image }}" bash -lc '
+            set -euo pipefail
+            export DEBIAN_FRONTEND=noninteractive
+            apt-get update -qq
+            apt-get install -y --no-install-recommends build-essential ca-certificates devscripts equivs
+            cd "$(cat /work/source-dir)"
+            mk-build-deps --install --remove --tool "apt-get -y --no-install-recommends" debian/control
+            dpkg-buildpackage -us -uc -b
+            mkdir -p /work/artifacts
+            cp ../*.deb /work/artifacts/
+          '
+      - name: Lint the built deb
+        run: |
+          set -euo pipefail
+          root="$PWD/.tideforge/deb/${{ matrix.target }}-cosmic-icon-theme"
+          docker run --rm --volume "$root:/work:ro" --volume "$PWD/scripts:/scripts:ro" "${{ matrix.image }}" \
+            bash /scripts/lint-generated-deb.sh /work/artifacts
+      - name: Clean-install with the staged prerequisite
+        run: |
+          set -euo pipefail
+          root="$PWD/.tideforge/deb/${{ matrix.target }}-cosmic-icon-theme"
+          docker run --rm --volume "$root:/work:ro" "${{ matrix.image }}" bash -lc '
+            set -euo pipefail
+            export DEBIAN_FRONTEND=noninteractive
+            apt-get update -qq
+            apt-get install -y --no-install-recommends dpkg-dev pkg-config
+            mkdir -p /var/lib/tideforge
+            cp /work/prerequisite/*.deb /var/lib/tideforge/
+            cp /work/artifacts/*.deb /var/lib/tideforge/
+            cd /var/lib/tideforge
+            dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz
+            printf "deb [trusted=yes] file:/var/lib/tideforge ./\n" > /etc/apt/sources.list.d/tideforge.list
+            printf "Package: *\nPin: origin \"\"\nPin-Priority: 1001\n" > /etc/apt/preferences.d/tideforge.pref
+            apt-get update -qq
+            apt-get install -y cosmic-icon-theme
+            dpkg-query -W cosmic-icon-theme pop-icon-theme
+            test -d /usr/share/icons/Cosmic
+          '
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: cosmic-icon-theme-${{ matrix.target }}-deb
+          path: .tideforge/deb/${{ matrix.target }}-cosmic-icon-theme/artifacts/
+          if-no-files-found: warn
+
   tideforge-gate:
     name: Tideforge gate
-    needs: [detect-changes, rpm-payload, rpm, opensuse-rpm, xfconf-split, gtkgreet-rpm, cpptrace-rpm, input-remapper-rpm, quickshell-rpm, niri-rpm, iio-niri-rpm, dms-stack-rpm, cosmic-icon-theme-rpm, cosmic-comp-rpm, deb]
+    needs: [detect-changes, rpm-payload, rpm, opensuse-rpm, xfconf-split, gtkgreet-rpm, cpptrace-rpm, input-remapper-rpm, quickshell-rpm, niri-rpm, iio-niri-rpm, dms-stack-rpm, cosmic-icon-theme-rpm, cosmic-comp-rpm, deb, cosmic-icon-theme-deb]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:

--- a/packages/cosmic-icon-theme/package.yaml
+++ b/packages/cosmic-icon-theme/package.yaml
@@ -16,13 +16,17 @@ dependencies:
   build:
     targets:
       el10: [just]
+      ubuntu: [just]
+      debian: [just]
   runtime:
     targets:
       el10: [pop-icon-theme]
+      ubuntu: [pop-icon-theme]
+      debian: [pop-icon-theme]
 files:
   common: [usr/share/icons/Cosmic]
 install:
   commands: ["just rootdir={destdir} prefix=/usr install"]
 verify:
   smoke: test -d /usr/share/icons/Cosmic
-targets: [el10]
+targets: [el10, ubuntu, debian]


### PR DESCRIPTION
Fourth cosmic deb slice (tunaOS#964), first staged one: `cosmic-icon-theme` Requires the tideforge-built `pop-icon-theme`, so its new dedicated job stages the prerequisite's deb artifacts into a pinned ephemeral repo — the deb spelling of `cosmic-icon-theme-rpm`. The gate stays independent of the published tideforge repo by design (a gate installing prereqs from the repo it feeds would track the repo, not the change). Aggregator `needs` updated; coverage 101/132 → **103/134**. After this proves: cosmic-comp (staged, libseat closure), then the other nine, session last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->