### PR TITLE
fix(mock): restore /builddir ownership on every container exit path

### DIFF
--- a/scripts/build-chain.sh
+++ b/scripts/build-chain.sh
@@ -423,6 +423,35 @@ build_package_podman() {
                 # everything after the break. A quoted phrase in this very comment
                 # did that and turned the whole container step into a no-op.
                 chown -R builder /builddir 2>/dev/null || true
+                # Hand /builddir back to root on ANY exit, not just the happy
+                # path. Mock runs as builder, so everything it writes under
+                # /builddir is builder-owned inside the container; the HOST
+                # process is the plain CI runner user, outside this container
+                # entirely, and cannot read builder-owned files through the
+                # bind mount.
+                #
+                # This was a plain command after the flock below. Under set -e
+                # it never ran when mock failed: the failure branch does exit 1
+                # INSIDE the flock string, so the flock command itself fails and
+                # aborts this script right there. So on exactly the path where
+                # the logs matter most, results stayed unreadable to the host.
+                #
+                # What that cost: the dnf5 already-installed retry below greps
+                # results/root.log to decide whether to retry. On an unreadable
+                # file grep -qs fails silently, so the guard fell through to
+                # return 1 and the retry never fired -- canary run 31242725235
+                # came back built=24 failed=8, bit-identical to its no-fix
+                # baseline. Traced directly: this chown appears in the set -x
+                # output for pytz and rust-matugen, which built, and is absent
+                # for python-wcwidth, which failed.
+                #
+                # It also predates that: without it a SUCCESSFUL build handed
+                # back results the host could not enumerate --
+                #   find: /tmp/tmp.XXXXXX/results: Permission denied
+                #   ERROR: No RPMs produced for xfce4-dev-tools
+                # -- which is what put the command here in the first place. A
+                # trap covers both, and cannot be skipped by a later early exit.
+                trap 'chown -R root:root /builddir 2>/dev/null || true' EXIT
                 # Assemble a config directory where the checked-out mock/ configs
                 # override the copies baked into this image: copy the WHOLE
                 # /etc/mock tree, then overlay the repo profiles on top.
@@ -459,19 +488,6 @@ build_package_podman() {
                             exit 1;
                         }
                 \"
-                # Mock ran as builder, so everything it wrote under /builddir is
-                # builder-owned inside the container. The container's own top
-                # level is root, and root can always chown back down — but
-                # nothing did, so control returned to the HOST process (which
-                # runs as the plain CI runner user, outside the container
-                # entirely) unable to read what mock had just produced:
-                #   find: /tmp/tmp.XXXXXX/results: Permission denied
-                #   ERROR: No RPMs produced for xfce4-dev-tools
-                # even though mock's own log said the build finished. Restore
-                # root ownership before the container exits and this handoff
-                # happens, regardless of whether mock succeeded or failed —
-                # build.log and root.log need to be host-readable on failure too.
-                chown -R root:root /builddir 2>/dev/null || true
             "
     }
 

