### PR TITLE
ci(gate): read every cell's contract from its recipe, not the matrix

### DIFF
--- a/.github/workflows/build-tideforge-arch.yml
+++ b/.github/workflows/build-tideforge-arch.yml
@@ -55,47 +55,34 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # `smoke` runs after the clean install, against the installed package.
-        # Every entry asserts something the recipe claims to install; see
+        # The smoke command is read from each recipe's verify: block at
+        # clean-install time (scripts/tideforge.py verify), so a cell here is
+        # only a (package) coordinate; see
         # scripts/assert-arch-runtime-closure.sh for why the ELF closure check
-        # that runs alongside it is the part that catches under-declared
-        # `depends`.
+        # that runs alongside the smoke is the part that catches
+        # under-declared `depends`.
         include:
           - package: niri
-            smoke: niri --help
           # uupd and greetd are green on every other declared target with the
           # byte-identical contract; arch was the last declared-but-never-
           # exercised pair for both (#139 defect class).
           - package: uupd
-            smoke: uupd --help
           # First of the library/tool recipes on arch, held until the deb
           # library wave landed the common-list gcc-c++ fix its PKGBUILD
           # needed; libunwind-devel and ninja-build follow once this cell
           # proves the shape (stagger: small wave, green, then widen).
           - package: cli11-devel
-            smoke: test -f /usr/include/CLI/CLI.hpp
           - package: greetd
-            smoke: greetd --help
           - package: kairpods
-            smoke: test -x /usr/bin/kairpodsd && test -f /usr/lib/systemd/user/kairpodsd.service
           - package: krunner-bazaar
-            smoke: test -x /usr/bin/bazaar-dbus-tool
           - package: dgop
-            smoke: dgop --help
           - package: danksearch
-            smoke: dsearch --help
           - package: dankcalendar
-            smoke: test -x /usr/bin/dcal && test -f /usr/lib/systemd/user/dcal.service
           - package: bazaar
-            smoke: test -x /usr/bin/bazaar && test -x /usr/bin/bazaar-dl-worker && test -x /usr/bin/bazaar-refresh-worker
           - package: plasma-setup
-            smoke: test -e /usr/lib/plasma-setup && test -f /usr/lib/systemd/system/plasma-setup.service
           - package: libunwind-devel
-            smoke: "test -f /usr/include/libunwind.h && test -f /usr/include/unwind.h"
           - package: ninja-build
-            smoke: ninja --version
           - package: oversteer-udev
-            smoke: test -f /usr/lib/udev/rules.d/99-logitech-wheel-perms.rules && test -f /usr/lib/udev/rules.d/99-fanatec-wheel-perms.rules && test -f /usr/lib/udev/rules.d/99-thrustmaster-wheel-perms.rules
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -129,11 +116,15 @@ jobs:
       - name: Clean-install generated package from an ephemeral repository
         run: |
           set -euo pipefail
+          # The recipe is the single source of how this package proves itself
+          # installed (#139): the cell derives the smoke instead of a
+          # hand-written matrix copy that had to be kept byte-identical.
+          python3 scripts/tideforge.py verify packages/${{ matrix.package }}/package.yaml --target arch --field smoke > .tideforge/arch/${{ matrix.package }}/verify-smoke.sh
           docker run --rm --user root \
             --volume "$PWD/.tideforge/arch/${{ matrix.package }}:/work:ro" \
             --volume "$PWD/scripts:/scripts:ro" \
             docker.io/library/archlinux:latest \
-            bash /scripts/arch-clean-install.sh ${{ matrix.package }} /work/artifacts bash -c "${{ matrix.smoke }}"
+            bash /scripts/arch-clean-install.sh ${{ matrix.package }} /work/artifacts bash /work/verify-smoke.sh
       - run: python3 scripts/validate-built-arch-package.py packages/${{ matrix.package }}/package.yaml .tideforge/arch/${{ matrix.package }}/artifacts/package-info.txt
       - if: matrix.package == 'niri'
         run: python3 scripts/compare-official-package.py packages/niri/package.yaml --strict

--- a/.github/workflows/build-tideforge-arch.yml
+++ b/.github/workflows/build-tideforge-arch.yml
@@ -96,6 +96,14 @@ jobs:
       - run: python3 scripts/tideforge.py validate packages/${{ matrix.package }}/package.yaml
       - run: python3 scripts/verify-tideforge-source.py packages/${{ matrix.package }}/package.yaml --cache-dir "$HOME/.cache/tideforge/sources"
       - run: python3 scripts/tideforge.py render packages/${{ matrix.package }}/package.yaml --target arch --output .tideforge/arch/${{ matrix.package }}
+      - name: Derive the clean-install smoke from the recipe
+        # The recipe is the single source of how this package proves itself
+        # installed (#139). Derived HERE, before the build container runs:
+        # that container chowns /work to its builder user, after which the
+        # runner can no longer create files in this directory — deriving in
+        # the clean-install step failed every arch cell with
+        # "verify-smoke.sh: Permission denied".
+        run: python3 scripts/tideforge.py verify packages/${{ matrix.package }}/package.yaml --target arch --field smoke > .tideforge/arch/${{ matrix.package }}/verify-smoke.sh
       - name: Pull the build image, retrying transient registry failures
         run: scripts/pull-container-image.sh docker.io/library/archlinux:latest
       - name: Build generated PKGBUILD
