### PR TITLE
fix(arch): install the package this job built, not Arch's

### DIFF
--- a/packages/bazaar/package.yaml
+++ b/packages/bazaar/package.yaml
@@ -45,7 +45,22 @@ dependencies:
       # libmd4c -> md4c, libglycin-gtk4-2 -> glycin-gtk4, libwebkitgtk-6.0 ->
       # webkitgtk-6.0. flatpak is repeated from capabilities so this list still
       # stands alone if a target override supersedes them.
-      arch: [flatpak, gtk4, gtksourceview5, libadwaita, libdex, libyaml, libsoup3, libproxy, md4c, glycin-gtk4, webkitgtk-6.0]
+      #
+      # The trailing names were NOT in that unresolved report, and that is the
+      # point: they are DT_NEEDED entries of the same binaries that happened to
+      # be on disk anyway, pulled in by flatpak's own closure or already present
+      # in the base image. ldd cannot distinguish "declared" from "someone else
+      # installed it", so the closure check goes green on them while the recipe
+      # still under-declares. Read off `readelf -d` over the artifact run
+      # 31116215447 uploaded, so the list is the binaries' full direct closure
+      # rather than the subset one container's contents exposed: libc/libm ->
+      # glibc, libgcc_s -> libgcc, lib{gio,gobject,glib}-2.0 -> glib2, libcairo
+      # -> cairo, libpango-1.0 -> pango, libgraphene-1.0 -> graphene,
+      # libappstream -> appstream, libxmlb -> libxmlb, libjson-glib-1.0 ->
+      # json-glib, libglycin-2 -> glycin, libsecret-1 -> libsecret,
+      # libmalcontent-0 -> libmalcontent (the library half of the build list's
+      # malcontent).
+      arch: [flatpak, gtk4, gtksourceview5, libadwaita, libdex, libyaml, libsoup3, libproxy, md4c, glycin-gtk4, webkitgtk-6.0, glibc, libgcc, glib2, cairo, pango, graphene, appstream, libxmlb, json-glib, glycin, libsecret, libmalcontent]
 files:
   common:
     - usr/bin/bazaar

--- a/packages/bazaar/package.yaml
+++ b/packages/bazaar/package.yaml
@@ -24,6 +24,28 @@ dependencies:
       arch: [base-devel, meson, gettext, python-babel, glib2-devel, gtk4, libadwaita, libdex, flatpak, appstream, libxmlb, libyaml, libsoup3, json-glib, glycin, glycin-gtk4, webkitgtk-6.0, libsecret, libproxy, malcontent, gtksourceview5, blueprint-compiler, md4c, libxml2]
   runtime:
     capabilities: [flatpak]
+    targets:
+      # Arch only, and not an oversight elsewhere: dh_shlibdeps derives these
+      # from the ELF headers for the deb targets, so debian/ubuntu already ship
+      # correct Depends. makepkg does no such thing — whatever is not named here
+      # is simply absent, and bazaar then fails to start on a missing library.
+      #
+      # This was invisible until arch-clean-install.sh stopped letting Arch's
+      # own bazaar answer for ours: with extra/bazaar installed, its depends
+      # satisfied every one of these and the closure check passed against a
+      # package this repository did not build. The first run that actually
+      # installed our artifact reported all ten unresolved across 7 ELF
+      # objects (run 31116215447).
+      #
+      # Derived from those DT_NEEDED entries, not guessed. Every name already
+      # appears in the arch build list above, so the spelling is proven by the
+      # build that consumes it: libgtk-4 -> gtk4, libgtksourceview-5 ->
+      # gtksourceview5, libadwaita-1 -> libadwaita, libdex-1 -> libdex,
+      # libyaml-0 -> libyaml, libsoup-3.0 -> libsoup3, libproxy -> libproxy,
+      # libmd4c -> md4c, libglycin-gtk4-2 -> glycin-gtk4, libwebkitgtk-6.0 ->
+      # webkitgtk-6.0. flatpak is repeated from capabilities so this list still
+      # stands alone if a target override supersedes them.
+      arch: [flatpak, gtk4, gtksourceview5, libadwaita, libdex, libyaml, libsoup3, libproxy, md4c, glycin-gtk4, webkitgtk-6.0]
 files:
   common:
     - usr/bin/bazaar

--- a/scripts/arch-clean-install.sh
+++ b/scripts/arch-clean-install.sh
@@ -58,21 +58,40 @@ cp /tmp/tideforge.db.tar.gz /var/lib/tideforge/tideforge.db
 # user-map root and make image-owned files read-only, and recent Arch images
 # no longer guarantee a copied /etc/pacman.conf survives that mapping. Write a
 # small, complete configuration of our own instead.
