### PR TITLE
fix(gtk4): give the devel-docs subpackage its %files section

### DIFF
--- a/src/deps/gtk4/gtk4.spec
+++ b/src/deps/gtk4/gtk4.spec
@@ -243,5 +243,16 @@ desktop-file-validate $RPM_BUILD_ROOT%{_datadir}/applications/*.desktop
 %{_libdir}/pkgconfig/*.pc
 %{_datadir}/gir-1.0/*.gir
 
+# -Ddocumentation=true generates gi-docgen trees for every backend. The
+# devel-docs %package existed without a %files section, so the first build
+# that got this far died with 'Installed (but unpackaged) file(s) found'
+# across all five doc directories (seeding run 30696407796, gtk-core).
+%files devel-docs
+%doc %{_datadir}/doc/gdk4/
+%doc %{_datadir}/doc/gdk4-wayland/
+%doc %{_datadir}/doc/gdk4-x11/
+%doc %{_datadir}/doc/gsk4/
+%doc %{_datadir}/doc/gtk4/
+
 %changelog
 %autochangelog


### PR DESCRIPTION
Round-6 find (seeding run 30696407796 — the deepest yet: **glycin, libgda, and sqlcipher all cleared**; gtk4 was the sole failure, and only because it finally built past source fetch). `%package devel-docs` existed with no `%files devel-docs`, so the five gi-docgen doc trees were installed-but-unpackaged. Section added, mirroring Fedora's. Round 7 dispatches after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->