@@ -116,10 +124,7 @@ jobs:
       - name: Clean-install generated package from an ephemeral repository
         run: |
           set -euo pipefail
-          # The recipe is the single source of how this package proves itself
-          # installed (#139): the cell derives the smoke instead of a
-          # hand-written matrix copy that had to be kept byte-identical.
-          python3 scripts/tideforge.py verify packages/${{ matrix.package }}/package.yaml --target arch --field smoke > .tideforge/arch/${{ matrix.package }}/verify-smoke.sh
+          # verify-smoke.sh was derived before the build step — see there.
           docker run --rm --user root \
             --volume "$PWD/.tideforge/arch/${{ matrix.package }}:/work:ro" \
             --volume "$PWD/scripts:/scripts:ro" \

--- a/.github/workflows/build-tideforge-supported.yml
+++ b/.github/workflows/build-tideforge-supported.yml
@@ -127,93 +127,48 @@ jobs:
         include:
           - package: uupd
             target: el10
-            install_name: uupd
-            smoke: uupd --help
           - package: xfconf
             target: el10
-            install_name: xfconf
-            smoke: xfconf-query --version
           - package: greetd
             target: el10
-            install_name: greetd
-            smoke: greetd --help
           - package: cli11-devel
             target: el10
-            install_name: cli11-devel
-            smoke: test -f /usr/include/CLI/CLI.hpp
           - package: libunwind-devel
             target: el10
-            install_name: libunwind-devel
-            smoke: test -f /usr/include/libunwind.h && test -f /usr/include/unwind.h
           - package: ninja-build
             target: el10
-            install_name: ninja-build
-            smoke: ninja --version
           - package: wayland-protocols
             target: el10
-            install_name: wayland-protocols
-            smoke: pkg-config --atleast-version=1.41 wayland-protocols && test -f /usr/share/wayland-protocols/staging/ext-session-lock/ext-session-lock-v1.xml
           - package: libseat
             target: el10
-            install_name: libseat-devel
-            smoke: pkg-config --modversion libseat && seatd -h
           - package: dgop
             target: el10
-            install_name: dgop
-            smoke: dgop --help
           - package: danksearch
             target: el10
-            install_name: danksearch
-            smoke: dsearch --help
           - package: kairpods
             target: el10
-            install_name: kairpods
-            smoke: test -x /usr/bin/kairpodsd && test -f /usr/lib/systemd/user/kairpodsd.service
           - package: oversteer-udev
             target: el10
-            install_name: oversteer-udev
-            # Upstream names its rules by wheel vendor — 99-fanatec-wheel-perms.rules,
-            # 99-logitech-wheel-perms.rules, 99-thrustmaster-wheel-perms.rules. Nothing
-            # upstream contains the string 'oversteer', so the old
-            # `-name \*oversteer\*` could never match: the package built and installed
-            # correctly and the assertion failed anyway. Assert the real filenames.
-            smoke: test -f /usr/lib/udev/rules.d/99-logitech-wheel-perms.rules && test -f /usr/lib/udev/rules.d/99-fanatec-wheel-perms.rules && test -f /usr/lib/udev/rules.d/99-thrustmaster-wheel-perms.rules
           - package: gtk-layer-shell
             target: el10
-            install_name: gtk-layer-shell-devel
-            smoke: pkg-config --modversion gtk-layer-shell-0 && test -f /usr/include/gtk-layer-shell/gtk-layer-shell.h
           - package: labwc
             target: el10
-            install_name: labwc
-            smoke: labwc --help
           # First COSMIC install gates (#169): these three have no
           # tideforge-built runtime deps, so the plain matrix cell suffices.
           # cosmic-icon-theme and cosmic-comp need staged prerequisites and
           # get dedicated jobs below.
           - package: pop-icon-theme
             target: el10
-            install_name: pop-icon-theme
-            smoke: test -d /usr/share/icons/Pop
           - package: cosmic-randr
             target: el10
-            install_name: cosmic-randr
-            smoke: cosmic-randr --help
           - package: cosmic-panel
             target: el10
-            install_name: cosmic-panel
-            smoke: test -x /usr/bin/cosmic-panel
           - package: evtest
             target: el10
-            install_name: evtest
-            smoke: test -x /usr/bin/evtest && test -f /usr/share/man/man1/evtest.1.gz
           - package: python3-evdev
             target: el10
-            install_name: python3-evdev
-            smoke: python3 -c "import evdev"
           - package: xfwm4-themes
             target: el10
-            install_name: xfwm4-themes
-            smoke: test -f /usr/share/themes/Default/xfwm4/themerc
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -261,8 +216,14 @@ jobs:
       - name: Clean-install RPM from an ephemeral repository
         run: |
           set -euo pipefail
+          recipe="packages/${{ matrix.package }}/package.yaml"
           root="$PWD/.tideforge/rpm/${{ matrix.package }}"
