### PR TITLE
fix(ci): use rclone sync not copy in refresh workflow

### DIFF
--- a/.github/workflows/refresh-gnome50-r2.yml
+++ b/.github/workflows/refresh-gnome50-r2.yml
@@ -72,19 +72,27 @@ jobs:
           done
 
           echo "=== Downloaded tree ==="
-          find repo-tree -name '*.rpm' | wc -l
-          echo "RPMs downloaded"
+          RPM_COUNT=$(find repo-tree -name '*.rpm' | wc -l)
+          echo "RPMs downloaded: ${RPM_COUNT} (expected ${TOTAL})"
+          if [[ "${RPM_COUNT}" -lt "${TOTAL}" ]]; then
+            echo "::error::Downloaded ${RPM_COUNT} of ${TOTAL} RPMs — refusing to sync (would delete published packages)"
+            exit 1
+          fi
           find repo-tree -type f | head -5 || true
 
       - name: Sync to R2 production path (repo/10-x86_64)
+        # rclone sync (not copy): the destination must EXACTLY mirror COPR.
+        # copy would leave orphaned stale RPMs (e.g. the ICU 77 packages from
+        # the old snapshot) that createrepo_c then indexes, re-poisoning the
+        # local-build repo.
         run: |
-          rclone copy repo-tree/ "r2:bluefin/repo/10-x86_64/" \
+          rclone sync repo-tree/ "r2:bluefin/repo/10-x86_64/" \
             --transfers 16 --checksum --verbose 2>&1 | tail -5
           echo "Synced to r2:bluefin/repo/10-x86_64/"
 
       - name: Sync to R2 GNOME 50 GHA path (gnome50/10-stream-x86_64)
         run: |
-          rclone copy repo-tree/ "r2:bluefin/gnome50/10-stream-x86_64/" \
+          rclone sync repo-tree/ "r2:bluefin/gnome50/10-stream-x86_64/" \
             --transfers 16 --checksum --verbose 2>&1 | tail -5
           echo "Synced to r2:bluefin/gnome50/10-stream-x86_64/"
 


### PR DESCRIPTION
`rclone copy` only adds files — the stale ICU 77 RPMs from the original seed stayed orphaned in the bucket (670 RPMs: 312 stale + 358 fresh). The distributed build seeds → `createrepo_c` indexes the stale `libicu-77.1` → "cannot install both libicu-74.2 and libicu-77.1" again.

`rclone sync` makes R2 exactly mirror the COPR tree, deleting orphaned stale packages. Also guard: refuse to sync if RPM count is short.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->