### PR TITLE
feat(gate): plan which cells need to run instead of building all 84

### DIFF
--- a/.github/workflows/build-tideforge-supported.yml
+++ b/.github/workflows/build-tideforge-supported.yml
@@ -51,6 +51,65 @@ jobs:
             echo "relevant=false" >> "$GITHUB_OUTPUT"
           fi
 
+  # ── The dispatcher ─────────────────────────────────────────────────────────
+  # detect-changes answers one question for the whole gate: did anything
+  # Tideforge-relevant change?  If yes, all 84 declared cells build -- so
+  # editing one recipe rebuilt 83 bit-identical artifacts, each paying for a
+  # runner and a container image pull.  This turns that boolean into a plan.
+  #
+  # It only ever SUBTRACTS from what the jobs below already declare, and it
+  # fails toward building: no diff information, an unreadable file, or a change
+  # to any shared input (scripts/, mock/, these workflows, .github/actions/)
+  # restores the full run.  See scripts/plan_gate_matrix.py for the rules and
+  # tests/test_plan_gate_matrix.py for what pins them.
+  #
+  # Only the matrix-free jobs consume it today.  A job with a static `include:`
+  # cannot also take a computed matrix, and those declarations are what the
+  # planner reads out of this file, so moving them is its own change.
+  plan:
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.relevant == 'true' }}
+    runs-on: ubuntu-latest
+    outputs:
+      gtkgreet_rpm_run: ${{ steps.plan.outputs.gtkgreet_rpm_run }}
+      cpptrace_rpm_run: ${{ steps.plan.outputs.cpptrace_rpm_run }}
+      quickshell_rpm_run: ${{ steps.plan.outputs.quickshell_rpm_run }}
+      niri_rpm_run: ${{ steps.plan.outputs.niri_rpm_run }}
+      iio_niri_rpm_run: ${{ steps.plan.outputs.iio_niri_rpm_run }}
+      dms_stack_rpm_run: ${{ steps.plan.outputs.dms_stack_rpm_run }}
+      cosmic_icon_theme_rpm_run: ${{ steps.plan.outputs.cosmic_icon_theme_rpm_run }}
+      cosmic_comp_rpm_run: ${{ steps.plan.outputs.cosmic_comp_rpm_run }}
+      cosmic_bg_rpm_run: ${{ steps.plan.outputs.cosmic_bg_rpm_run }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.14'
+      - run: pip install pyyaml
+      - name: Collect the changed paths
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+        run: |
+          set -euo pipefail
+          # No base to diff against (dispatch/push/schedule) means no file, and
+          # the planner treats a missing file as "build everything".
+          if [ -n "${BASE_SHA:-}" ]; then
+            git diff --name-only "$BASE_SHA"...HEAD > changed-files.txt
+            echo "changed paths:"; cat changed-files.txt
+          fi
+      - id: plan
+        name: Plan which gate cells need to run
+        run: |
+          set -euo pipefail
+          args=(--workflow .github/workflows/build-tideforge-supported.yml
+                --github-output "$GITHUB_OUTPUT")
+          if [ -f changed-files.txt ]; then
+            args+=(--changed-files changed-files.txt)
+          fi
+          python3 scripts/plan_gate_matrix.py "${args[@]}"
+
   rpm-payload:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.relevant == 'true' }}
@@ -400,7 +459,8 @@ jobs:
 
   gtkgreet-rpm:
     name: gtkgreet (el10 staged closure RPM)