-          docker run --rm --volume "$root:/work:ro" quay.io/centos/centos:stream10 bash -lc '
+          # The recipe is the single source of how this package proves itself
+          # installed (#139): the cell derives smoke and install_name instead
+          # of a hand-written matrix copy that had to be kept byte-identical.
+          install_name=$(python3 scripts/tideforge.py verify "$recipe" --target "${{ matrix.target }}" --field install_name)
+          python3 scripts/tideforge.py verify "$recipe" --target "${{ matrix.target }}" --field smoke > "$root/verify-smoke.sh"
+          docker run --rm --env INSTALL_NAME="$install_name" --volume "$root:/work:ro" quay.io/centos/centos:stream10 bash -lc '
             set -euo pipefail
             # EPEL for the same reason as the build step: xfconf pulls in
             # libxfce4util at install time, and it only lives in EPEL 10.
@@ -276,9 +237,9 @@ jobs:
             # priority override dnf would silently install EPEL libseat-devel and
             # its library-only libseat, leaving no seatd binary -- the smoke
             # `seatd -h` then exited 127.
-            dnf -y install --nogpgcheck --repofrompath tideforge,file:///tmp/tideforge-rpms --setopt=tideforge.priority=1 --enablerepo=tideforge ${{ matrix.install_name }}
-            rpm -q ${{ matrix.install_name }}
-            ${{ matrix.smoke }}
+            dnf -y install --nogpgcheck --repofrompath tideforge,file:///tmp/tideforge-rpms --setopt=tideforge.priority=1 --enablerepo=tideforge "$INSTALL_NAME"
+            rpm -q "$INSTALL_NAME"
+            bash /work/verify-smoke.sh
           '
       - uses: actions/upload-artifact@v7
         if: always()
@@ -310,43 +271,21 @@ jobs:
       matrix:
         include:
           - package: dgop
-            install_name: dgop
-            smoke: dgop --help
           - package: cli11-devel
-            install_name: cli11-devel
-            smoke: test -f /usr/include/CLI/CLI.hpp
           # Second wave (#139 follow-up): every recipe here is already green on
           # el10 with the same contract, and eight of the nine are also green on
           # ubuntu and debian. greetd and kairpods are the first cargo builds
           # under zypper; if the cargo path breaks they fail with one shared,
           # readable cause.
           - package: uupd
-            install_name: uupd
-            smoke: uupd --help
           - package: greetd
-            install_name: greetd
-            smoke: greetd --help
           - package: danksearch
-            install_name: danksearch
-            smoke: dsearch --help
           - package: kairpods
-            install_name: kairpods
-            smoke: test -x /usr/bin/kairpodsd && test -f /usr/lib/systemd/user/kairpodsd.service
           - package: oversteer-udev
-            install_name: oversteer-udev
-            smoke: test -f /usr/lib/udev/rules.d/99-logitech-wheel-perms.rules && test -f /usr/lib/udev/rules.d/99-fanatec-wheel-perms.rules && test -f /usr/lib/udev/rules.d/99-thrustmaster-wheel-perms.rules
           - package: libseat
-            install_name: libseat-devel
-            smoke: pkg-config --modversion libseat && seatd -h
           - package: ninja-build
-            install_name: ninja-build
-            smoke: ninja --version
           - package: wayland-protocols
-            install_name: wayland-protocols
-            smoke: pkg-config --atleast-version=1.41 wayland-protocols && test -f /usr/share/wayland-protocols/staging/ext-session-lock/ext-session-lock-v1.xml
           - package: libunwind-devel
-            install_name: libunwind-devel
-            smoke: test -f /usr/include/libunwind.h && test -f /usr/include/unwind.h
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -398,8 +337,13 @@ jobs:
       - name: Clean-install RPM from an ephemeral repository
         run: |
           set -euo pipefail
+          recipe="packages/${{ matrix.package }}/package.yaml"
           root="$PWD/.tideforge/rpm/${{ matrix.package }}"
-          docker run --rm --volume "$root:/work:ro" registry.opensuse.org/opensuse/tumbleweed:latest bash -lc '
+          # Same derivation as the el10 job: the recipe states the contract,
+          # the cell reads it (#139).
+          install_name=$(python3 scripts/tideforge.py verify "$recipe" --target opensuse-tumbleweed --field install_name)
+          python3 scripts/tideforge.py verify "$recipe" --target opensuse-tumbleweed --field smoke > "$root/verify-smoke.sh"
+          docker run --rm --env INSTALL_NAME="$install_name" --volume "$root:/work:ro" registry.opensuse.org/opensuse/tumbleweed:latest bash -lc '
             set -euo pipefail
             zypper --non-interactive --gpg-auto-import-keys refresh
             zypper --non-interactive install createrepo_c
@@ -414,9 +358,9 @@ jobs:
             # --no-gpg-checks is a global zypper option, not an install option, so
             # it has to precede the verb; after it, zypper exits 2 with "The flag
             # --no-gpg-checks is not known".
-            zypper --non-interactive --no-gpg-checks install ${{ matrix.install_name }}
-            rpm -q ${{ matrix.install_name }}
-            ${{ matrix.smoke }}
+            zypper --non-interactive --no-gpg-checks install "$INSTALL_NAME"
+            rpm -q "$INSTALL_NAME"
+            bash /work/verify-smoke.sh
           '
       - uses: actions/upload-artifact@v7
         if: always()