+#
+# [tideforge] MUST come before [core] and [extra]. pacman resolves `-S <name>`
+# by walking the sync repositories in configuration order and taking the first
+# one that provides the name — it does not compare versions across them. With
+# tideforge listed last, every package name that also exists in an official
+# Arch repository was installed FROM Arch, and the artifact this job just built
+# was never exercised at all.
+#
+# That is not hypothetical. Run 31113235209 built bazaar 0.9.1-1, uploaded it as
+# the job's artifact, and then reported `bazaar 0.9.2-1` from `pacman -Q` —
+# extra's build, not ours. It only surfaced because Arch's 0.9.2 replaced
+# /usr/bin/bazaar-refresh-worker with bazaar-daemon and tripped the smoke. The
+# other matrix entries that exist in extra (niri, greetd, dgop) stayed green
+# while validating a package this repository did not produce, which is the more
+# expensive failure: a gate that passes for the wrong reason teaches nothing.
+#
+# Ordering it first is what makes the closure check and the smoke assertions
+# statements about OUR package. tideforge holds only what this job built, so
+# it can shadow nothing else.
 {
     echo '[options]'
     echo 'Architecture = auto'
     echo 'SigLevel = Required DatabaseOptional'
     echo 'LocalFileSigLevel = Optional'
     echo
+    echo '[tideforge]'
+    echo 'SigLevel = Optional TrustAll'
+    echo 'Server = file:///var/lib/tideforge'
+    echo
     echo '[core]'
     echo 'Include = /etc/pacman.d/mirrorlist'
     echo
     echo '[extra]'
     echo 'Include = /etc/pacman.d/mirrorlist'
-    echo
-    echo '[tideforge]'
-    echo 'SigLevel = Optional TrustAll'
-    echo 'Server = file:///var/lib/tideforge'
 } > /tmp/tideforge-pacman.conf
 
 pacman --config /tmp/tideforge-pacman.conf -Sy --noconfirm

