### PR TITLE
fix(manifests): reconcile dependency trees with recipe deps, and keep them reconciled

### DIFF
--- a/manifests/dependency-trees/cosmic.yaml
+++ b/manifests/dependency-trees/cosmic.yaml
@@ -3,7 +3,7 @@ tree: cosmic
 targets: [el10, ubuntu, debian]
 roots: [cosmic-session, cosmic-settings, cosmic-greeter, xdg-desktop-portal-cosmic]
 nodes:
-  cosmic-session: {source: pop-os/cosmic-epoch, needs: [cosmic-bg, cosmic-comp, cosmic-idle, cosmic-notifications, cosmic-osd, cosmic-panel, cosmic-settings, xdg-desktop-portal-cosmic, greetd]}
+  cosmic-session: {source: pop-os/cosmic-epoch, needs: [cosmic-bg, cosmic-comp, cosmic-greeter, cosmic-idle, cosmic-notifications, cosmic-osd, cosmic-panel, cosmic-randr, cosmic-settings, cosmic-settings-daemon, xdg-desktop-portal-cosmic, greetd]}
   cosmic-bg: {source: pop-os/cosmic-bg, needs: [cosmic-icon-theme, cargo-toolchain, wayland-stack]}
   cosmic-icon-theme: {source: pop-os/cosmic-icons, needs: [pop-icon-theme]}
   cosmic-idle: {source: pop-os/cosmic-idle, needs: [cosmic-icon-theme, cargo-toolchain, wayland-stack]}
@@ -11,14 +11,15 @@ nodes:
   cosmic-osd: {source: pop-os/cosmic-osd, needs: [cosmic-icon-theme, cargo-toolchain, pipewire-stack, wayland-stack]}
   cosmic-panel: {source: pop-os/cosmic-panel, needs: [cargo-toolchain, wayland-stack]}
   pop-icon-theme: {source: pop-os/icon-theme, needs: [meson-toolchain]}
-  cosmic-comp: {source: pop-os/cosmic-comp, needs: [cargo-toolchain, wayland-stack]}
-  cosmic-settings: {source: pop-os/cosmic-settings, needs: [cosmic-settings-daemon, cosmic-randr, cargo-toolchain]}
+  cosmic-comp: {source: pop-os/cosmic-comp, needs: [cosmic-icon-theme, libseat, cargo-toolchain, wayland-stack]}
+  cosmic-settings: {source: pop-os/cosmic-settings, needs: [cosmic-icon-theme, cosmic-settings-daemon, cosmic-randr, cargo-toolchain]}
   cosmic-settings-daemon: {source: pop-os/cosmic-settings-daemon, needs: [cargo-toolchain, wayland-stack]}
   cosmic-randr: {source: pop-os/cosmic-randr, needs: [cargo-toolchain, wayland-stack]}
-  cosmic-greeter: {source: pop-os/cosmic-greeter, needs: [greetd]}
-  xdg-desktop-portal-cosmic: {source: pop-os/xdg-desktop-portal-cosmic, needs: [cosmic-comp, cosmic-settings]}
+  cosmic-greeter: {source: pop-os/cosmic-greeter, needs: [cosmic-comp, cosmic-icon-theme, greetd]}
+  xdg-desktop-portal-cosmic: {source: pop-os/xdg-desktop-portal-cosmic, needs: [cosmic-icon-theme, cosmic-comp, cosmic-settings]}
   cargo-toolchain: {kind: distro-build-dependency}
   meson-toolchain: {kind: distro-build-dependency}
   wayland-stack: {kind: distro-build-dependency}
   pipewire-stack: {kind: distro-runtime-dependency}
   greetd: {kind: distro-or-factory-package}
+  libseat: {kind: distro-or-factory-package}

--- a/manifests/dependency-trees/niri.yaml
+++ b/manifests/dependency-trees/niri.yaml
@@ -12,8 +12,8 @@ nodes:
   wayland-protocols: {source: wayland/wayland-protocols, needs: []}
   quickshell: {source: quickshell-mirror/quickshell, needs: [cli11-devel, cpptrace-devel, ninja-build, wayland-protocols, libdrm, qt6-wayland, wayland-stack]}
   dms: {source: AvengeMedia/DankMaterialShell, needs: [quickshell]}