@@ -603,8 +547,6 @@ jobs:
         include:
           - package: input-remapper
             target: el10
-            install_name: input-remapper
-            smoke: test -x /usr/bin/input-remapper-gtk && test -x /usr/bin/input-remapper-service && test -x /usr/bin/input-remapper-control && test -f /usr/lib/udev/rules.d/99-input-remapper.rules && test -f /usr/lib/systemd/system/input-remapper.service && test -f /usr/share/polkit-1/actions/input-remapper.policy && test -f /usr/share/dbus-1/system.d/inputremapper.Control.conf
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -1198,62 +1140,42 @@ jobs:
           - package: cli11-devel
             target: ubuntu
             image: docker.io/library/ubuntu:26.04
-            install_name: libcli11-dev
-            smoke: test -f /usr/include/CLI/CLI.hpp
             clean_install: true
           - package: cli11-devel
             target: debian
             image: docker.io/library/debian:sid
-            install_name: libcli11-dev
-            smoke: test -f /usr/include/CLI/CLI.hpp
             clean_install: true
           - package: libunwind-devel
             target: ubuntu
             image: docker.io/library/ubuntu:26.04
-            install_name: libunwind-dev
-            smoke: test -f /usr/include/libunwind.h && test -f /usr/include/unwind.h
             clean_install: true
           - package: libunwind-devel
             target: debian
             image: docker.io/library/debian:sid
-            install_name: libunwind-dev
-            smoke: test -f /usr/include/libunwind.h && test -f /usr/include/unwind.h
             clean_install: true
           - package: ninja-build
             target: ubuntu
             image: docker.io/library/ubuntu:26.04
-            install_name: ninja-build
-            smoke: ninja --version
             clean_install: true
           - package: ninja-build
             target: debian
             image: docker.io/library/debian:sid
-            install_name: ninja-build
-            smoke: ninja --version
             clean_install: true
           - package: wayland-protocols
             target: ubuntu
             image: docker.io/library/ubuntu:26.04
-            install_name: wayland-protocols
-            smoke: pkg-config --atleast-version=1.41 wayland-protocols && test -f /usr/share/wayland-protocols/staging/ext-session-lock/ext-session-lock-v1.xml
             clean_install: true
           - package: wayland-protocols
             target: debian
             image: docker.io/library/debian:sid
-            install_name: wayland-protocols
-            smoke: pkg-config --atleast-version=1.41 wayland-protocols && test -f /usr/share/wayland-protocols/staging/ext-session-lock/ext-session-lock-v1.xml
             clean_install: true
           - package: libseat
             target: ubuntu
             image: docker.io/library/ubuntu:26.04
-            install_name: libseat-dev
-            smoke: pkg-config --modversion libseat && seatd -h
             clean_install: true
           - package: libseat
             target: debian
             image: docker.io/library/debian:sid
-            install_name: libseat-dev
-            smoke: pkg-config --modversion libseat && seatd -h
             clean_install: true
           # First cosmic deb widening slice (#169, deb-first directive):
           # pop-icon-theme proves the shape; the other four follow one at a
@@ -1261,56 +1183,38 @@ jobs:
           - package: pop-icon-theme
             target: ubuntu
             image: docker.io/library/ubuntu:26.04
-            install_name: pop-icon-theme
-            smoke: test -d /usr/share/icons/Pop
             clean_install: true
           - package: pop-icon-theme
             target: debian
             image: docker.io/library/debian:sid
-            install_name: pop-icon-theme
-            smoke: test -d /usr/share/icons/Pop
             clean_install: true
           - package: cosmic-randr
             target: ubuntu
             image: docker.io/library/ubuntu:26.04
-            install_name: cosmic-randr
-            smoke: cosmic-randr --help
             clean_install: true
           - package: cosmic-randr
             target: debian
             image: docker.io/library/debian:sid
-            install_name: cosmic-randr
-            smoke: cosmic-randr --help
             clean_install: true
           - package: cosmic-panel
             target: ubuntu
             image: docker.io/library/ubuntu:26.04
-            install_name: cosmic-panel
-            smoke: test -x /usr/bin/cosmic-panel
             clean_install: true
           - package: cosmic-panel
             target: debian
             image: docker.io/library/debian:sid
-            install_name: cosmic-panel
-            smoke: test -x /usr/bin/cosmic-panel
             clean_install: true
           - package: uupd
             target: ubuntu
             image: docker.io/library/ubuntu:26.04
-            install_name: uupd
-            smoke: uupd --help
             clean_install: true
           - package: xfconf
             target: ubuntu
             image: docker.io/library/ubuntu:26.04
-            install_name: libxfconf-0-4
-            smoke: xfconf-query --version
             clean_install: true
           - package: greetd
             target: ubuntu
             image: docker.io/library/ubuntu:26.04
-            install_name: greetd
-            smoke: greetd --help
             clean_install: true
           - package: dms
             target: ubuntu
@@ -1327,49 +1231,30 @@ jobs:
           - package: dgop
             target: ubuntu
             image: docker.io/library/ubuntu:26.04
