### PR TITLE
fix(ci): broken pipe in refresh workflow

### DIFF
--- a/.github/workflows/refresh-gnome50-r2.yml
+++ b/.github/workflows/refresh-gnome50-r2.yml
@@ -65,7 +65,7 @@ jobs:
           echo "=== Downloaded tree ==="
           find repo-tree -name '*.rpm' | wc -l
           echo "RPMs downloaded"
-          find repo-tree -type f | head -5
+          find repo-tree -type f | head -5 || true
 
       - name: Sync to R2 production path (repo/10-x86_64)
         run: |


### PR DESCRIPTION
The `find repo-tree -type f | head -5` line dies under `set -euo pipefail` when head closes the pipe early. Add `|| true`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->