### PR TITLE
fix(gdk-pixbuf2): provide gdk-pixbuf2-modules + add to gtk-core tier

### DIFF
--- a/build-order.yml
+++ b/build-order.yml
@@ -113,6 +113,12 @@ tiers:
     packages:
       - path: src/gnome-50/gsettings-desktop-schemas
       - path: src/gnome-50/gnome-desktop3
+      # gdk-pixbuf2 2.44.x merges the modules subpackage (Obsoletes +
+      # Provides). Must build here before gtk4/glycin so the local-build
+      # gdk-pixbuf2 provides gdk-pixbuf2-modules — otherwise EL10's gtk3
+      # (pulled into gtk4's builddep via gstreamer1-plugins-bad-free) can't
+      # install and gtk4 dies.
+      - path: src/deps/gdk-pixbuf2
       - path: src/deps/gtk4
       - copr_name: highway         # runtime dep of glycin-loaders (bundled libjxl); in EPEL10 but explicit here for self-contained COPR
       - path: src/deps/glycin

--- a/src/deps/gdk-pixbuf2/gdk-pixbuf2.spec
+++ b/src/deps/gdk-pixbuf2/gdk-pixbuf2.spec
@@ -28,7 +28,11 @@ Requires: glycin-libs%{?_isa} >= %{glycin_version}
 Requires: shared-mime-info
 
 # All modules previously provided by gdk-pixbuf itself are obsoleted by Glycin.
+# EL10's gtk3 still Requires gdk-pixbuf2-modules(x86-64) — provide it so the
+# merged package satisfies that dependency instead of dnf failing to install
+# gtk3 (gtk4's builddep chain pulls gtk3 via gstreamer1-plugins-bad-free).
 Obsoletes: %{name}-modules < %{version}-%{release}
+Provides:  %{name}-modules%{?_isa} = %{version}-%{release}
 
 # Most third-party pixbuf loaders are also obsolete. If Glycin supports the
 # format, then it will take precedence and the third-party loader won't be used.


### PR DESCRIPTION
The custom `gdk-pixbuf2` 2.44.5 merges the `modules` subpackage but only had `Obsoletes: gdk-pixbuf2-modules`, no `Provides`.

EL10 `gtk3` Requires `gdk-pixbuf2-modules(x86-64)`. gtk4 builddep pulls gtk3 via `gstreamer1-plugins-bad-free` → dnf cannot install the best candidate → gtk-core tier dies.

Fix: standard RPM merge pattern — add `Provides: gdk-pixbuf2-modules`. Also wire gdk-pixbuf2 into the gtk-core tier (before gtk4) so the distributed build rebuilds it with the fixed spec.

Evidence (run 30929115999):
```
- package gdk-pixbuf2-2.44.5-4.el10 from local-build obsoletes gdk-pixbuf2-modules < 2.44.5-4.el10 provided by gdk-pixbuf2-modules-2.42.12-5.el10
- package gdk-pixbuf2-devel-2.44.5-4.el10 requires gdk-pixbuf2(x86-64) = 2.44.5-4.el10, but none of the providers can be installed
- cannot install the best candidate for the job
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->