### PR TITLE
fix(mock): survive dnf5 failing an already-satisfied dynamic BuildRequires

### DIFF
--- a/scripts/build-chain.sh
+++ b/scripts/build-chain.sh
@@ -389,85 +389,119 @@ build_package_podman() {
     local mock_check_flag="--nocheck"
     $WITH_CHECKS && mock_check_flag=""
 
-    podman run --rm --privileged \
-        --pull=always \
-        -v "${builddir}:/builddir:Z" \
-        -v "${LOCAL_REPO}:/local-repo:Z" \
-        -v "${REPO_ROOT}/mock:/repo-mock:ro,Z" \
-        "${MOCK_CACHE_ARGS[@]}" \
-        "${BUILD_IMAGE}" \
-        bash -exc "
-            # mock refuses to run as root — even 'mock --version' exits with
-            # 'Insufficient rights.' It wants an unprivileged user in the mock
-            # group and drops privileges itself. This container runs as root,
-            # which was fine with older mock but broke every build once the
-            # runner image was rebuilt onto a newer one: mock exited before
-            # producing build.log or root.log, so the failure looked like an
-            # infrastructure glitch rather than a permissions rule.
-            #
-            # Only /builddir: that is what mock writes results into.
-            # /local-repo is a HOST-mounted directory that mock merely reads as
-            # a repo, and chowning it to the in-container builder uid locked the
-            # runner out of its own workspace, so createrepo_c could not create
-            # .repodata there.
-            #
-            # NOTE: never put a double quote in this string, not even inside a
-            # comment. It is passed as bash -exc from the host shell, so a
-            # literal double quote closes it early; bash then gets the script
-            # as two arguments, treats the second as $0, and silently drops
-            # everything after the break. A quoted phrase in this very comment
-            # did that and turned the whole container step into a no-op.
-            chown -R builder /builddir 2>/dev/null || true
-            # Assemble a config directory where the checked-out mock/ configs
-            # override the copies baked into this image: copy the WHOLE
-            # /etc/mock tree, then overlay the repo profiles on top.
-            #
-            # The whole tree, not just site-defaults.cfg and logging.ini. An
-            # include() of an ABSOLUTE path such as /etc/mock/fedora-44-x86_64.cfg
-            # resolves to the image, but that distro config then does a
-            # RELATIVE include of templates/fedora-branched.tpl, and relative
-            # includes resolve against --configdir, not /etc/mock — a
-            # configdir carrying only .cfg files orphans the templates
-            # directory and mock dies with: Could not find included config
-            # file: /tmp/mock-configdir/templates/fedora-branched.tpl
-            # (run 30654065913).
-            mkdir -p /tmp/mock-configdir
-            cp -a /etc/mock/. /tmp/mock-configdir/
-            cp /repo-mock/*.cfg /tmp/mock-configdir/
-            chmod -R a+rX /tmp/mock-configdir
-            # Use flock to ensure only one process runs mock at a time
-            # because they share mock chroot initialization.
-            flock /local-repo/repo.lock -c \"
-                setpriv --reuid=builder --regid=mock --init-groups \\
-                mock --configdir /tmp/mock-configdir -r '${MOCK_CONFIG}' \\
-                    --uniqueext='${pkg_name}' \\
-                    --rebuild /builddir/SRPMS/*.src.rpm \\
-                    --resultdir=/builddir/results \\
-                    --define 'dist ${DIST}' \\
-                    ${mock_check_flag} \\
-                    --no-clean \\
-                    --no-cleanup-after || {
-                        echo 'ERROR: mock failed. Printing build.log:';
-                        cat /builddir/results/build.log || true;
-                        echo 'ERROR: Printing root.log:';
-                        cat /builddir/results/root.log || true;
-                        exit 1;
-                    }
-            \"
-            # Mock ran as builder, so everything it wrote under /builddir is
-            # builder-owned inside the container. The container's own top
-            # level is root, and root can always chown back down — but
-            # nothing did, so control returned to the HOST process (which
-            # runs as the plain CI runner user, outside the container
-            # entirely) unable to read what mock had just produced:
-            #   find: /tmp/tmp.XXXXXX/results: Permission denied
-            #   ERROR: No RPMs produced for xfce4-dev-tools
-            # even though mock's own log said the build finished. Restore
-            # root ownership before the container exits and this handoff
-            # happens, regardless of whether mock succeeded or failed —
-            # build.log and root.log need to be host-readable on failure too.
-            chown -R root:root /builddir 2>/dev/null || true
-        "
+    # Wrapped in a function so the retry below re-runs the IDENTICAL
+    # invocation with one extra mock argument, rather than a second copy
+    # of it drifting out of sync with this one.
+    _run_mock_container() {
+        local mock_extra_args="${1:-}"
+        podman run --rm --privileged \
+            --pull=always \
+            -v "${builddir}:/builddir:Z" \
+            -v "${LOCAL_REPO}:/local-repo:Z" \
+            -v "${REPO_ROOT}/mock:/repo-mock:ro,Z" \
+            "${MOCK_CACHE_ARGS[@]}" \
+            "${BUILD_IMAGE}" \
+            bash -exc "
+                # mock refuses to run as root — even 'mock --version' exits with
+                # 'Insufficient rights.' It wants an unprivileged user in the mock
+                # group and drops privileges itself. This container runs as root,
+                # which was fine with older mock but broke every build once the
+                # runner image was rebuilt onto a newer one: mock exited before
+                # producing build.log or root.log, so the failure looked like an
+                # infrastructure glitch rather than a permissions rule.
+                #
+                # Only /builddir: that is what mock writes results into.
+                # /local-repo is a HOST-mounted directory that mock merely reads as
+                # a repo, and chowning it to the in-container builder uid locked the
+                # runner out of its own workspace, so createrepo_c could not create
+                # .repodata there.
+                #
+                # NOTE: never put a double quote in this string, not even inside a
+                # comment. It is passed as bash -exc from the host shell, so a
+                # literal double quote closes it early; bash then gets the script
+                # as two arguments, treats the second as $0, and silently drops
+                # everything after the break. A quoted phrase in this very comment
+                # did that and turned the whole container step into a no-op.
+                chown -R builder /builddir 2>/dev/null || true
+                # Assemble a config directory where the checked-out mock/ configs
+                # override the copies baked into this image: copy the WHOLE
+                # /etc/mock tree, then overlay the repo profiles on top.
+                #
+                # The whole tree, not just site-defaults.cfg and logging.ini. An
+                # include() of an ABSOLUTE path such as /etc/mock/fedora-44-x86_64.cfg
+                # resolves to the image, but that distro config then does a
+                # RELATIVE include of templates/fedora-branched.tpl, and relative
+                # includes resolve against --configdir, not /etc/mock — a
+                # configdir carrying only .cfg files orphans the templates
+                # directory and mock dies with: Could not find included config
+                # file: /tmp/mock-configdir/templates/fedora-branched.tpl
+                # (run 30654065913).
+                mkdir -p /tmp/mock-configdir
+                cp -a /etc/mock/. /tmp/mock-configdir/
+                cp /repo-mock/*.cfg /tmp/mock-configdir/
+                chmod -R a+rX /tmp/mock-configdir
+                # Use flock to ensure only one process runs mock at a time
+                # because they share mock chroot initialization.
+                flock /local-repo/repo.lock -c \"
+                    setpriv --reuid=builder --regid=mock --init-groups \\
+                    mock --configdir /tmp/mock-configdir -r '${MOCK_CONFIG}' \\
+                        --uniqueext='${pkg_name}' \\
+                        --rebuild /builddir/SRPMS/*.src.rpm \\
+                        --resultdir=/builddir/results \\
+                        --define 'dist ${DIST}' \\
+                        ${mock_check_flag} \\
+                        --no-clean \\
+                        --no-cleanup-after ${mock_extra_args} || {
+                            echo 'ERROR: mock failed. Printing build.log:';
+                            cat /builddir/results/build.log || true;
+                            echo 'ERROR: Printing root.log:';
+                            cat /builddir/results/root.log || true;
+                            exit 1;
+                        }
+                \"
+                # Mock ran as builder, so everything it wrote under /builddir is
+                # builder-owned inside the container. The container's own top
+                # level is root, and root can always chown back down — but
+                # nothing did, so control returned to the HOST process (which
+                # runs as the plain CI runner user, outside the container
+                # entirely) unable to read what mock had just produced:
+                #   find: /tmp/tmp.XXXXXX/results: Permission denied
+                #   ERROR: No RPMs produced for xfce4-dev-tools
+                # even though mock's own log said the build finished. Restore
+                # root ownership before the container exits and this handoff
+                # happens, regardless of whether mock succeeded or failed —
+                # build.log and root.log need to be host-readable on failure too.
+                chown -R root:root /builddir 2>/dev/null || true
+            "
+    }
+
+    # mock 6.7 + dnf5 5.4.2.1: mock's dynamic-BuildRequires loop
+    # (backend.py rebuild_package -> installSrpmDeps -> pkg_manager.builddep)
+    # runs dnf5 builddep on the generated .buildreqs.nosrc.rpm. When
+    # %generate_buildrequires emits requirements the base buildroot ALREADY
+    # satisfies, dnf5 fails the whole transaction with "Failed to resolve the
+    # transaction: Package \"<nevra>\" is already installed." and mock raises
+    # BuildError -- with nothing actually wrong with the package.
+    #
+    # Measured across all five parallel desktop runs: niri-00 (31231968581)
+    # 70 occurrences over 11 distinct packages, kde-00 (31215339645) 31,
+    # gnome-00 (31215535607) 25, xfce (31215533814) 4 -- and no other error
+    # shape in three of the four (kde's zimg has a genuine stale patch). One
+    # toolchain bug wearing 36 package costumes.
+    #
+    # Retry once with the loop disabled, gated on that exact signature.
+    # Disabling it cannot deprive the build of anything in this case: the
+    # error being matched is dnf5's own statement that the packages are
+    # already present, so the loop has nothing left to install. Every other
+    # failure keeps the original behavior and fails loud on the first try.
+    if ! _run_mock_container ""; then
+        if grep -qs "is already installed" "${builddir}/results/root.log"; then
+            echo "==> [${pkg_name}] mock hit the dnf5 already-installed dynamic-BuildRequires bug; retrying with dynamic_buildrequires=False"
+            _run_mock_container "--config-opts=dynamic_buildrequires=False"
+        else
+            return 1
+        fi
+    fi
 
     # Collect RPMs from results
     local rpm_count=0

--- a/tests/test_mock_dynamic_br_retry.py
+++ b/tests/test_mock_dynamic_br_retry.py
@@ -1,0 +1,136 @@
+"""The mock dynamic-BuildRequires retry in scripts/build-chain.sh.
+
+mock 6.7 + dnf5 5.4.2.1: mock's dynamic-BuildRequires loop (backend.py
+rebuild_package -> installSrpmDeps -> pkg_manager.builddep) runs dnf5 builddep
+on the generated .buildreqs.nosrc.rpm.  When %generate_buildrequires emits
+requirements the base buildroot ALREADY satisfies, dnf5 fails the whole
+transaction with `Failed to resolve the transaction: Package "<nevra>" is
+already installed.` and mock raises BuildError -- with nothing actually wrong
+with the package.
+
+Measured across all five parallel desktop runs: niri-00 (31231968581) 70
+occurrences over 11 distinct packages, kde-00 (31215339645) 31, gnome-00
+(31215535607) 25, xfce (31215533814) 4 -- and no other error shape in three of
+the four (kde's zimg has a genuine stale patch).  36 of the 37 "package
+failures" were one toolchain bug.
+
+The retry cannot be exercised for real without privileged mock, so these drive
+the extracted control flow with the container call stubbed.  That is the part
+a mistake would break: retrying unconditionally would mask real dependency
+errors, and not retrying at all would leave the bug in place.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "build-chain.sh"
+
+
+def retry_block() -> str:
+    """The `if ! _run_mock_container ...` guard, lifted verbatim."""
+    text = SCRIPT.read_text()
+    match = re.search(r'^    if ! _run_mock_container "".*?^    fi$', text, re.S | re.M)
+    assert match, "retry guard not found in build-chain.sh"
+    return match.group(0)
+
+
+def run_case(tmp_path: Path, root_log: str | None, first_call_fails: bool) -> tuple[int, list[str]]:
+    """Execute the real guard with a stubbed container call.
+
+    Returns (exit status, the argument each _run_mock_container call received).
+    """
+    results = tmp_path / "results"
+    results.mkdir(parents=True, exist_ok=True)
+    if root_log is not None:
+        (results / "root.log").write_text(root_log)
+    calls = tmp_path / "calls"
+
+    fail_logic = (
+        'if [ "$(cat "$CALLS" | wc -l)" -le 1 ]; then return 1; fi; return 0'
+        if first_call_fails
+        else "return 0"
+    )
+    script = f"""
+set -uo pipefail
+builddir={tmp_path!s}
+pkg_name=demo
+CALLS={calls!s}
+: > "$CALLS"
+_run_mock_container() {{
+    printf '%s\\n' "${{1-<none>}}" >> "$CALLS"
+    {fail_logic}
+}}
+run_guard() {{
+{retry_block()}
+}}
+run_guard
+"""
+    proc = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    recorded = calls.read_text().splitlines() if calls.exists() else []
+    return proc.returncode, recorded
+
+
+ALREADY = 'Failed to resolve the transaction:\nPackage "less-704-3.hum1.x86_64" is already installed.\n'
+OTHER = "No match for argument: totally-absent-package\nError: Unable to find a match\n"
+
+
+def test_success_first_try_never_retries(tmp_path):
+    status, calls = run_case(tmp_path, root_log=None, first_call_fails=False)
+    assert status == 0
+    assert len(calls) == 1, f"expected a single invocation, got {calls}"
+
+
+def test_already_installed_failure_retries_once_with_the_override(tmp_path):
+    status, calls = run_case(tmp_path, root_log=ALREADY, first_call_fails=True)
+    assert status == 0, "the retry should carry the build to success"
+    assert len(calls) == 2, f"expected exactly one retry, got {calls}"
+    assert calls[0] == "", "the first attempt must be unmodified"
+    assert calls[1] == "--config-opts=dynamic_buildrequires=False"
+
+
+def test_unrelated_failure_does_not_retry(tmp_path):
+    """A real dependency error must still fail loud on the first attempt."""
+    status, calls = run_case(tmp_path, root_log=OTHER, first_call_fails=True)
+    assert status != 0
+    assert len(calls) == 1, f"a non-matching failure must not retry, got {calls}"
+
+
+def test_missing_root_log_does_not_retry(tmp_path):
+    """No log to match against is not licence to retry blindly."""
+    status, calls = run_case(tmp_path, root_log=None, first_call_fails=True)
+    assert status != 0
+    assert len(calls) == 1
+
+
+def test_retry_is_bounded_to_one_attempt(tmp_path):
+    """If the override does not help, the build fails rather than looping."""
+    tmp = tmp_path
+    (tmp / "results").mkdir(parents=True, exist_ok=True)
+    (tmp / "results" / "root.log").write_text(ALREADY)
+    calls = tmp / "calls"
+    script = f"""
+set -uo pipefail
+builddir={tmp!s}
+pkg_name=demo
+CALLS={calls!s}
+: > "$CALLS"
+_run_mock_container() {{ printf '%s\\n' "${{1-<none>}}" >> "$CALLS"; return 1; }}
+run_guard() {{
+{retry_block()}
+}}
+run_guard
+"""
+    proc = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    recorded = calls.read_text().splitlines()
+    assert proc.returncode != 0
+    assert len(recorded) == 2, f"must not loop past one retry, got {recorded}"
+
+
+def test_the_container_call_is_a_single_definition(tmp_path):
+    """The retry must re-run the same invocation, not a drifting copy."""
+    text = SCRIPT.read_text()
+    assert text.count("_run_mock_container() {") == 1
+    assert "${mock_extra_args}" in text, "the hook the retry rides on is gone"


### PR DESCRIPTION
## What

**36 of the 37 package failures** across the five parallel Hummingbird desktop runs were one toolchain bug, not 36 broken packages.

mock 6.7's dynamic-BuildRequires loop (`backend.py rebuild_package → installSrpmDeps → pkg_manager.builddep`) runs `dnf5 builddep` on the generated `.buildreqs.nosrc.rpm`. When `%generate_buildrequires` emits requirements the base buildroot **already satisfies**, dnf5 5.4.2.1 fails the whole transaction:

```
Failed to resolve the transaction:
Package "less-704-3.hum1.x86_64" is already installed.
```

and mock raises `BuildError`. Nothing is wrong with the package — the requirement it asked for is present, which is exactly why the transaction is empty.

Measured, not inferred. Every cluster carries the same signature:

| tier | `is already installed` | other error shapes |
|---|---|---|
| niri-00 ([31231968581](https://github.com/tuna-os/tunaos-packages/actions/runs/31231968581)) | 70 hits / 11 packages | none |
| kde-00 ([31215339645](https://github.com/tuna-os/tunaos-packages/actions/runs/31215339645)) | 31 | + zimg, a genuine stale patch |
| gnome-00 ([31215535607](https://github.com/tuna-os/tunaos-packages/actions/runs/31215535607)) | 25 | + 3 transient Curl |
| xfce ([31215533814](https://github.com/tuna-os/tunaos-packages/actions/runs/31215533814)) | 4 | + 1 transient Curl |

The named packages give it away: `pyproject-rpm-macros`, `python3-devel`, `python3-pytest`, `meson`, `gcc`, `gettext`, `zip`, `fish`, `tcsh`, `zsh` — buildroot furniture, not per-package dependencies. `config_opts['additional_packages']` is unset in `mock/*.cfg`, so `preexisting_deps` is empty and the failure is in `builddep` itself.

## Changes

- `scripts/build-chain.sh`: retry once with `dynamic_buildrequires=False`, **gated on that exact signature** in `root.log`. The podman invocation moved into `_run_mock_container()` so the retry re-runs the identical command with one added argument rather than a drifting second copy.

**The gate is the whole design.** Disabling the loop cannot deprive the build of anything in this case, because the matched error is dnf5's own statement that the packages are already present — there is nothing left to install. Every other failure keeps the current behavior and fails loud on the first attempt, so a real missing dependency is never masked.

## Testing

The real path needs privileged mock, so `tests/test_mock_dynamic_br_retry.py` extracts the guard **verbatim** from the script and drives it with the container call stubbed:

- success never retries
- the already-installed failure retries exactly once **and carries the override**
- an unrelated failure does not retry
- a missing `root.log` does not retry
- the retry is bounded to one attempt

Mutation-verified: removing the signature gate fails two tests; removing the argument hook fails another. Suite **380 → 386**.

## Not fixed here

kde's **zimg** is genuinely different — it fails on a patch that no longer applies (`1 out of 1 hunk FAILED … src/zimg/colorspace/x86/operation_impl_x86.cpp.rej`) and needs a real rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->