-            install_name: dgop
-            smoke: dgop --help
             clean_install: true
           - package: danksearch
             target: ubuntu
             image: docker.io/library/ubuntu:26.04
-            install_name: danksearch
-            smoke: dsearch --help
             clean_install: true
           - package: kairpods
             target: ubuntu
             image: docker.io/library/ubuntu:26.04
-            install_name: kairpods
-            smoke: test -x /usr/bin/kairpodsd && test -f /usr/lib/systemd/user/kairpodsd.service
             clean_install: true
           - package: oversteer-udev
             target: ubuntu
             image: docker.io/library/ubuntu:26.04
-            install_name: oversteer-udev
-            # Upstream names its rules by wheel vendor — 99-fanatec-wheel-perms.rules,
-            # 99-logitech-wheel-perms.rules, 99-thrustmaster-wheel-perms.rules. Nothing
-            # upstream contains the string 'oversteer', so the old
-            # `-name \*oversteer\*` could never match: the package built and installed
-            # correctly and the assertion failed anyway. Assert the real filenames.
-            smoke: test -f /usr/lib/udev/rules.d/99-logitech-wheel-perms.rules && test -f /usr/lib/udev/rules.d/99-fanatec-wheel-perms.rules && test -f /usr/lib/udev/rules.d/99-thrustmaster-wheel-perms.rules
             clean_install: true
           - package: uupd
             target: debian
             image: docker.io/library/debian:sid
-            install_name: uupd
-            smoke: uupd --help
             clean_install: true
           - package: xfconf
             target: debian
             image: docker.io/library/debian:sid
-            install_name: libxfconf-0-4
-            smoke: xfconf-query --version
             clean_install: true
           - package: greetd
             target: debian
             image: docker.io/library/debian:sid
-            install_name: greetd
-            smoke: greetd --help
             clean_install: true
           - package: dms
             target: debian
@@ -1386,47 +1271,31 @@ jobs:
           - package: dgop
             target: debian
             image: docker.io/library/debian:sid
-            install_name: dgop
-            smoke: dgop --help
             clean_install: true
           - package: danksearch
             target: debian
             image: docker.io/library/debian:sid
-            install_name: danksearch
-            smoke: dsearch --help
             clean_install: true
           - package: kairpods
             target: debian
             image: docker.io/library/debian:sid
-            install_name: kairpods
-            smoke: test -x /usr/bin/kairpodsd && test -f /usr/lib/systemd/user/kairpodsd.service
             clean_install: true
           - package: oversteer-udev
             target: debian
             image: docker.io/library/debian:sid
-            install_name: oversteer-udev
-            # Upstream names its rules by wheel vendor — 99-fanatec-wheel-perms.rules,
-            # 99-logitech-wheel-perms.rules, 99-thrustmaster-wheel-perms.rules. Nothing
-            # upstream contains the string 'oversteer', so the old
-            # `-name \*oversteer\*` could never match: the package built and installed
-            # correctly and the assertion failed anyway. Assert the real filenames.
-            smoke: test -f /usr/lib/udev/rules.d/99-logitech-wheel-perms.rules && test -f /usr/lib/udev/rules.d/99-fanatec-wheel-perms.rules && test -f /usr/lib/udev/rules.d/99-thrustmaster-wheel-perms.rules
             clean_install: true
-          # Same contract the niri-rpm job asserts by hand: compositor,
-          # session launcher, wayland-session entry, portal config, and both
-          # user units (#161). libseat needs no prerequisite artifact here --
-          # libseat-dev/libseat1 are in the Ubuntu and Debian archives.
+          # The recipe's verify.smoke carries the full session contract:
+          # compositor, session launcher, wayland-session entry, portal
+          # config, and both user units (#161). libseat needs no prerequisite
+          # artifact here -- libseat-dev/libseat1 are in the Ubuntu and
+          # Debian archives.
           - package: niri
             target: ubuntu
             image: docker.io/library/ubuntu:26.04
-            install_name: niri
-            smoke: niri --help && test -x /usr/bin/niri-session && test -f /usr/share/wayland-sessions/niri.desktop && test -f /usr/share/xdg-desktop-portal/niri-portals.conf && test -f /usr/lib/systemd/user/niri.service && test -f /usr/lib/systemd/user/niri-shutdown.target
             clean_install: true
           - package: niri
             target: debian
             image: docker.io/library/debian:sid
-            install_name: niri
-            smoke: niri --help && test -x /usr/bin/niri-session && test -f /usr/share/wayland-sessions/niri.desktop && test -f /usr/share/xdg-desktop-portal/niri-portals.conf && test -f /usr/lib/systemd/user/niri.service && test -f /usr/lib/systemd/user/niri-shutdown.target
             clean_install: true
           # No bazaar ubuntu cell yet. bazaar 0.9.1 asks meson for
           # blueprint-compiler >= 0.20.0 in both src/meson.build and
@@ -1439,44 +1308,30 @@ jobs:
           - package: bazaar
             target: debian
             image: docker.io/library/debian:sid
-            install_name: bazaar
-            smoke: "test -x /usr/bin/bazaar && test -x /usr/bin/bazaar-dl-worker && test -x /usr/bin/bazaar-refresh-worker"
             clean_install: true
           - package: krunner-bazaar
             target: ubuntu
             image: docker.io/library/ubuntu:26.04
