### PR TITLE
test(gate): pin every dedicated job's inline assertions to its recipe

### DIFF
--- a/packages/cpptrace-devel/package.yaml
+++ b/packages/cpptrace-devel/package.yaml
@@ -33,5 +33,9 @@ outputs:
         description: C++ stacktrace library built with libunwind.
         files: [usr/include/cpptrace, usr/include/ctrace, usr/lib/*/libcpptrace.so*, usr/lib/*/cmake/cpptrace]
 verify:
-  smoke: "test -f /usr/include/cpptrace/cpptrace.hpp && test -f /usr/include/ctrace/ctrace.h"
+  # The ldconfig assertion is the el10 gate job's long-standing third check:
+  # headers existing proves nothing about the shared library actually being
+  # installed and registered. Recorded here so the recipe carries the gate's
+  # full contract instead of a weaker one a switchover would silently adopt.
+  smoke: "test -f /usr/include/cpptrace/cpptrace.hpp && test -f /usr/include/ctrace/ctrace.h && ldconfig -p | grep -F libcpptrace.so.1"
 targets: [el10, ubuntu, debian, opensuse-tumbleweed, arch]

--- a/tests/test_gate_verify_consistency.py
+++ b/tests/test_gate_verify_consistency.py
@@ -12,6 +12,7 @@ go away, this file proves nothing was lost in the move.
 from __future__ import annotations
 
 import importlib.util
+import re
 from pathlib import Path
 
 import pytest
@@ -199,3 +200,116 @@ def test_niri_carries_its_full_session_contract() -> None:
         "/usr/lib/systemd/user/niri-shutdown.target",
     ):
         assert asset in smoke, f"niri verify.smoke does not assert {asset}"