-    needs: [detect-changes, rpm]
+    needs: [detect-changes, plan, rpm]
+    if: ${{ needs.plan.outputs.gtkgreet_rpm_run == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -472,7 +532,8 @@ jobs:
 
   cpptrace-rpm:
     name: cpptrace-devel (el10 RPM)
-    needs: [detect-changes, rpm]
+    needs: [detect-changes, plan, rpm]
+    if: ${{ needs.plan.outputs.cpptrace_rpm_run == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -614,7 +675,8 @@ jobs:
 
   quickshell-rpm:
     name: quickshell (el10 RPM)
-    needs: [detect-changes, rpm, cpptrace-rpm]
+    needs: [detect-changes, plan, rpm, cpptrace-rpm]
+    if: ${{ needs.plan.outputs.quickshell_rpm_run == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -696,7 +758,8 @@ jobs:
 
   niri-rpm:
     name: niri (el10 RPM)
-    needs: [detect-changes, rpm]
+    needs: [detect-changes, plan, rpm]
+    if: ${{ needs.plan.outputs.niri_rpm_run == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -767,7 +830,8 @@ jobs:
 
   iio-niri-rpm:
     name: iio-niri (el10 RPM)
-    needs: [detect-changes, rpm, niri-rpm]
+    needs: [detect-changes, plan, rpm, niri-rpm]
+    if: ${{ needs.plan.outputs.iio_niri_rpm_run == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -834,7 +898,8 @@ jobs:
 
   dms-stack-rpm:
     name: DMS stack (el10 RPM integration)
-    needs: [detect-changes, rpm-payload, rpm, cpptrace-rpm, quickshell-rpm]
+    needs: [detect-changes, plan, rpm-payload, rpm, cpptrace-rpm, quickshell-rpm]
+    if: ${{ needs.plan.outputs.dms_stack_rpm_run == 'true' }}
     runs-on: ubuntu-latest
     steps:
       # Checkout first, and only then download artifacts: actions/checkout
@@ -904,7 +969,8 @@ jobs:
   # clean-install and assert the recipe's contract.
   cosmic-icon-theme-rpm:
     name: cosmic-icon-theme (el10 RPM)
-    needs: [detect-changes, rpm]
+    needs: [detect-changes, plan, rpm]
+    if: ${{ needs.plan.outputs.cosmic_icon_theme_rpm_run == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -967,7 +1033,8 @@ jobs:
 
   cosmic-comp-rpm:
     name: cosmic-comp (el10 RPM)
-    needs: [detect-changes, rpm, cosmic-icon-theme-rpm]
+    needs: [detect-changes, plan, rpm, cosmic-icon-theme-rpm]
+    if: ${{ needs.plan.outputs.cosmic_comp_rpm_run == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -1051,7 +1118,8 @@ jobs:
   # the ephemeral repo, then install and assert the recipe's contract.
   cosmic-bg-rpm:
     name: cosmic-bg (el10 RPM)
-    needs: [detect-changes, rpm, cosmic-icon-theme-rpm]
+    needs: [detect-changes, plan, rpm, cosmic-icon-theme-rpm]
+    if: ${{ needs.plan.outputs.cosmic_bg_rpm_run == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -1434,9 +1502,24 @@ jobs:
 
   # The single check worth requiring in branch protection (#173). It always
   # reports: not-applicable PRs pass via detect-changes, and any needed job
-  # that failed, was cancelled, OR WAS SKIPPED fails it -- a skipped cell is
-  # unproven, not passed. Making this required is a deliberate repo-settings
-  # step, not something this file can do.
+  # that failed or was cancelled fails it. Making this required is a
+  # deliberate repo-settings step, not something this file can do.
+  #
+  # SKIPPED used to fail this gate too, on the rule "a skipped cell is
+  # unproven, not passed". That rule was right while the only way to skip was
+  # an upstream dying. The planner (job `plan`) introduces a second, legitimate
+  # reason: the cell's recipe and every input feeding it are unchanged, so
+  # there is nothing new to prove. Failing on that would make the dispatcher
+  # impossible.
+  #
+  # Accepting skipped does NOT re-open the hole the old rule guarded, because
+  # the two causes are still distinguishable from here: every gate job is in
+  # this job's `needs:`, so a job that actually broke reports failure/cancelled
+  # to this step directly. A dependent going skipped in that scenario is always
+  # accompanied by its upstream's own non-success result, which still fails the
+  # gate. What is no longer required is that every cell RAN -- and that is the
+  # planner's job to justify, which it does by logging every skip with the
+  # reason that produced it.
   # Staged deb closure gate (#169 / tunaOS#964): cosmic-icon-theme Requires
   # the tideforge-built pop-icon-theme at install time. The gate stays
   # independent of the PUBLISHED tideforge repo on purpose -- a gate that
@@ -1629,7 +1712,7 @@ jobs:
 
   tideforge-gate:
     name: Tideforge gate
-    needs: [detect-changes, rpm-payload, rpm, opensuse-rpm, xfconf-split, gtkgreet-rpm, cpptrace-rpm, input-remapper-rpm, quickshell-rpm, niri-rpm, iio-niri-rpm, dms-stack-rpm, cosmic-icon-theme-rpm, cosmic-comp-rpm, cosmic-bg-rpm, deb, cosmic-icon-theme-deb, cosmic-comp-deb]
+    needs: [detect-changes, plan, rpm-payload, rpm, opensuse-rpm, xfconf-split, gtkgreet-rpm, cpptrace-rpm, input-remapper-rpm, quickshell-rpm, niri-rpm, iio-niri-rpm, dms-stack-rpm, cosmic-icon-theme-rpm, cosmic-comp-rpm, cosmic-bg-rpm, deb, cosmic-icon-theme-deb, cosmic-comp-deb]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
@@ -1645,7 +1728,13 @@ jobs:
             echo "No Tideforge-relevant changes; gate not applicable."
             exit 0
           fi
-          bad=$(echo "$NEEDS" | jq -r 'to_entries[] | select(.value.result != "success") | "\(.key)=\(.value.result)"')
+          # A job the planner trimmed reports "skipped", and that is a pass:
+          # its cells had nothing to prove.  Accepting skipped cannot hide a
+          # real failure, because every gate job is in this job's `needs:`, so
+          # a genuine failure appears here as failure/cancelled on the job
+          # itself -- a dependent going skipped because its upstream broke is
+          # always accompanied by that upstream's own non-success result.
+          bad=$(echo "$NEEDS" | jq -r 'to_entries[] | select(.value.result != "success" and .value.result != "skipped") | "\(.key)=\(.value.result)"')
           if [ -n "$bad" ]; then
             echo "Gate jobs not successful:" >&2
             echo "$bad" >&2

--- a/scripts/plan_gate_matrix.py
+++ b/scripts/plan_gate_matrix.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Decide which Tideforge gate cells actually need to run.
+
+WHY.  `detect-changes` is one boolean for the whole gate: if anything under
+packages/, scripts/, the gate workflows or .github/actions/ changed, ALL 98
+cells build (84 supported + 14 arch); otherwise none do.  Editing one recipe
+therefore rebuilds 97 bit-identical artifacts, each paying for a runner, a
+container image pull and a full mock/sbuild cycle.
+
+This module replaces that boolean with a plan.  It never invents cells: it
+reads the cells the workflows already declare and *subtracts*, so the
+workflows stay the single source of truth and the coverage gate keeps working.
+
+THE DANGEROUS DIRECTION.  This repo's recurring defect is the silent skip — a
+declared target no cell exercised (#139), a wishlist that quietly made every
+missing package optional (#1080).  A dispatcher is a machine for manufacturing
+exactly that, so every rule here is written to fail toward building:
+
+  * unknown event, unreadable file, unparseable workflow, missing recipe,
+    absent proven-set  -> build everything
+  * a shared input changed (renderer, mock config, workflow, actions)
+    -> build everything, because those inputs feed every cell
+  * a job whose upstream runs -> runs, transitively, because it consumes that
+    upstream's artifacts
+
+and every skip is reported with the reason that produced it.
+
+INTER-CELL EDGES COME FROM THE WORKFLOW, NOT THE RECIPES.  A recipe's
+`dependencies:` lists DISTRO package names (gcc, meson, cmake) -- measured:
+zero of the 46 recipes name a sibling recipe there.  The real edges are the
+jobs' own `needs:`, e.g. quickshell-rpm needs cpptrace-rpm and cosmic-comp-rpm
+needs cosmic-icon-theme-rpm.  Closing over `dependencies:` would have produced
+a plan that looks dependency-aware and silently drops the consumer of a
+changed producer.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+# Files that feed EVERY cell.  A change to any of them invalidates the whole
+# gate, so the plan degrades to "build everything".  Deliberately broad: a
+# false full-build costs runner minutes, a false skip costs a regression.
+SHARED_INPUT_PATTERNS = (
+    re.compile(r"^scripts/"),
+    re.compile(r"^mock/"),
+    re.compile(r"^\.github/workflows/build-tideforge-"),
+    re.compile(r"^\.github/actions/"),
+    re.compile(r"^manifests/package-factory\.yaml$"),
+    re.compile(r"^build-order-"),
+)
+
+# Files whose contents go into every fingerprint, so a change to one of them
+# makes previously-proven fingerprints stale automatically rather than relying
+# on the SHARED_INPUT_PATTERNS short-circuit alone.  Belt and braces on purpose.
+FINGERPRINT_SHARED_FILES = (
+    "scripts/tideforge.py",
+    "scripts/assemble-deb-source-tree.py",
+    "scripts/build-chain.sh",
+)
+
+RECIPE_PATH = re.compile(r"^packages/([A-Za-z0-9_.+-]+)/")
+RECIPE_IN_BODY = re.compile(r"packages/([A-Za-z0-9_.+-]+)/package\.yaml")
+
+
+class PlanError(Exception):
+    """Raised only for caller mistakes; never for 'I could not decide'."""
+
+
+def is_shared_input(path: str) -> bool:
+    return any(p.search(path) for p in SHARED_INPUT_PATTERNS)
+
+
+def changed_packages(changed_files) -> set[str]:
+    """Recipe directories touched by this diff."""
+    found = set()
+    for path in changed_files:
+        match = RECIPE_PATH.match(path.strip())
+        if match:
+            found.add(match.group(1))
+    return found
+
+
+def load_workflow(path: Path) -> dict:
+    return yaml.safe_load(path.read_text())
+
+
+def job_packages(name: str, job: dict) -> set[str]:
+    """Every recipe a job builds: matrix `package:` keys, else paths in its body.
+
+    Dedicated jobs (gtkgreet-rpm, niri-rpm, ...) name their recipe in a step
+    rather than a matrix, which is why the body is scanned as a fallback.
+    """
+    include = (job.get("strategy") or {}).get("matrix", {}).get("include") or []
+    pkgs = {cell["package"] for cell in include if isinstance(cell, dict) and "package" in cell}
+    if pkgs:
+        return pkgs
+    return set(RECIPE_IN_BODY.findall(yaml.safe_dump(job)))
+
+
+def job_needs(job: dict) -> list[str]:
+    needs = job.get("needs")
+    if isinstance(needs, str):
+        return [needs]
+    return list(needs or [])
+
+
+def running_jobs(workflow: dict, seeds: set[str]) -> tuple[set[str], set[str]]:
+    """(jobs that build a seeded package, jobs pulled in downstream of those).
+
+    The split is load-bearing, not bookkeeping.  A SEEDED job runs because one
+    of its own recipes changed, so only that recipe's cells have anything to
+    prove.  A DOWNSTREAM job runs because it installs an upstream's freshly
+    built artifact -- cosmic-comp-deb consumes cosmic-icon-theme-deb -- and
+    there the changed recipe is somebody else's, so every one of its cells must
+    run.  Filtering downstream cells by "is your own recipe in the diff" drops
+    exactly the consumer the closure just worked to include.
+    """
+    jobs = workflow.get("jobs", {})
+    seeded = {name for name, job in jobs.items() if job_packages(name, job) & seeds}
+    running = set(seeded)
+    # Transitive closure over `needs:` edges, downstream direction.
+    changed = True
+    while changed:
+        changed = False
+        for name, job in jobs.items():
+            if name in running:
+                continue
+            if set(job_needs(job)) & running:
+                running.add(name)
+                changed = True
+    return seeded, running - seeded
+
+
+def _read_bytes(root: Path, rel: str) -> bytes:
+    try:
+        return (root / rel).read_bytes()
+    except OSError:
+        # Absent shared file is not an error; it just contributes nothing.
+        return b""
+
+
+def recipe_fingerprint(root: Path, package: str, target: str, image: str, extra: bytes = b"") -> str | None:
+    """Build identity for one cell, or None when it cannot be computed.
+
+    None means "cannot prove this is unchanged", and every caller treats that
+    as must-build.
+    """
+    pkg_dir = root / "packages" / package
+    if not pkg_dir.is_dir():
+        return None
+    digest = hashlib.sha256()
+    try:
+        for path in sorted(p for p in pkg_dir.rglob("*") if p.is_file()):
+            digest.update(str(path.relative_to(pkg_dir)).encode())
+            digest.update(path.read_bytes())
+    except OSError:
+        return None
+    digest.update(b"\0target=" + target.encode())
+    # The image is pinned by whatever the cell declares.  A tag that moves
+    # under us (debian:sid) is exactly why phase 2 alone is not trusted to
+    # catch base-image changes -- SHARED_INPUT_PATTERNS covers the workflow
+    # edit that would accompany a deliberate bump.
+    digest.update(b"\0image=" + image.encode())
+    for rel in FINGERPRINT_SHARED_FILES:
+        digest.update(b"\0" + rel.encode())
+        digest.update(hashlib.sha256(_read_bytes(root, rel)).digest())
+    digest.update(b"\0" + extra)
+    return digest.hexdigest()
+
+
+def plan(
+    workflow: dict,
+    changed_files=None,
+    root: Path = Path("."),
+    proven: set[str] | None = None,
+) -> dict:
+    """Return {job: {"run": bool, "matrix": {...}|None, "skipped": [...]}}.
+
+    changed_files=None means "no diff information" -> build everything.
+    proven=None means "no proven-fingerprint set" -> skip nothing on that basis.
+    """
+    jobs = workflow.get("jobs", {})
+    proven = proven or set()
+
+    if changed_files is None:
+        reason, seeds, full = "no diff information", set(), True
+    else:
+        shared = sorted(f for f in (c.strip() for c in changed_files) if is_shared_input(f))
+        if shared:
+            reason, seeds, full = f"shared input changed: {shared[0]}", set(), True
+        else:
+            seeds = changed_packages(changed_files)
+            reason, full = f"changed recipes: {sorted(seeds) or 'none'}", False
+
+    if full:
+        seeded_jobs, live = set(jobs), set(jobs)
+    else:
+        seeded_jobs, downstream = running_jobs(workflow, seeds)
+        live = seeded_jobs | downstream
+
+    result = {"_reason": reason, "_full": full, "jobs": {}}
+    for name, job in jobs.items():
+        include = (job.get("strategy") or {}).get("matrix", {}).get("include") or []
+        entry = {"run": name in live, "matrix": None, "skipped": []}
+        if not include:
+            if not entry["run"]:
+                entry["skipped"].append({"cell": name, "why": "no changed package reaches this job"})
+            result["jobs"][name] = entry
+            continue
+
+        kept = []
+        for cell in include:
+            pkg = cell.get("package") if isinstance(cell, dict) else None
+            if name not in live:
+                entry["skipped"].append({"cell": f"{name}:{pkg}", "why": "job not reached by the change"})
+                continue
+            if pkg and not full and name in seeded_jobs and pkg not in seeds:
+                # A seeded matrix job is live because ONE of its packages
+                # changed; its other cells still have nothing to prove.  This
+                # filter deliberately does NOT apply to downstream jobs -- see
+                # running_jobs().
+                entry["skipped"].append({"cell": f"{name}:{pkg}", "why": "recipe unchanged"})
+                continue
+            fp = recipe_fingerprint(
+                root, pkg or "", cell.get("target", ""), cell.get("image", "")
+            ) if pkg else None
+            if fp and fp in proven:
+                entry["skipped"].append({"cell": f"{name}:{pkg}", "why": f"already proven ({fp[:12]})"})
+                continue
+            kept.append(cell)
+        entry["matrix"] = {"include": kept}
+        entry["run"] = bool(kept)
+        result["jobs"][name] = entry
+    return result
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--workflow", required=True, type=Path)
+    ap.add_argument("--changed-files", type=Path,
+                    help="file of changed paths, one per line; omit for a full build")
+    ap.add_argument("--proven", type=Path,
+                    help="file of already-proven fingerprints, one per line")
+    ap.add_argument("--root", type=Path, default=Path("."))
+    ap.add_argument("--github-output", type=Path)
+    args = ap.parse_args(argv)
+
+    try:
+        workflow = load_workflow(args.workflow)
+    except (OSError, yaml.YAMLError) as exc:
+        # Fail open, loudly: an unreadable workflow must not silence the gate.
+        print(f"plan-gate-matrix: cannot read {args.workflow} ({exc}); building everything",
+              file=sys.stderr)
+        workflow = {"jobs": {}}
+
+    changed = None
+    if args.changed_files:
+        try:
+            changed = [l for l in args.changed_files.read_text().splitlines() if l.strip()]
+        except OSError as exc:
+            print(f"plan-gate-matrix: cannot read {args.changed_files} ({exc}); building everything",
+                  file=sys.stderr)
+    proven = set()
+    if args.proven:
+        try:
+            proven = {l.strip() for l in args.proven.read_text().splitlines() if l.strip()}
+        except OSError as exc:
+            print(f"plan-gate-matrix: cannot read {args.proven} ({exc}); proving nothing",
+                  file=sys.stderr)
+
+    result = plan(workflow, changed, args.root, proven)
+
+    print(f"plan-gate-matrix: {result['_reason']}")
+    total_kept = total_skipped = 0
+    for name, entry in sorted(result["jobs"].items()):
+        kept = len((entry["matrix"] or {}).get("include", [])) if entry["matrix"] else int(entry["run"])
+        total_kept += kept
+        total_skipped += len(entry["skipped"])
+        if entry["skipped"]:
+            # No silent skips: every dropped cell is named with its reason.
+            for s in entry["skipped"]:
+                print(f"  skip {s['cell']}: {s['why']}")
+    print(f"plan-gate-matrix: {total_kept} cell(s) to build, {total_skipped} skipped")
+
+    if args.github_output:
+        with args.github_output.open("a") as fh:
+            for name, entry in result["jobs"].items():
+                key = name.replace("-", "_")
+                fh.write(f"{key}_run={str(entry['run']).lower()}\n")
+                if entry["matrix"] is not None:
+                    fh.write(f"{key}_matrix={json.dumps(entry['matrix'])}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_plan_gate_matrix.py
+++ b/tests/test_plan_gate_matrix.py
@@ -1,0 +1,274 @@
+"""The gate dispatcher: scripts/plan_gate_matrix.py.
+
+The gate declares 98 cells (84 supported + 14 arch) behind ONE boolean, so
+editing a single recipe rebuilds 97 bit-identical artifacts.  This plans the
+run instead.
+
+Everything here is written against the dangerous direction.  A dispatcher's
+failure mode is not "built too much", it is the silent skip -- the declared
+target no cell exercised (#139), the wishlist that made every missing package
+optional (#1080).  So the fail-open paths get as much coverage as the happy
+one, and the downstream-closure tests exist because the first implementation
+DID drop cosmic-comp-deb: it was pulled in correctly by the `needs:` closure
+and then filtered right back out by a "your own recipe is unchanged" rule that
+must not apply to a job whose whole reason for running is somebody else's
+rebuilt artifact.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from plan_gate_matrix import (  # noqa: E402
+    changed_packages,
+    is_shared_input,
+    plan,
+    recipe_fingerprint,
+    running_jobs,
+)
+
+SUPPORTED = ROOT / ".github" / "workflows" / "build-tideforge-supported.yml"
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict:
+    return yaml.safe_load(SUPPORTED.read_text())
+
+
+def running(result) -> set[str]:
+    return {n for n, e in result["jobs"].items() if e["run"]}
+
+
+def cells(result) -> int:
+    total = 0
+    for entry in result["jobs"].values():
+        if entry["matrix"] is not None:
+            total += len(entry["matrix"]["include"])
+        elif entry["run"]:
+            total += 1
+    return total
+
+
+# ── fail open ──────────────────────────────────────────────────────────────
+
+def test_no_diff_information_builds_everything(workflow):
+    """push/dispatch/schedule carry no usable base -- never trim those."""
+    result = plan(workflow, changed_files=None, root=ROOT)
+    assert result["_full"] is True
+    assert running(result) == set(workflow["jobs"])
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "scripts/tideforge.py",
+        "scripts/build-chain.sh",
+        "mock/centos-stream-10-local.cfg",
+        ".github/workflows/build-tideforge-supported.yml",
+        ".github/actions/tideforge-source-cache/action.yml",
+        "manifests/package-factory.yaml",
+        "build-order-xfce.yml",
+    ],
+)
+def test_shared_inputs_force_a_full_build(workflow, path):
+    """These feed every cell; trimming after one changes is the silent skip."""
+    assert is_shared_input(path)
+    result = plan(workflow, [path], root=ROOT)
+    assert result["_full"] is True
+    assert cells(result) == cells(plan(workflow, None, root=ROOT))
+
+
+def test_an_unrelated_change_builds_nothing(workflow):
+    result = plan(workflow, ["README.md", "docs/whatever.md"], root=ROOT)
+    assert cells(result) == 0
+    assert running(result) == set()
+
+
+def test_a_missing_recipe_directory_cannot_be_proven(tmp_path):
+    """No recipe on disk -> no fingerprint -> the cell must build."""
+    assert recipe_fingerprint(tmp_path, "does-not-exist", "el10", "img") is None
+
+
+# ── the trimming itself ────────────────────────────────────────────────────
+
+def test_changed_packages_reads_the_recipe_directory():
+    assert changed_packages(["packages/uupd/package.yaml"]) == {"uupd"}
+    assert changed_packages(["packages/niri/patches/x.patch"]) == {"niri"}
+    assert changed_packages(["README.md"]) == set()
+
+
+def test_one_leaf_recipe_trims_the_run_hard(workflow):
+    full = cells(plan(workflow, None, root=ROOT))
+    result = plan(workflow, ["packages/uupd/package.yaml"], root=ROOT)
+    assert 0 < cells(result) < full / 2, "a leaf recipe should not rebuild the world"
+
+
+def test_a_seeded_matrix_job_drops_its_other_cells(workflow):
+    result = plan(workflow, ["packages/uupd/package.yaml"], root=ROOT)
+    rpm = result["jobs"]["rpm"]
+    packages = {c["package"] for c in rpm["matrix"]["include"]}
+    assert packages == {"uupd"}
+
+
+# ── downstream closure: the part that broke ────────────────────────────────
+
+def test_a_producer_change_drags_its_consumers(workflow):
+    """cosmic-icon-theme feeds cosmic-comp and cosmic-bg, on both rpm and deb."""
+    result = plan(workflow, ["packages/cosmic-icon-theme/package.yaml"], root=ROOT)
+    live = running(result)
+    for consumer in ("cosmic-comp-rpm", "cosmic-bg-rpm", "cosmic-comp-deb", "cosmic-icon-theme-deb"):
+        assert consumer in live, f"{consumer} consumes the changed artifact and must rebuild"
+
+
+def test_downstream_jobs_keep_all_their_cells(workflow):
+    """The regression that shipped in the first draft.
+
+    cosmic-comp-deb's own recipe is untouched -- that is precisely why it is
+    downstream -- so a 'recipe unchanged' filter silently emptied its matrix
+    and the job vanished after the closure had already included it.
+    """
+    result = plan(workflow, ["packages/cosmic-icon-theme/package.yaml"], root=ROOT)
+    entry = result["jobs"]["cosmic-comp-deb"]
+    declared = workflow["jobs"]["cosmic-comp-deb"]["strategy"]["matrix"]["include"]
+    assert entry["run"] is True
+    assert len(entry["matrix"]["include"]) == len(declared)
+
+
+def test_transitive_closure_reaches_two_hops(workflow):
+    """quickshell-rpm needs cpptrace-rpm; dms-stack-rpm needs quickshell-rpm."""
+    seeded, downstream = running_jobs(workflow, {"cpptrace-devel"})
+    assert "cpptrace-rpm" in seeded
+    assert {"quickshell-rpm", "dms-stack-rpm"} <= downstream
+
+
+# ── phase 2: fingerprints ──────────────────────────────────────────────────
+
+def test_fingerprint_is_stable_and_target_scoped(workflow):
+    a = recipe_fingerprint(ROOT, "uupd", "el10", "img")
+    b = recipe_fingerprint(ROOT, "uupd", "el10", "img")
+    c = recipe_fingerprint(ROOT, "uupd", "debian", "img")
+    d = recipe_fingerprint(ROOT, "uupd", "el10", "other-image")
+    assert a and a == b
+    assert a != c, "the same recipe on another target is a different proof"
+    assert a != d, "a different toolchain image is a different proof"
+
+
+def test_fingerprint_follows_the_recipe_contents(tmp_path):
+    pkg = tmp_path / "packages" / "demo"
+    pkg.mkdir(parents=True)
+    (pkg / "package.yaml").write_text("version: 1\n")
+    before = recipe_fingerprint(tmp_path, "demo", "el10", "img")
+    (pkg / "package.yaml").write_text("version: 2\n")
+    assert recipe_fingerprint(tmp_path, "demo", "el10", "img") != before
+
+
+def test_fingerprint_follows_shared_renderer_files(tmp_path):
+    pkg = tmp_path / "packages" / "demo"
+    pkg.mkdir(parents=True)
+    (pkg / "package.yaml").write_text("version: 1\n")
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "tideforge.py").write_text("# v1\n")
+    before = recipe_fingerprint(tmp_path, "demo", "el10", "img")
+    (scripts / "tideforge.py").write_text("# v2\n")
+    assert recipe_fingerprint(tmp_path, "demo", "el10", "img") != before, (
+        "a renderer change must invalidate every previously-proven fingerprint"
+    )
+
+
+def test_a_proven_fingerprint_drops_only_that_cell(workflow):
+    result = plan(workflow, ["packages/uupd/package.yaml"], root=ROOT)
+    kept = result["jobs"]["rpm"]["matrix"]["include"]
+    assert kept, "precondition: uupd has an rpm cell"
+    cell = kept[0]
+    fp = recipe_fingerprint(ROOT, cell["package"], cell.get("target", ""), cell.get("image", ""))
+    assert fp
+    pruned = plan(workflow, ["packages/uupd/package.yaml"], root=ROOT, proven={fp})
+    assert cell not in pruned["jobs"]["rpm"]["matrix"]["include"]
+
+
+def test_an_unknown_proven_set_prunes_nothing(workflow):
+    base = plan(workflow, ["packages/uupd/package.yaml"], root=ROOT)
+    same = plan(workflow, ["packages/uupd/package.yaml"], root=ROOT, proven={"deadbeef" * 8})
+    assert cells(same) == cells(base)
+
+
+def test_every_skip_carries_a_reason(workflow):
+    result = plan(workflow, ["packages/uupd/package.yaml"], root=ROOT)
+    for entry in result["jobs"].values():
+        for skip in entry["skipped"]:
+            assert skip["why"], "a skip without a reason is a silent skip"
+
+
+# ── wiring: the plan must actually be consumed, and safely ─────────────────
+
+WIRED_JOBS = {
+    "gtkgreet-rpm", "cpptrace-rpm", "quickshell-rpm", "niri-rpm", "iio-niri-rpm",
+    "dms-stack-rpm", "cosmic-icon-theme-rpm", "cosmic-comp-rpm", "cosmic-bg-rpm",
+}
+
+
+def test_the_plan_job_exists_and_outputs_every_wired_job(workflow):
+    plan_job = workflow["jobs"].get("plan")
+    assert plan_job, "the dispatcher job is gone; the wiring below is decoration"
+    outputs = plan_job.get("outputs", {})
+    for job in WIRED_JOBS:
+        assert f"{job.replace('-', '_')}_run" in outputs, f"plan does not publish a verdict for {job}"
+
+
+@pytest.mark.parametrize("job", sorted(WIRED_JOBS))
+def test_wired_jobs_gate_on_the_plan(workflow, job):
+    spec = workflow["jobs"][job]
+    assert "plan" in spec["needs"], f"{job} reads the plan's output but does not need it"
+    assert f"needs.plan.outputs.{job.replace('-', '_')}_run == 'true'" in spec["if"]
+
+
+def test_every_matrix_free_build_job_is_wired(workflow):
+    """A new dedicated job must not silently miss the dispatcher.
+
+    Missing wiring only costs runner minutes, but the reverse mistake -- a job
+    wired to an output the plan never publishes -- evaluates to an empty string
+    and skips the job forever.  Both directions are caught here.
+    """
+    from plan_gate_matrix import job_packages
+    infra = {"detect-changes", "plan", "tideforge-gate", "rpm-payload"}
+    for name, spec in workflow["jobs"].items():
+        if name in infra:
+            continue
+        has_matrix = bool((spec.get("strategy") or {}).get("matrix", {}).get("include"))
+        if has_matrix or not job_packages(name, spec):
+            continue
+        assert name in WIRED_JOBS, f"{name} builds a recipe, has no matrix, and is not wired to the plan"
+
+
+def test_the_aggregate_gate_accepts_planned_skips(workflow):
+    """Trimming a job makes it 'skipped'; the gate must not call that failure.
+
+    Read the step's `run:` script straight off the parsed job -- re-dumping it
+    to YAML escapes the quotes and the substring silently never matches, which
+    is a test that passes for the wrong reason.
+    """
+    scripts = " ".join(step.get("run", "") for step in workflow["jobs"]["tideforge-gate"]["steps"])
+    assert 'result != "skipped"' in scripts, (
+        "the gate still demands success from every job, so any trimmed job turns the PR red"
+    )
+
+
+def test_the_gate_still_waits_on_every_build_job(workflow):
+    """Trimming must never remove a job from the gate's needs list.
+
+    That list is what makes accepting 'skipped' safe: a real failure is visible
+    to the gate directly, so a dependent's skip can never launder it.
+    """
+    needs = set(workflow["jobs"]["tideforge-gate"]["needs"])
+    for name, spec in workflow["jobs"].items():
+        if name in {"detect-changes", "tideforge-gate"}:
+            continue
+        if (spec.get("strategy") or {}).get("matrix", {}).get("include") or name in WIRED_JOBS or name == "rpm-payload":
+            assert name in needs, f"{name} builds but the gate does not wait on it"


### PR DESCRIPTION
## What

`detect-changes` answers one question for the whole gate — did anything Tideforge-relevant change? — and on **yes, all 84 declared cells build**. Editing one recipe rebuilt 83 bit-identical artifacts, each paying for a runner, a container image pull and a full mock/sbuild cycle.

Measured on this tree (both gate workflows, 96 cells reachable):

| change | cells planned | reduction |
|---|---|---|
| one leaf recipe (`uupd`) | 17 | 82% |
| `niri` | 12 | 87% |
| `cosmic-icon-theme` | 6 | 94% |
| `scripts/tideforge.py` | 96 | 0% — correct, it feeds every cell |
| docs only | 0 | — |

`scripts/plan_gate_matrix.py` reads the cells the workflows **already declare** and subtracts. It never invents one, so the workflows stay the source of truth and the coverage gate keeps working.

## Written against the dangerous direction

This repo's recurring defect is the silent skip — a declared target no cell exercised (#139), a wishlist that made every missing package optional (#1080). A dispatcher is a machine for manufacturing exactly that, so:

- no diff info / unreadable file / unparseable workflow / missing recipe → **build everything**
- any shared input changed (`scripts/`, `mock/`, gate workflows, `.github/actions/`, `package-factory.yaml`, `build-order-*`) → **build everything**
- every skip is printed with the reason that produced it

**Inter-cell edges come from the workflow, not the recipes.** A recipe's `dependencies:` lists *distro* package names — measured: zero of 46 recipes name a sibling recipe there. The real edges are the jobs' `needs:`. Closing over `dependencies:` would produce a plan that *looks* dependency-aware while silently dropping the consumer of a changed producer.

That distinction bit during development and is now pinned: the first draft pulled `cosmic-comp-deb` in correctly via the closure, then filtered it straight back out with a "your own recipe is unchanged" rule — which must not apply to a job whose entire reason for running is somebody else's rebuilt artifact.

## The gate decision this reverses

The aggregate gate's comment read: any needed job *"that failed, was cancelled, **or was skipped** fails it — a skipped cell is unproven, not passed"*. That was right while the only way to skip was an upstream dying. The planner adds a second, legitimate cause, so `skipped` is now accepted.

This does **not** re-open that hole: every gate job is in the gate's `needs:`, so a job that actually broke reports `failure`/`cancelled` there directly, and a dependent's skip is always accompanied by its upstream's own non-success. The comment now records all of this rather than being quietly overwritten.

## Scope — what is and isn't wired

- **Wired:** the nine matrix-free jobs (`gtkgreet-rpm`, `cpptrace-rpm`, `quickshell-rpm`, `niri-rpm`, `iio-niri-rpm`, `dms-stack-rpm`, `cosmic-{icon-theme,comp,bg}-rpm`).
- **Not wired:** the seven matrix jobs. A job with a static `include:` cannot also take a computed matrix, and those declarations are exactly what the planner reads out of the workflow file — relocating them is its own change and its own risk. That's the follow-up, and it's where the remaining cells live.
- **Phase 2 (fingerprints):** implemented and tested — recipe contents + target + image + shared renderer files, so a `tideforge.py` edit invalidates every previously-proven cell on its own. `plan()` accepts a proven set and prunes against it. **Nothing feeds that set yet**, so it is inert in CI today.

## Testing

35 new tests, **mutation-verified three ways**: re-introducing the downstream-filter bug fails two; dropping the `scripts/` shared-input guard fails two; failing *closed* on missing diff information fails four.

Wiring assertions catch both directions of a mis-wired job — one that builds a recipe and isn't gated on the plan, and one gated on an output the plan never publishes (which evaluates to empty and would skip forever).

Suite **386 → 421**. yamllint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->