### PR TITLE
fix(gnome50): build gdk-pixbuf2 in system-tools tier before gtk-core

### DIFF
--- a/.github/workflows/build-gnome50-distributed.yml
+++ b/.github/workflows/build-gnome50-distributed.yml
@@ -816,6 +816,7 @@ jobs:
           - src/deps/python-dbusmock
           - src/deps/avahi
           - src/gnome-50/gjs
+          - src/deps/gdk-pixbuf2
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/build-order.yml
+++ b/build-order.yml
@@ -107,18 +107,17 @@ tiers:
         build_tool: true
       - path: src/deps/avahi
       - path: src/gnome-50/gjs
+      # gdk-pixbuf2 2.44.x merges the modules subpackage: needs Obsoletes +
+      # Provides. Builds here (before gtk-core) using the seed's glycin so
+      # gtk4's builddep (which pulls EL10 gtk3 via gstreamer1-plugins-bad-free)
+      # can resolve gdk-pixbuf2-modules.
+      - path: src/deps/gdk-pixbuf2
 
   # Tier 11: GTK Core.
   - name: gtk-core
     packages:
       - path: src/gnome-50/gsettings-desktop-schemas
       - path: src/gnome-50/gnome-desktop3
-      # gdk-pixbuf2 2.44.x merges the modules subpackage (Obsoletes +
-      # Provides). Must build here before gtk4/glycin so the local-build
-      # gdk-pixbuf2 provides gdk-pixbuf2-modules — otherwise EL10's gtk3
-      # (pulled into gtk4's builddep via gstreamer1-plugins-bad-free) can't
-      # install and gtk4 dies.
-      - path: src/deps/gdk-pixbuf2
       - path: src/deps/gtk4
       - copr_name: highway         # runtime dep of glycin-loaders (bundled libjxl); in EPEL10 but explicit here for self-contained COPR
       - path: src/deps/glycin


### PR DESCRIPTION
PR #243 added gdk-pixbuf2 to the gtk-core tier, but tier jobs build in **parallel** — gtk4 builddep ran against the seed's OLD gdk-pixbuf2 (no Provides) and still died on `gdk-pixbuf2-modules`.

Move gdk-pixbuf2 into **system-tools** (builds before gtk-core, uses the seed's glycin), so the freshly-built gdk-pixbuf2 with the Provides fix is consolidated into `repo-10` before gtk4's tier starts.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->