### PR TITLE
fix(hummingbird): publish the RPMs that built even when part of a tier fails

### DIFF
--- a/.github/workflows/build-hummingbird-desktops.yml
+++ b/.github/workflows/build-hummingbird-desktops.yml
@@ -141,8 +141,18 @@ jobs:
             echo "::endgroup::"
           done
 
+      # !cancelled(): publish what BUILT even when some packages in the tier
+      # failed. Tier gnome-00's first real run built 108 of 124 packages and
+      # then exited 1 on the 16 failures — these ifs (which implicitly require
+      # every prior step to succeed) skipped publishing, so 4h50m of built
+      # RPMs went to a GitHub artifact instead of R2 and the re-run had to
+      # build all 108 again (run 31137480986). Partial publishes are exactly
+      # what the rclone step below is designed for: copy-not-sync, so nothing
+      # already published can be deleted, and the R2 seed step makes the next
+      # run rebuild only what is missing. The job still fails on failed
+      # packages — publishing is not success, it is not losing the work.
       - name: Sign RPMs and publish
-        if: inputs.publish
+        if: ${{ !cancelled() && inputs.publish }}
         uses: crazy-max/ghaction-import-gpg@v7
         id: import-gpg
         with:
@@ -150,7 +160,7 @@ jobs:
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Publish signed rpm-md repository
-        if: inputs.publish
+        if: ${{ !cancelled() && inputs.publish }}
         run: |
           echo "%_signature gpg" > ~/.rpmmacros
           echo "%_gpg_name ${{ steps.import-gpg.outputs.keyid }}" >> ~/.rpmmacros


### PR DESCRIPTION
Tier gnome-00's first real run ([31137480986](https://github.com/tuna-os/tunaos-packages/actions/runs/31137480986)) built **108 of its 124 packages** in 4h50m, exited 1 on the 16 that failed (dconf, exempi, gnome-user-docs, iso-codes, libbytesize, libldac, libnvme, libplist, libuser, lockdev, mozjs140, orc, python-argcomplete, redhat-menus, v4l-utils, wavpack), and published **nothing**: the publish steps' `if: inputs.publish` implicitly also requires every prior step to have succeeded, so the built RPMs went to a 240MB GitHub artifact instead of R2 — and the next run has to build all 108 again.

Publishing a partial tier is exactly what this workflow's own publish step is designed to make safe — rclone **copy**, not sync, "a partial tier run must never delete packages an earlier tier published" — and the R2 seed step at the top exists so a re-run rebuilds only what is missing. Skipping the publish on partial failure defeats both.

`!cancelled() && inputs.publish` runs the publish after a failed build step but not on a cancelled run. The job still exits failure when packages fail: publishing is not success, it is not losing the work.

After this merges, re-dispatching `gnome-00` with `publish: true` rebuilds the 108 once more (nothing is in R2 yet), publishes them regardless of how the 16 strays fare, and every run after that is incremental.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->