--- a/tests/test_mock_results_readable_on_failure.py
+++ b/tests/test_mock_results_readable_on_failure.py
@@ -1,0 +1,133 @@
+"""The container step must hand /builddir back to root on EVERY exit path.
+
+scripts/build-chain.sh runs mock inside a podman container as an unprivileged
+`builder` user, over a bind-mounted host directory.  Everything mock writes is
+therefore builder-owned, and the HOST process -- the plain CI runner user,
+outside the container entirely -- cannot read it through the mount.  The
+container has to chown the tree back before it exits.
+
+That restore used to be a plain command placed after the mock invocation.  The
+container script runs under `bash -exc`, and mock's failure branch does
+`exit 1` INSIDE the `flock -c` string, so the flock command itself fails and
+set -e aborts the script right there -- the restore never ran on the failure
+path.
+
+Two things broke as a result, one of them silently:
+
+  * A SUCCESSFUL build whose results the host could not enumerate:
+        find: /tmp/tmp.XXXXXX/results: Permission denied
+        ERROR: No RPMs produced for xfce4-dev-tools
+    This is the failure that put the command there originally.
+
+  * The dnf5 already-installed retry (see test_mock_dynamic_br_retry.py) greps
+    results/root.log to decide whether to retry.  On a file it cannot read,
+    `grep -qs` fails SILENTLY -- the -s is there to swallow exactly that -- so
+    the guard fell through to `return 1` and the retry never fired.  Canary run
+    31242725235 came back built=24 failed=8, bit-identical to the baseline the
+    fix was supposed to move.  Traced directly in that log: the restore appears
+    in the set -x output for pytz and rust-matugen, both of which built, and is
+    absent for python-wcwidth, which failed.
+
+So the property under test is not "a chown exists somewhere" -- it did, and it
+was unreachable.  It is that the restore survives an early exit.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "build-chain.sh"
+
+
+def container_script() -> str:
+    """The bash -exc body podman runs, lifted verbatim from _run_mock_container."""
+    text = SCRIPT.read_text()
+    match = re.search(
+        r"^    _run_mock_container\(\) \{.*?^    \}$", text, re.S | re.M
+    )
+    assert match, "_run_mock_container not found in build-chain.sh"
+    return match.group(0)
+
+
+def code_lines() -> list[str]:
+    """Container script lines with comments stripped.
+
+    Commenting the restore out has to fail these exactly like deleting it.
+    """
+    return [
+        line
+        for line in container_script().splitlines()
+        if not line.strip().startswith("#")
+    ]
+
+
+def test_ownership_is_restored_from_an_exit_trap() -> None:
+    """A trailing command is not enough -- set -e can skip it."""
+    traps = [
+        line
+        for line in code_lines()
+        if "trap" in line and "chown -R root:root /builddir" in line and "EXIT" in line
+    ]
+    assert traps, (
+        "the container script never installs an EXIT trap restoring root "
+        "ownership of /builddir. Without one, a mock failure aborts the script "
+        "at the flock and the host is left unable to read results/root.log."
+    )
+
+
+def test_the_trap_is_installed_before_anything_that_can_fail() -> None:
+    """A trap registered after the mock run covers nothing that matters."""
+    lines = code_lines()
+    trap_at = next(
+        i for i, line in enumerate(lines) if "trap" in line and "EXIT" in line
+    )
+    flock_at = next(i for i, line in enumerate(lines) if "flock" in line)
+    assert trap_at < flock_at, (
+        f"the EXIT trap is installed at line {trap_at} of the container script, "
+        f"after the mock invocation at {flock_at} -- a failure in between exits "
+        "with the tree still builder-owned."
+    )
+
+
+def test_no_double_quote_in_the_container_script() -> None:
+    """The script is passed as `bash -exc "..."` from the host shell.
+
+    A literal double quote closes that string early; bash then takes the script
+    as two arguments, treats the second as $0, and silently drops everything
+    after the break.  build-chain.sh carries this warning inline because a
+    quoted phrase in a COMMENT once turned the whole container step into a
+    no-op -- so the fix above must not reintroduce one.
+    """
+    body = container_script()
+    # The host-side heredoc escapes its own quotes as \" -- those are fine.
+    unescaped = re.sub(r'\\"', "", body)
+    parts = unescaped.split('bash -exc "', 1)
+    assert len(parts) == 2, "container script is no longer a bash -exc string"
+    lines = parts[1].splitlines()
+    # Drop the string's own terminator -- the last line that is only a quote.
+    closing = max(i for i, line in enumerate(lines) if line.strip() == '"')
+    offending = [line for line in lines[:closing] if '"' in line]
+    assert not offending, f"literal double quote inside the bash -exc string: {offending}"
+
+
+def test_early_exit_still_runs_the_restore(tmp_path: Path) -> None:
+    """The behaviour itself, on the exact shape build-chain.sh uses.
+
+    set -e + a failing `flock -c` whose body exits 1 -- the arrangement that
+    skipped the old trailing command.  The marker file stands in for the chown.
+    """
+    marker = tmp_path / "restored"
+    script = f"""
+set -ex
+trap 'touch {marker!s}' EXIT
+flock {tmp_path!s}/lock -c 'exit 1'
+echo "unreachable trailing restore"
+"""
+    proc = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert proc.returncode != 0, "the failing flock should abort the script"
+    assert "unreachable trailing restore" not in proc.stdout, (
+        "set -e did not abort at the flock -- this test no longer models the bug"
+    )
+    assert marker.exists(), "the EXIT trap did not run on the aborted path"


### PR DESCRIPTION
## The retry from #261 never fired

Canary run [31242725235](https://github.com/tuna-os/tunaos-packages/actions/runs/31242725235) (`niri-00`, publish off) came back **`built=24 failed=8`** — bit-identical to the baseline the fix was supposed to move. All 8 failures were the same `python-*` packages, and their `root.log` carried the exact signature the guard greps for:

```
Failed to resolve the transaction:
Package "pyproject-rpm-macros-1.23.2-1.hum1.noarch" is already installed.
Package "python3-devel-3.14.6-2.2.hum1.x86_64" is already installed.
Package "python3-pytest-9.0.3-5.hum1.noarch" is already installed.
Package "python3-packaging-26.2-4.1.hum1.noarch" is already installed.
```

The retry message appears nowhere in the log.

## Why the guard was unreachable

```bash
if grep -qs "is already installed" "${builddir}/results/root.log"
```

Mock runs inside the container as `builder`, so everything under `/builddir` is builder-owned; the host process is the plain CI runner user and cannot read it through the bind mount. The container chowns the tree back before exiting — except that restore was a plain command placed **after** the mock invocation, and the container script runs under `bash -exc`.

Mock's failure branch does `exit 1` **inside** the `flock -c` string. So the `flock` command itself fails, `set -e` aborts the script right there, and the restore never runs. On exactly the path where `build.log` and `root.log` matter most, they stayed unreadable. `grep -qs` then failed silently — the `-s` exists to swallow precisely that — and the guard fell through to `return 1`.

## Traced, not inferred

`chown -R root:root /builddir` in the canary's `set -x` output:

| package | outcome | restore ran |
|---|---|---|
| `pytz` | built 1 RPM | yes (log line 4456) |
| `rust-matugen` | built 3 RPMs | yes (log line 4819) |
| `python-wcwidth` | **mock failed** (line 730) | **no** |

## The fix

Move the restore into an `EXIT` trap installed before anything that can fail. That covers both users of it — this retry, and the older failure that put the command there in the first place: a *successful* build whose results the host could not enumerate (`find: /tmp/tmp.XXXXXX/results: Permission denied` → `ERROR: No RPMs produced for xfce4-dev-tools`).

## Testing

`tests/test_mock_results_readable_on_failure.py` pins the property that was missing rather than the line that was present — the restore must **survive an early exit**. Four tests:

1. the restore is an `EXIT` trap, not a trailing command (comment-stripped, so commenting it out fails like deleting it)
2. the trap is installed before the mock invocation
3. no literal double quote in the `bash -exc` string — a trap the file already documents, since a quoted phrase in a *comment* once turned the whole container step into a no-op
4. a behavioural test running the exact shape (`set -e` + a failing `flock -c` whose body exits 1) and asserting the trap still fires, with a guard that fails if the arrangement stops modelling the bug

Mutation-verified four ways: reverting to a trailing command (2 fail), moving the trap after the mock run (1), commenting it out (2), reintroducing a literal double quote (1).

Suite **247 → 251**, no failures. (Three test files fail to *collect* on Python 3.11 because `scripts/tideforge.py` uses a backslash inside an f-string expression, which needs 3.12+; pre-existing on `main` and unrelated to this diff — CI runs a newer Python.)

## Next

Re-dispatch the canary once this lands. The bar is unchanged and unchanged deliberately: the 8 `python-*` packages must build **and** the log must contain `mock hit the dnf5 already-installed dynamic-BuildRequires bug; retrying`. If they build without that line, something else fixed it and the retry is still unproven.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->