### PR TITLE
feat(ci): publish cosmic-icon-theme debs

### DIFF
--- a/.github/workflows/publish-tideforge-debs.yml
+++ b/.github/workflows/publish-tideforge-debs.yml
@@ -55,6 +55,14 @@ jobs:
             distro: debian-sid
             target: debian
             image: docker.io/library/debian:sid
+          - package: cosmic-icon-theme
+            distro: ubuntu
+            target: ubuntu
+            image: docker.io/library/ubuntu:26.04
+          - package: cosmic-icon-theme
+            distro: debian-sid
+            target: debian
+            image: docker.io/library/debian:sid
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -200,9 +208,10 @@ jobs:
             curl -fsSL https://repo.tunaos.org/tideforge/${{ matrix.distro }}/tideforge.gpg -o /usr/share/keyrings/tideforge.gpg
             echo "deb [signed-by=/usr/share/keyrings/tideforge.gpg] https://repo.tunaos.org/tideforge/${{ matrix.distro }} ./" > /etc/apt/sources.list.d/tideforge.list
             apt-get update
-            apt-get install -y pop-icon-theme cosmic-randr cosmic-panel
-            dpkg-query -W pop-icon-theme cosmic-randr cosmic-panel
+            apt-get install -y pop-icon-theme cosmic-randr cosmic-panel cosmic-icon-theme
+            dpkg-query -W pop-icon-theme cosmic-randr cosmic-panel cosmic-icon-theme
             test -d /usr/share/icons/Pop
             cosmic-randr --help
             test -x /usr/bin/cosmic-panel
+            test -d /usr/share/icons/Cosmic
           '


### PR DESCRIPTION
cosmic-icon-theme proved on both deb targets (run 30708484561, first staged-closure gate). Joins the publish matrix + verify assertions. Its pop-icon-theme dependency resolves inside the published repo — asserted cold by the verify job. Third publish dispatch follows the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->