+
+
+# --- dedicated jobs' inline scripts, pinned to the recipes -------------------
+#
+# The matrix-include tests above cannot see the dedicated jobs: those carry
+# their assertions inline in `run:` blocks, which is how seven packages ended
+# up with no verify block at all while this file claimed the gate was fully
+# cross-checked. The niri test above pinned exactly one of them, by hand.
+# These tests generalise it: every dedicated job's inline script must contain
+# every fragment of the recipe's verify.smoke for the targets that job builds,
+# so weakening either side without the other is a test failure.
+#
+# The jobs may assert MORE than the recipe (closure `rpm -q` lists, the DMS
+# stack's non-root `runuser -- dms --help` integration check, which spans
+# three packages plus quickshell and cannot be a single recipe's smoke).
+# What they may not do is assert less.
+
+SUPPORTED_GATE = ROOT / ".github" / "workflows" / "build-tideforge-supported.yml"
+
+# job name -> (package, target) pairs whose recipe contract the job's inline
+# steps must carry. input-remapper-rpm is absent on purpose: its cell carries
+# `smoke`/`install_name` matrix keys, so the byte-identity tests above already
+# cover it.
+DEDICATED_JOB_CONTRACTS = {
+    "gtkgreet-rpm": [("gtkgreet", "el10")],
+    "cpptrace-rpm": [("cpptrace-devel", "el10")],
+    "quickshell-rpm": [("quickshell", "el10")],
+    "niri-rpm": [("niri", "el10")],
+    "iio-niri-rpm": [("iio-niri", "el10")],
+    "dms-stack-rpm": [("dms", "el10"), ("dms-cli", "el10"), ("dms-greeter", "el10")],
+    "cosmic-icon-theme-rpm": [("cosmic-icon-theme", "el10")],
+    "cosmic-comp-rpm": [("cosmic-comp", "el10")],
+    "cosmic-bg-rpm": [("cosmic-bg", "el10")],
+    "cosmic-icon-theme-deb": [
+        ("cosmic-icon-theme", "ubuntu"),
+        ("cosmic-icon-theme", "debian"),
+    ],
+    "cosmic-comp-deb": [("cosmic-comp", "ubuntu"), ("cosmic-comp", "debian")],
+}
+
+
+def _normalise(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _job_run_text(job: dict) -> str:
+    return _normalise("\n".join(step.get("run", "") for step in job.get("steps", [])))
+
+
+def _supported_jobs() -> dict:
+    return yaml.safe_load(SUPPORTED_GATE.read_text())["jobs"]
+
+
+DEDICATED_CASES = [
+    (job, package, target)
+    for job, pairs in DEDICATED_JOB_CONTRACTS.items()
+    for package, target in pairs
+]
+
+
+@pytest.mark.parametrize(
+    "job_name,package,target",
+    DEDICATED_CASES,
+    ids=[f"{job}-{package}-{target}" for job, package, target in DEDICATED_CASES],
+)
+def test_dedicated_job_carries_the_recipe_contract(
+    job_name: str, package: str, target: str
+) -> None:
+    jobs = _supported_jobs()
+    assert job_name in jobs, f"gate job {job_name} disappeared; update the contract map"
+    job_text = _job_run_text(jobs[job_name])
+    smoke = tideforge.verify_metadata(recipe_for(package), target)["smoke"]
+    assert smoke, f"{package} has no verify.smoke to pin {job_name} against"
+    for fragment in (part.strip() for part in smoke.split("&&")):
+        assert _normalise(fragment) in job_text, (
+            f"{job_name}: inline script does not assert {fragment!r} from "
+            f"{package}'s verify.smoke ({target}). Either the job weakened the "
+            "gate below the recipe contract, or the recipe grew a check the "
+            "job does not run -- fix whichever side is wrong, in the open."
+        )
+
+
+def test_every_dedicated_recipe_job_is_pinned() -> None:
+    """A new dedicated job must land in DEDICATED_JOB_CONTRACTS.
+
+    Detect dedicated jobs the same way they betray themselves: a literal
+    `packages/<name>/package.yaml` reference in a step (matrix-driven jobs
+    interpolate the package name instead). Without this, the next
+    single-package job would repeat the original gap this section closes.
+    """
+    literal = re.compile(r"packages/([a-z0-9-]+)/package\.yaml")
+    pinned = {
+        (job, package)
+        for job, pairs in DEDICATED_JOB_CONTRACTS.items()
+        for package, _ in pairs
+    }
+    for job_name, job in _supported_jobs().items():
+        references = set()
+        for step in job.get("steps", []):
+            references.update(literal.findall(step.get("run", "")))
+            references.update(literal.findall(str(step.get("with", {}).get("recipe", ""))))
+        for package in references:
+            has_matrix_verify_cells = any(
+                cell.get("package") == package and ("smoke" in cell or "install_name" in cell)
+                for cell in job.get("strategy", {}).get("matrix", {}).get("include", [])
+            )
+            if has_matrix_verify_cells:
+                continue
+            assert (job_name, package) in pinned, (
+                f"{job_name} builds packages/{package} outside the matrix but is "
+                "not in DEDICATED_JOB_CONTRACTS; add it so its inline assertions "
+                "stay pinned to the recipe."
+            )


### PR DESCRIPTION
The byte-identity tests in `tests/test_gate_verify_consistency.py` only walk matrix-include cells. The nine dedicated jobs — `gtkgreet-rpm`, `cpptrace-rpm`, `quickshell-rpm`, `niri-rpm`, `iio-niri-rpm`, `dms-stack-rpm`, `cosmic-icon-theme-rpm`, `cosmic-comp-rpm`, `cosmic-bg-rpm`, `cosmic-icon-theme-deb`, `cosmic-comp-deb` — assert their contracts in inline `run:` blocks that nothing cross-checked against the recipes; only the niri session contract had a hand-written pin.

This PR generalises that pin:

- `test_dedicated_job_carries_the_recipe_contract` (15 parametrized cases): every `&&`-fragment of the recipe's `verify.smoke` must appear (whitespace-normalized) in the dedicated job's inline script, for each target the job builds. Weakening either side without the other now fails the suite. Jobs may still assert *more* (closure `rpm -q` lists, the DMS stack's multi-package `useradd` + `runuser -- dms --help` integration check, which spans dms/dms-cli/dms-greeter/quickshell and cannot be one recipe's smoke); they may not assert less.
- `test_every_dedicated_recipe_job_is_pinned`: any new job referencing a literal `packages/<name>/package.yaml` outside a smoke-carrying matrix must be added to the contract map, so the next dedicated job cannot recreate the gap.
- `input-remapper-rpm` is deliberately absent from the map: its cell carries `smoke`/`install_name` matrix keys, so the existing byte-identity tests already cover it.

**One real divergence surfaced and resolved toward the workflow:** `cpptrace-rpm` has always asserted `ldconfig -p | grep -F libcpptrace.so.1` on top of the recipe's two header checks. The job is the provably stronger contract (headers existing proves nothing about the shared library being installed and registered — and the job's check has been green in CI), so `packages/cpptrace-devel/package.yaml` `verify.smoke` is raised to match. No matrix cell anywhere carries cpptrace smoke, so byte-identity is unaffected.

**Mutation verification** (run locally, then reverted):
- deleting `test -f /usr/lib/systemd/user/niri.service` from `niri-rpm`'s inline block → `FAILED ...[niri-rpm-niri-el10]`
- strengthening `cosmic-bg`'s recipe smoke without a gate follow-up → `FAILED ...[cosmic-bg-rpm-cosmic-bg-el10]`

Tests: `pytest tests/` — 351 passed (335 on main + 16 new).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->