### PR TITLE
fix(xfwl4): update vendor tarball to include xfconf 0.2.2

### DIFF
--- a/src/xfce-wayland/xfwl4/xfwl4.spec
+++ b/src/xfce-wayland/xfwl4/xfwl4.spec
@@ -22,7 +22,7 @@ Source0: https://gitlab.xfce.org/xfce/xfwl4/-/archive/%{commit}/xfwl4-%{commit}.
 # Pre-vendored with `cargo vendor` against this exact commit's Cargo.lock
 # (crates.io deps + the smithay git dep); see release notes for how it
 # was generated if it ever needs regenerating after a Cargo.lock bump.
-Source1: https://github.com/tuna-os/tunaos-packages/releases/download/xfwl4-vendor-6b38df65/vendor.tar.gz
+Source1: https://github.com/tuna-os/tunaos-packages/releases/download/xfwl4-vendor-5c2802c0/vendor.tar.gz
 # resources/xfce-wayland-protocols is a git submodule (custom XFCE Wayland
 # protocol XML: output-management, input-device-list, etc.) — not included
 # in the plain archive tarball, same as any other git submodule. Referenced


### PR DESCRIPTION
## Problem

The vendor tarball `xfwl4-vendor-6b38df65` contained `xfconf 0.1.0`, but `Cargo.toml` at both commits `5c2802c` and `d961899` requires `xfconf 0.2.2`. This caused offline cargo builds to fail:

```
error: failed to select a version for the requirement `xfconf = "^0.2.2"` (locked to 0.2.2)
candidate versions found which didn"t match: 0.1.0
```

This was masked before because the dma-cfg patch failed first in `%prep`, so cargo never ran.

## Fix

Regenerated the vendor tarball with `cargo vendor` against commit `5c2802c` (Cargo.lock identical for `d961899`) and uploaded as release `xfwl4-vendor-5c2802c0`.

**SHA256**: `736a21063a7c8de5584d38633d843a2bc09a2fa536fd1ffbccd71531a2e7c365`

## Changed files

- `src/xfce-wayland/xfwl4/xfwl4.spec` — update `Source1` URL

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->