### PR TITLE
fix(gtk4): package bash-completion and mime files

### DIFF
--- a/src/deps/gtk4/gtk4.spec
+++ b/src/deps/gtk4/gtk4.spec
@@ -235,6 +235,10 @@ desktop-file-validate $RPM_BUILD_ROOT%{_datadir}/applications/*.desktop
 %{_sysconfdir}/gtk-4.0/
 %{_datadir}/gettext/its/gtk4builder.*
 %{_mandir}/man1/*.1*
+# Installed but unpackaged in the first successful build (run 30939010019);
+# listed explicitly in Fedora's spec, use globs to stay robust to new tools.
+%{_datadir}/bash-completion/completions/gtk4-*
+%{_datadir}/mime/packages/gtk-mime.xml
 
 %files devel
 %{_includedir}/gtk-4.0/


### PR DESCRIPTION
The first successful gtk4 build (run 30939010019) died at the %files check:
```
error: Installed (but unpackaged) file(s) found:
   /usr/share/bash-completion/completions/gtk4-builder-tool
   ... gtk4-demo, gtk4-image-tool, gtk4-node-editor, gtk4-path-tool,
       gtk4-print-editor, gtk4-rendernode-tool, gtk4-widget-factory
   /usr/share/mime/packages/gtk-mime.xml
```
Fedora lists these explicitly; use globs to stay robust.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->