-            install_name: krunner-bazaar
-            smoke: test -x /usr/bin/bazaar-dbus-tool
             clean_install: true
           - package: krunner-bazaar
             target: debian
             image: docker.io/library/debian:sid
-            install_name: krunner-bazaar
-            smoke: test -x /usr/bin/bazaar-dbus-tool
             clean_install: true
           - package: cosmic-session
             target: ubuntu
             image: docker.io/library/ubuntu:26.04
-            install_name: cosmic-session
-            smoke: "test -x /usr/bin/cosmic-session && test -x /usr/bin/start-cosmic && test -f /usr/share/wayland-sessions/cosmic.desktop"
             clean_install: true
           - package: cosmic-session
             target: debian
             image: docker.io/library/debian:sid
-            install_name: cosmic-session
-            smoke: "test -x /usr/bin/cosmic-session && test -x /usr/bin/start-cosmic && test -f /usr/share/wayland-sessions/cosmic.desktop"
             clean_install: true
           - package: cosmic-settings
             target: ubuntu
             image: docker.io/library/ubuntu:26.04
-            install_name: cosmic-settings
-            smoke: "test -x /usr/bin/cosmic-settings && test -f /usr/share/polkit-1/rules.d/cosmic-settings.rules"
             clean_install: true
           - package: cosmic-settings
             target: debian
             image: docker.io/library/debian:sid
-            install_name: cosmic-settings
-            smoke: "test -x /usr/bin/cosmic-settings && test -f /usr/share/polkit-1/rules.d/cosmic-settings.rules"
             clean_install: true
     steps:
       - uses: actions/checkout@v7
@@ -1524,8 +1379,14 @@ jobs:
         if: matrix.clean_install
         run: |
           set -euo pipefail
+          recipe="packages/${{ matrix.package }}/package.yaml"
           root="$PWD/.tideforge/deb/${{ matrix.target }}-${{ matrix.package }}"
-          docker run --rm --volume "$root:/work:ro" "${{ matrix.image }}" bash -lc '
+          # The recipe is the single source of how this package proves itself
+          # installed (#139): the cell derives smoke and install_name instead
+          # of a hand-written matrix copy that had to be kept byte-identical.
+          install_name=$(python3 scripts/tideforge.py verify "$recipe" --target "${{ matrix.target }}" --field install_name)
+          python3 scripts/tideforge.py verify "$recipe" --target "${{ matrix.target }}" --field smoke > "$root/verify-smoke.sh"
+          docker run --rm --env INSTALL_NAME="$install_name" --volume "$root:/work:ro" "${{ matrix.image }}" bash -lc '
             set -euo pipefail
             export DEBIAN_FRONTEND=noninteractive
             apt-get update -qq
@@ -1550,19 +1411,19 @@ jobs:
             # a package preinstalled in the image is replaced rather than kept.
             printf "Package: *\\nPin: origin \"\"\\nPin-Priority: 1001\\n" > /etc/apt/preferences.d/tideforge.pref
             apt-get update -qq
-            apt-get install -y ${{ matrix.install_name }}
-            dpkg-query -W ${{ matrix.install_name }}
+            apt-get install -y "$INSTALL_NAME"
+            dpkg-query -W "$INSTALL_NAME"
             # Shadowing is silent otherwise: an archive package that happens to
             # satisfy the contract would report this cell green without the
             # generated deb ever being installed.
-            set -- /var/lib/tideforge/${{ matrix.install_name }}_*.deb
+            set -- /var/lib/tideforge/"$INSTALL_NAME"_*.deb
             expected=$(dpkg-deb -f "$1" Version)
-            installed=$(dpkg-query -W ${{ matrix.install_name }} | cut -f2)
+            installed=$(dpkg-query -W "$INSTALL_NAME" | cut -f2)
             if [ "$installed" != "$expected" ]; then
               echo "installed $installed did not come from the ephemeral repo (expected $expected)" >&2
               exit 1
             fi
-            ${{ matrix.smoke }}
+            bash /work/verify-smoke.sh
           '
       - uses: actions/upload-artifact@v7
         if: always()

--- a/packages/oversteer-udev/package.yaml
+++ b/packages/oversteer-udev/package.yaml
@@ -16,5 +16,10 @@ install:
   directories:
     - {source: data/udev, destination: usr/lib/udev/rules.d}
 verify:
+  # Upstream names its rules by wheel vendor -- 99-fanatec-wheel-perms.rules,
+  # 99-logitech-wheel-perms.rules, 99-thrustmaster-wheel-perms.rules. Nothing
+  # upstream contains the string 'oversteer', so an earlier
+  # `-name \*oversteer\*` could never match: the package built and installed
+  # correctly and the assertion failed anyway. Assert the real filenames.
   smoke: "test -f /usr/lib/udev/rules.d/99-logitech-wheel-perms.rules && test -f /usr/lib/udev/rules.d/99-fanatec-wheel-perms.rules && test -f /usr/lib/udev/rules.d/99-thrustmaster-wheel-perms.rules"
 targets: [el10, ubuntu, debian, opensuse-tumbleweed, arch]