-  dms-cli: {source: AvengeMedia/DankMaterialShell, needs: [dms]}
-  dms-greeter: {source: AvengeMedia/DankMaterialShell, needs: [dms, greetd]}
+  dms-cli: {source: AvengeMedia/DankMaterialShell, needs: [dms, quickshell]}
+  dms-greeter: {source: AvengeMedia/DankMaterialShell, needs: [dms, greetd, quickshell]}
   dgop: {source: AvengeMedia/dgop, needs: []}
   danksearch: {source: AvengeMedia/danksearch, needs: []}
   dankcalendar: {source: AvengeMedia/dankcalendar, needs: [quickshell]}

--- a/tests/test_dependency_tree_consistency.py
+++ b/tests/test_dependency_tree_consistency.py
@@ -1,0 +1,128 @@
+"""Cross-check the dependency trees against the recipes' declared dependencies.
+
+The trees in manifests/dependency-trees/ claim to be the shared source graph,
+but nothing connected their edges to what the recipes actually require, which
+is how cosmic-comp runtime-required cosmic-icon-theme (and the gate staged it
+as a prerequisite artifact) while the cosmic tree's node carried no such edge.
+A tree that disagrees with the recipes cannot be used to derive anything.
+
+Two directions:
+
+* Every factory-built runtime dependency a recipe declares must be an edge of
+  that package's tree node.  A missing edge is exactly the cosmic-comp bug.
+* Every tree edge pointing at a factory-built package must be explained by the
+  recipe -- as a runtime dependency, as a build dependency (the trees encode
+  build ordering too: cpptrace-devel -> libunwind-devel), or as a reviewed
+  functional-coupling edge listed in KNOWN_UNDECLARED_EDGES below.  An
+  unexplained edge is either stale or a dependency the recipe forgot.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+TREES = sorted((ROOT / "manifests" / "dependency-trees").glob("*.yaml"))
+PACKAGES = {
+    path.parent.name: yaml.safe_load(path.read_text())
+    for path in (ROOT / "packages").glob("*/package.yaml")
+    if path.parent.name != "_template"
+}
+
+# Tree edges to factory-built packages that no recipe dependency declares but
+# that survive review as intentional ordering/coupling edges. Each entry is a
+# claim someone can audit; a new unexplained edge fails the test instead of
+# joining this list silently.
+KNOWN_UNDECLARED_EDGES = {
+    # The session queue's gates end in greetd-login: greetd must be built and
+    # shipped for the stack to be testable, though cosmic-session's own
+    # Requires reaches greetd only transitively via cosmic-greeter.
+    ("cosmic", "cosmic-session"): {"greetd"},
+    # The portal backend is functionally coupled to the compositor and the
+    # settings daemon's config surface; neither is a package Requires.
+    ("cosmic", "xdg-desktop-portal-cosmic"): {"cosmic-comp", "cosmic-settings"},
+    # The KRunner plugin queries the Bazaar D-Bus service at search time; the
+    # plugin installs without it, so it is ordering, not Requires.
+    ("aurora-kde", "krunner-bazaar"): {"bazaar"},
+    # The greeter presents the DankMaterialShell experience; its packaged
+    # runtime needs are greetd and quickshell only.
+    ("niri-dms", "dms-greeter"): {"dms"},
+}
+
+
+def _provides() -> dict[str, str]:
+    """Map every name a recipe answers to (dir name, install_names) to its dir."""
+    provides: dict[str, str] = {}
+    for name, recipe in PACKAGES.items():
+        provides[name] = name
+        verify = recipe.get("verify") or {}
+        if verify.get("install_name"):
+            provides[verify["install_name"]] = name
+        for override in (verify.get("targets") or {}).values():
+            if override.get("install_name"):
+                provides[override["install_name"]] = name
+    return provides
+
+
+PROVIDES = _provides()
+
+
+def _base(dependency: str) -> str:
+    return dependency.split()[0].split(">=")[0].split("<=")[0].split("=")[0].strip()
+
+
+def _factory_dependencies(recipe: dict, kind: str) -> set[str]:
+    block = (recipe.get("dependencies") or {}).get(kind) or {}
+    names = list(block.get("common") or [])
+    for target_list in (block.get("targets") or {}).values():
+        names.extend(target_list or [])
+    return {PROVIDES[_base(name)] for name in names if _base(name) in PROVIDES}
+
+
+def _tree_cases() -> list[tuple[str, str, dict, dict]]:
+    cases = []
+    for tree_path in TREES:
+        tree = yaml.safe_load(tree_path.read_text())
+        for node, spec in (tree.get("nodes") or {}).items():
+            if node in PACKAGES:
+                cases.append((tree.get("tree", tree_path.stem), node, spec or {}, PACKAGES[node]))
+    return cases
+
+
+CASES = _tree_cases()
+
+
+def test_trees_actually_reference_recipes() -> None:
+    """An empty case list would make the tests below vacuously pass."""
+    assert len(CASES) >= 30
+
+
+@pytest.mark.parametrize("tree,node,spec,recipe", CASES, ids=[f"{t}-{n}" for t, n, _, _ in CASES])
+def test_factory_runtime_deps_are_tree_edges(tree: str, node: str, spec: dict, recipe: dict) -> None:
+    runtime = _factory_dependencies(recipe, "runtime")
+    edges = {PROVIDES[n] for n in spec.get("needs") or [] if n in PROVIDES}
+    missing = runtime - edges
+    assert not missing, (
+        f"{tree}: {node} runtime-requires factory-built {sorted(missing)} "
+        "but the tree node has no such edge -- the tree cannot derive the "
+        "staging this package needs."
+    )
+
+
+@pytest.mark.parametrize("tree,node,spec,recipe", CASES, ids=[f"{t}-{n}" for t, n, _, _ in CASES])
+def test_tree_edges_are_explained_by_the_recipe(tree: str, node: str, spec: dict, recipe: dict) -> None:
+    edges = {PROVIDES[n] for n in spec.get("needs") or [] if n in PROVIDES}
+    explained = (
+        _factory_dependencies(recipe, "runtime")
+        | _factory_dependencies(recipe, "build")
+        | KNOWN_UNDECLARED_EDGES.get((tree, node), set())
+    )
+    unexplained = edges - explained
+    assert not unexplained, (
+        f"{tree}: {node} has edges to factory-built {sorted(unexplained)} that "
+        "no recipe dependency declares. Either the recipe under-declares, the "
+        "edge is stale, or it is a reviewed coupling that belongs in "
+        "KNOWN_UNDECLARED_EDGES with a justification."
+    )


### PR DESCRIPTION
The trees in `manifests/dependency-trees/` claim to be the shared source graph, but nothing connected their edges to what the recipes declare. `cosmic-comp` runtime-requires `cosmic-icon-theme >= 1.4.0` (`packages/cosmic-comp/package.yaml`) and the gate stages both it and `libseat` as prerequisite artifacts, yet the cosmic tree's node carried neither edge. Reconciling all five trees against all recipes surfaced more of the same. **Every mismatch found is listed here, none fixed silently:**

Missing edges added (each matches a dependency the recipe already declares; for cosmic, artifacts the gate already stages):

- `cosmic.yaml` `cosmic-comp`: + `cosmic-icon-theme`, `libseat` (and a `libseat` node, kind `distro-or-factory-package`, same as `greetd`)
- `cosmic.yaml` `cosmic-settings`: + `cosmic-icon-theme`
- `cosmic.yaml` `cosmic-greeter`: + `cosmic-comp`, `cosmic-icon-theme`
- `cosmic.yaml` `xdg-desktop-portal-cosmic`: + `cosmic-icon-theme`
- `cosmic.yaml` `cosmic-session`: + `cosmic-greeter`, `cosmic-randr`, `cosmic-settings-daemon`
- `niri.yaml` `dms-cli`: + `quickshell` (recipe: `runtime.common: [dms, quickshell]`)
- `niri.yaml` `dms-greeter`: + `quickshell` (recipe: `runtime.common: [greetd, quickshell]`)

Tree edges no recipe dependency declares — kept, but now explicitly reviewed in the test's `KNOWN_UNDECLARED_EDGES` with justifications rather than floating free:

- `cosmic-session → greetd` (the queue's gates end in greetd-login; reachable only transitively via cosmic-greeter as a package Requires)
- `xdg-desktop-portal-cosmic → cosmic-comp, cosmic-settings` (functional coupling, not Requires)
- `krunner-bazaar → bazaar` (plugin queries the Bazaar D-Bus service at search time; installs without it)
- `dms-greeter → dms` (greeter presents the DMS experience; packaged needs are greetd+quickshell)

New test `tests/test_dependency_tree_consistency.py` (87 cases across all five trees) enforces both directions from now on: every factory-built runtime dep in a recipe must be a tree edge, and every tree edge to a factory-built package must be explained by the recipe's runtime or build deps or by a justified allowlist entry — a new unexplained edge fails the suite.

Mutation-verified: reverting the cosmic-comp edge fails `test_factory_runtime_deps_are_tree_edges[cosmic-cosmic-comp]`.

Tests: `pytest tests/` — 422 passed (335 on main + 87 new). `scripts/validate-target-queues.py` — valid (5 manifests).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->