--- a/tests/bats/test_arch_clean_install.bats
+++ b/tests/bats/test_arch_clean_install.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+# BATS tests for scripts/arch-clean-install.sh — Arch clean-install harness.
+#
+# The whole point of this harness is to prove that the package THIS JOB BUILT
+# installs and resolves. pacman resolves `-S <name>` by walking the sync
+# repositories in configuration order and taking the first that provides the
+# name; it does not compare versions across them. So if [tideforge] is not
+# listed ahead of [core]/[extra], every package name that also exists in an
+# official Arch repository is installed from Arch, and the built artifact is
+# never exercised.
+#
+# That regression is silent by construction — the job still goes green, just
+# against the wrong package. Run 31113235209 built bazaar 0.9.1-1 and reported
+# `bazaar 0.9.2-1`; niri, greetd and dgop all exist in extra too and were
+# passing the same way. So the ordering is pinned here rather than left to
+# review.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+SCRIPT="${REPO_ROOT}/scripts/arch-clean-install.sh"
+
+# Extract the repository section names, in order, from the pacman.conf the
+# script generates. Parsing the emitted config rather than grepping the source
+# means a refactor that still produces the right file keeps passing, and one
+# that produces the wrong file fails even if the source text looks fine.
+emitted_repo_order() {
+	sed -n '/^} > \/tmp\/tideforge-pacman.conf/q;p' "$SCRIPT" |
+		sed -n "s/^[[:space:]]*echo '\[\([a-z]*\)\]'.*/\1/p"
+}
+
+@test "arch-clean-install.sh: exists" {
+	run test -f "$SCRIPT"
+	[ "$status" -eq 0 ]
+}
+
+@test "arch-clean-install.sh: has bash shebang" {
+	run head -1 "$SCRIPT"
+	[[ "$output" =~ ^#!/.*bash ]]
+}
+
+@test "the generated pacman.conf defines options, tideforge, core and extra" {
+	run emitted_repo_order
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"options"* ]]
+	[[ "$output" == *"tideforge"* ]]
+	[[ "$output" == *"core"* ]]
+	[[ "$output" == *"extra"* ]]
+}
+
+# The assertion this file exists for.
+@test "tideforge is searched before core and extra" {
+	local order tideforge core extra
+	order="$(emitted_repo_order)"
+	tideforge=$(echo "$order" | grep -n '^tideforge$' | cut -d: -f1)
+	core=$(echo "$order" | grep -n '^core$' | cut -d: -f1)
+	extra=$(echo "$order" | grep -n '^extra$' | cut -d: -f1)
+
+	[ -n "$tideforge" ]
+	[ -n "$core" ]
+	[ -n "$extra" ]
+	# Lower position number == searched first == wins the name.
+	[ "$tideforge" -lt "$core" ]
+	[ "$tideforge" -lt "$extra" ]
+}
+
+# A local repository pacman refuses to read is the same failure wearing a
+# different hat: the built package cannot win a name it cannot be loaded from.
+@test "the tideforge repository stays installable with unsigned CI artifacts" {
+	run grep -A2 "echo '\[tideforge\]'" "$SCRIPT"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"SigLevel = Optional TrustAll"* ]]
+	[[ "$output" == *"Server = file:///var/lib/tideforge"* ]]
+}
+
+# `pacman -Q` after the install is what turned the 0.9.1-vs-0.9.2 substitution
+# from invisible into evidence. It is load-bearing, not decoration.
+@test "the install is proven with pacman -Q afterwards" {
+	run grep -E '^pacman -Q "\$package"' "$SCRIPT"
+	[ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## The bug

`pacman` resolves `-S <name>` by walking the sync repositories **in configuration order** and taking the first one that provides the name. It does not compare versions across them.

`scripts/arch-clean-install.sh` wrote `[tideforge]` *after* `[core]` and `[extra]`. So for any package name that also exists in an official Arch repository, pacman installed **Arch's** build, and the artifact the job had just produced was never exercised.

## The evidence was already in the log

Run [31113235209](https://github.com/tuna-os/tunaos-packages/actions/runs/31113235209) built `bazaar 0.9.1-1` and uploaded it as the job artifact. The same job then printed:

```
bazaar 0.9.2-1
```

from the `pacman -Q "$package"` line that exists precisely to prove the install happened. That line did its job; it was read past.

## Only one package noticed

`bazaar` went red only by accident — Arch's 0.9.2 replaced `/usr/bin/bazaar-refresh-worker` with `bazaar-daemon`, so the smoke assertion stopped matching. Checking the rest of the Arch matrix against archlinux.org:

| package | in Arch official | what happened |
|---|---|---|
| `bazaar` | `extra` 0.9.2-1 | **red** — 0.9.2 dropped a binary the smoke asserts |
| `niri` | `extra` 26.04-1 | green, validating Arch's build |
| `greetd` | `extra` 0.10.3-2 | green, validating Arch's build |
| `dgop` | `extra` 0.2.3-1 | green, validating Arch's build |

(`uupd`, `kairpods` and `plasma-setup` are not in the official repos, so those cells were testing the right package all along.)

The three silent ones are the more expensive half. `bazaar` failed loudly; the others passed for the wrong reason, and a gate that passes for the wrong reason teaches nothing. This is the same shape as the defect already documented in this script's own header — "The package was never installed, `pacman -Q` never ran, and the job still went green".

## The fix

Order `[tideforge]` ahead of `[core]` and `[extra]`. It contains only what this job built, so putting it first can shadow nothing else, and it is what makes the ELF closure check and the smoke assertions statements about *our* package.

**`build-tideforge-arch.yml` needs no change.** The built `bazaar 0.9.1-1` does ship `bazaar-refresh-worker` — I verified this by unpacking the job's own artifact:

```
usr/bin/bazaar
usr/bin/bazaar-dl-worker
usr/bin/bazaar-refresh-worker
usr/bin/bge-demo
```

So the smoke assertion is correct as written. Renaming the binary there — the obvious one-line fix — would have been wrong: it would have pinned the gate to Arch's package permanently and left the three silent cells silent.

## Testing

6 new bats cases in `tests/bats/test_arch_clean_install.bats`. They parse the `pacman.conf` the script emits rather than grepping the source, so a refactor that still produces a correct file keeps passing, and one that produces a wrong file fails even if the source reads fine.

Mutation-verified: restoring the old ordering fails `tideforge is searched before core and extra` and **only** that test.

Not verified here: this cannot be exercised without running the Arch container, so the real proof is the next `bazaar` cell reporting `0.9.1-1` from `pacman -Q` instead of `0.9.2-1`. Worth watching on the first run of this branch.

## Why a separate PR

Found while investigating why `bazaar (Arch, unpatched)` blocks #250. It is unrelated to that PR's hummingbird work — #250 only triggered the matrix because `detect-changes` marks it relevant on `^scripts/`. Merging this unblocks #250's required `Tideforge gate (arch)`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->