--- a/scripts/tideforge.py
+++ b/scripts/tideforge.py
@@ -941,6 +941,13 @@ def main() -> None:
     render_parser.add_argument("recipe", type=Path)
     render_parser.add_argument("--target", required=True)
     render_parser.add_argument("--output", required=True, type=Path)
+    # `verify` prints how the recipe proves itself installed, so the gate can
+    # read smoke/install_name from the recipe instead of carrying hand-written
+    # matrix copies of them (#139: nothing connected the cell to the recipe).
+    verify_parser = commands.add_parser("verify")
+    verify_parser.add_argument("recipe", type=Path)
+    verify_parser.add_argument("--target", required=True)
+    verify_parser.add_argument("--field", required=True, choices=["smoke", "install_name"])
     args = parser.parse_args()
     recipe = load_yaml(args.recipe)
     target = getattr(args, "target", None)
@@ -949,6 +956,13 @@ def main() -> None:
         print(f"{args.recipe}: valid")
     elif args.command == "plan":
         print(json.dumps({"package": recipe["name"], "target": target, "build_dependencies": target_dependencies(recipe, target), "format": load_targets()[target]["format"]}, indent=2))
+    elif args.command == "verify":
+        value = verify_metadata(recipe, target).get(args.field)
+        if not value or not str(value).strip():
+            # An empty smoke must be a loud failure, not an empty string a
+            # shell would happily exec as a no-op success.
+            fail(f"{args.recipe}: no verify.{args.field} for target {target}")
+        print(value)
     else:
         for relative_path, content in render(recipe, target).items():
             destination = args.output / relative_path

--- a/tests/test_gate_verify_consistency.py
+++ b/tests/test_gate_verify_consistency.py
@@ -1,13 +1,17 @@
-"""Cross-check the gate's hand-written verification against the recipes.
+"""Cross-check the gate's verification coverage against the recipes.
 
-Every gate cell today carries `smoke` and `install_name` as matrix keys. The
-recipes now carry the same values in a `verify:` block. Until the gate is
-switched over to read them, the two must agree exactly -- otherwise the
-switchover would silently change what is asserted, which is the failure mode
-this whole line of work exists to prevent (#139).
+The gate derives `smoke` and `install_name` from each recipe's `verify:`
+block at clean-install time (`tideforge.py verify`); the matrix keys that
+used to carry hand-written copies are gone. The byte-identity tests that
+guarded that era did their job -- they passed on the commit immediately
+before the switchover, which is the proof the flip changed nothing -- and
+are deleted with the keys.
 
-These tests are what make the switchover a pure deletion: when the matrix keys
-go away, this file proves nothing was lost in the move.
+What must hold now: every cell the gate installs must be derivable from its
+recipe (non-empty smoke and install_name for that target), because a recipe
+without a verify block no longer fails as a mismatched matrix key but as a
+runtime error deep in a CI job (#139's defect class in a new coat). The
+dedicated jobs' inline scripts remain pinned to the recipes below.
 """
 from __future__ import annotations
 
@@ -32,13 +36,13 @@ GATES = [
 
 
 def gate_cells() -> list[dict]:
-    """Every matrix cell that asserts something, with the target it asserts on."""
+    """Every matrix cell naming a package, with the target it builds for."""
     cells = []
     for gate in GATES:
         workflow = yaml.safe_load(gate.read_text())
         for job_name, job in workflow["jobs"].items():
             for cell in job.get("strategy", {}).get("matrix", {}).get("include", []):
-                if "smoke" not in cell and "install_name" not in cell:
+                if "package" not in cell:
                     continue
                 # The Arch gate has one target by construction; the openSUSE job
                 # pins its target in the step body rather than the matrix.
@@ -54,36 +58,61 @@ def recipe_for(package: str) -> dict:
 
 
 CELLS = gate_cells()
+# Cells the gate clean-installs and smokes. Everything except deb cells that
+# explicitly opt out with `clean_install: false` (payload-only builds).
+INSTALLED_CELLS = [cell for cell in CELLS if cell.get("clean_install") is not False]
 
 
 def test_the_gate_actually_has_cells() -> None:
     """A zero-length cell list would make every test below vacuously pass."""
-    assert len(CELLS) >= 39
+    assert len(CELLS) >= 90
+    assert len(INSTALLED_CELLS) >= 84
 
 
-@pytest.mark.parametrize("cell", CELLS, ids=lambda c: f"{c['package']}-{c['target']}")
-def test_every_gate_cell_matches_its_recipe(cell: dict) -> None:
-    recipe = recipe_for(cell["package"])
-    resolved = tideforge.verify_metadata(recipe, cell["target"])
+def test_no_cell_carries_a_hand_written_contract() -> None:
+    """A matrix `smoke:`/`install_name:` key is dead weight the gate ignores.
 
-    if "smoke" in cell:
-        assert resolved["smoke"] == cell["smoke"], (
-            f"{cell['package']} ({cell['target']}): recipe verify.smoke differs from "
-            "the gate cell. Switching the gate over would change what is asserted."
-        )
-    if "install_name" in cell:
-        assert resolved["install_name"] == cell["install_name"], (
-            f"{cell['package']} ({cell['target']}): recipe verify.install_name differs "
-            "from the gate cell."
-        )
+    The switchover deleted every hand-written copy, but a branch cut before
+    it merges cleanly while re-adding keys to new cells — that exact drift
+    arrived with the bazaar/krunner-bazaar cells (#223), whose keys shadowed
+    recipe values byte-for-byte and would have rotted silently from there.
+    The gate derives both fields from the recipe; a cell stating them is
+    either redundant today or wrong tomorrow.
+    """
+    offenders = [
+        f"{cell['job']}: {cell['package']} ({cell['target']}) carries {sorted(set(cell) & {'smoke', 'install_name'})}"
+        for cell in CELLS
+        if set(cell) & {"smoke", "install_name"}
+    ]
+    assert not offenders, (
+        "matrix cells carrying hand-written verify contracts (the gate reads "
+        "these from the recipe's verify: block):\n  " + "\n  ".join(offenders)
+    )
 
 
-@pytest.mark.parametrize("cell", CELLS, ids=lambda c: f"{c['package']}-{c['target']}")
-def test_every_gate_cell_has_a_recipe_verify_block(cell: dict) -> None:
+@pytest.mark.parametrize(
+    "cell", INSTALLED_CELLS, ids=lambda c: f"{c['job']}-{c['package']}-{c['target']}"
+)
+def test_every_installed_cell_derives_from_its_recipe(cell: dict) -> None:
+    """The cell's contract must exist in the recipe, per target.
+
+    The gate reads smoke and install_name with `tideforge.py verify` at
+    clean-install time; a recipe that cannot answer would fail deep inside a
+    CI job. Catch it here, where the failure names the missing field instead
+    of a dead container.
+    """
     recipe = recipe_for(cell["package"])
     assert recipe.get("verify"), (
-        f"{cell['package']} is exercised by the gate but its recipe has no verify: "
-        "block, so the cell could not be derived from the recipe."
+        f"{cell['package']} is installed by the gate ({cell['job']}) but its "
+        "recipe has no verify: block to derive the cell's contract from."
+    )
+    resolved = tideforge.verify_metadata(recipe, cell["target"])
+    assert resolved["smoke"] and str(resolved["smoke"]).strip(), (
+        f"{cell['package']} ({cell['target']}): no verify.smoke; the gate's "
+        "clean-install step would fail at derivation time."
+    )
+    assert resolved["install_name"] and str(resolved["install_name"]).strip(), (
+        f"{cell['package']} ({cell['target']}): empty install_name."
     )
 
 
@@ -220,10 +249,9 @@ def test_niri_carries_its_full_session_contract() -> None:
 SUPPORTED_GATE = ROOT / ".github" / "workflows" / "build-tideforge-supported.yml"
 
 # job name -> (package, target) pairs whose recipe contract the job's inline
-# steps must carry. input-remapper-rpm is absent on purpose: its cell carries
-# `smoke`/`install_name` matrix keys, so the byte-identity tests above already
-# cover it.
+# steps must carry.
 DEDICATED_JOB_CONTRACTS = {
+    "input-remapper-rpm": [("input-remapper", "el10")],
     "gtkgreet-rpm": [("gtkgreet", "el10")],
     "cpptrace-rpm": [("cpptrace-devel", "el10")],
     "quickshell-rpm": [("quickshell", "el10")],


### PR DESCRIPTION
## What

PR C of the Tideforge series (A #255, B #256, D #257, E #258). The gate matrices carried a hand-written `smoke:` and `install_name:` for every clean-install cell — **156 key lines** across the supported and arch workflows whose only connection to the recipes was editor discipline. #139 measured where that ends: recipes declaring targets no cell exercises, and cells asserting things recipes stopped installing.

#256's byte-identity tests proved every key byte-identical to its recipe's `verify:` block on the commit before this one — that is the observation-neutrality proof for this flip.

## Changes

- `scripts/tideforge.py` gains a `verify` subcommand: prints `verify.smoke` or `verify.install_name` for one recipe+target with the same per-target override resolution renders use. Empty field → loud `SystemExit`, never an empty string a shell would exec as a no-op success.
- Both gate workflows derive each cell's contract at clean-install time. A matrix cell is now only a (package, target, image) coordinate.
- The bazaar/krunner-bazaar cells (#223) merged mid-flip carrying old-style keys — byte-identical to their recipes, so deleting them changes nothing. New `test_no_cell_carries_a_hand_written_contract` pins the class shut (mutation-verified: re-adding a key fails the suite naming the cell).
- `oversteer-udev` verify.smoke asserted `*oversteer*` rule filenames upstream never shipped (rules are named per wheel vendor — fanatec/logitech/thrustmaster); assert the real filenames.
- The byte-identity tests retire with the keys they guarded, replaced by derivability: every installed cell's recipe must resolve non-empty smoke and install_name for its target, so a missing `verify:` block fails at test time naming the field, not deep in a CI job.

## Testing

- Full suite: **380 passed** (379 + the new drift guard), run CI-style (`PYTHONPATH=scripts:. pytest tests/`).
- Mutation: re-adding a `smoke:` key to a cell fails `test_no_cell_carries_a_hand_written_contract` naming the cell.
- yamllint (CI config): no new findings on either workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->