### PR TITLE
perf(hummingbird): let mock builds run concurrently instead of taking turns

### DIFF
--- a/.github/workflows/build-hummingbird-desktops.yml
+++ b/.github/workflows/build-hummingbird-desktops.yml
@@ -132,8 +132,14 @@ jobs:
       - name: Build tiers
         run: |
           IFS=',' read -ra TIERS <<< "${{ steps.tiers.outputs.list }}"
+          # One worker per core. This was hardcoded to 2, which was the right
+          # number while every mock run held an EXCLUSIVE lock on the local
+          # repo -- extra workers could only queue behind it, so raising this
+          # bought nothing and just burned memory. That lock is now shared, so
+          # workers genuinely build at the same time and the core count is the
+          # real ceiling.
           ARGS=(--manifest "${MANIFEST}" --mock-config hummingbird-ci
-                --local-repo "$PWD/local-repo-hummingbird" --jobs 2)
+                --local-repo "$PWD/local-repo-hummingbird" --jobs "$(nproc)")
           if [[ "${{ inputs.force }}" == "true" ]]; then ARGS+=(--force); fi
           for tier in "${TIERS[@]}"; do
             echo "::group::tier ${tier}"

--- a/scripts/build-chain.sh
+++ b/scripts/build-chain.sh
@@ -469,9 +469,27 @@ build_package_podman() {
                 cp -a /etc/mock/. /tmp/mock-configdir/
                 cp /repo-mock/*.cfg /tmp/mock-configdir/
                 chmod -R a+rX /tmp/mock-configdir
-                # Use flock to ensure only one process runs mock at a time
-                # because they share mock chroot initialization.
-                flock /local-repo/repo.lock -c \"
+                # SHARED lock: mock only READS /local-repo as a dnf repo, so
+                # any number of builds can hold it at once. The exclusive half
+                # is `createrepo_c --update` on the host, which rewrites the
+                # metadata mock is reading -- that is the only thing here that
+                # ever needed serializing.
+                #
+                # This was an EXCLUSIVE lock, with the comment: the builds
+                # \"share mock chroot initialization\". They do not, on three
+                # counts, all of which predate this change:
+                #   * --uniqueext below gives every package its own chroot
+                #     (/var/lib/mock/<config>-<pkg>), which is what the flag is
+                #     for;
+                #   * /var/lib/mock lives INSIDE this container and is thrown
+                #     away with it, so two concurrent builds cannot see each
+                #     other's chroots at all;
+                #   * /var/cache/mock is only bind-mounted when MOCK_CACHE_DIR
+                #     is set, and the Hummingbird workflow does not set it.
+                # So the exclusive lock protected nothing, while serialising
+                # the single most expensive step in the run: --jobs N started N
+                # workers that then took turns compiling one at a time.
+                flock -s /local-repo/repo.lock -c \"
                     setpriv --reuid=builder --regid=mock --init-groups \\
                     mock --configdir /tmp/mock-configdir -r '${MOCK_CONFIG}' \\
                         --uniqueext='${pkg_name}' \\

--- a/scripts/build-chain.sh
+++ b/scripts/build-chain.sh
@@ -471,9 +471,16 @@ build_package_podman() {
                 chmod -R a+rX /tmp/mock-configdir
                 # SHARED lock: mock only READS /local-repo as a dnf repo, so
                 # any number of builds can hold it at once. The exclusive half
-                # is `createrepo_c --update` on the host, which rewrites the
+                # is the createrepo_c --update on the host, which rewrites the
                 # metadata mock is reading -- that is the only thing here that
                 # ever needed serializing.
+                #
+                # No backticks anywhere in this comment, for the same reason
+                # the header above bans double quotes: these lines are inside
+                # the bash -exc STRING, where a backtick is command
+                # substitution, not punctuation. Quoting createrepo_c that way
+                # made shellcheck flag SC2006 -- and it was right, the host
+                # shell would have run it while building the string.
                 #
                 # This was an EXCLUSIVE lock, with the comment: the builds
                 # \"share mock chroot initialization\". They do not, on three

--- a/tests/test_mock_builds_run_concurrently.py
+++ b/tests/test_mock_builds_run_concurrently.py
@@ -1,0 +1,151 @@
+"""Concurrent mock builds must not serialise on the local-repo lock.
+
+`build-chain.sh --jobs N` starts N worker processes per tier.  Every one of
+them ran `mock --rebuild` inside `flock /local-repo/repo.lock` -- an EXCLUSIVE
+lock -- so the workers took turns doing the single most expensive step in the
+run.  `--jobs` selected how many processes waited, not how many built.
+
+The comment justifying it said the builds "share mock chroot initialization".
+They do not, on three counts, none of which this change introduced:
+
+  * `--uniqueext=<pkg>` gives every package its own chroot at
+    /var/lib/mock/<config>-<pkg>; that is what the flag exists for.
+  * /var/lib/mock lives inside the per-build container and dies with it, so
+    two concurrent builds cannot observe each other's chroots at all.
+  * /var/cache/mock is bind-mounted only when MOCK_CACHE_DIR is set, and
+    .github/workflows/build-hummingbird-desktops.yml does not set it.
+
+What genuinely needs serialising is `createrepo_c --update`, which REWRITES the
+metadata mock reads.  That is a classic reader/writer split: builds take the
+lock shared, the metadata update takes it exclusive.
+
+These tests pin the split.  Getting it backwards is silent in both directions
+-- an exclusive build lock just makes everything slow, and a shared metadata
+lock just corrupts a repo occasionally -- so neither shows up as a test failure
+anywhere else.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "build-chain.sh"
+
+
+def code() -> str:
+    """build-chain.sh with comment lines stripped."""
+    return "\n".join(
+        line
+        for line in SCRIPT.read_text().splitlines()
+        if not line.strip().startswith("#")
+    )
+
+
+def podman_backend() -> str:
+    """build_package_podman only -- the backend the desktop builds use.
+
+    The scope matters. `build_package_mock` runs mock straight on the HOST,
+    where /var/lib/mock and /var/cache/mock ARE shared between concurrent
+    processes, so its exclusive lock is doing real work and must stay. Only the
+    containerised backend gets the isolation that makes a shared lock safe.
+    """
+    text = "\n".join(
+        line
+        for line in SCRIPT.read_text().splitlines()
+        if not line.strip().startswith("#")
+    )
+    match = re.search(
+        r"^build_package_podman\(\) \{.*?^\}$", text, re.S | re.M
+    )
+    assert match, "build_package_podman not found in build-chain.sh"
+    return match.group(0)
+
+
+def test_the_mock_build_takes_the_lock_shared() -> None:
+    """The expensive step must not exclude its peers."""
+    mock_locks = [
+        line
+        for line in podman_backend().splitlines()
+        if "flock" in line and "repo.lock" in line and "createrepo" not in line
+    ]
+    assert mock_locks, "no flock guarding the containerised mock build found"
+    for line in mock_locks:
+        assert "flock -s" in line, (
+            f"the mock build takes an EXCLUSIVE lock on the local repo: {line.strip()}\n"
+            "That serialises every --jobs worker onto one build at a time. "
+            "mock only READS the repo; use `flock -s`."
+        )
+
+
+def test_the_host_mock_backend_keeps_its_exclusive_lock() -> None:
+    """The other backend has none of the isolation, so it must not be 'fixed' too."""
+    text = "\n".join(
+        line
+        for line in SCRIPT.read_text().splitlines()
+        if not line.strip().startswith("#")
+    )
+    match = re.search(r"^build_package_mock\(\) \{.*?^\}$", text, re.S | re.M)
+    assert match, "build_package_mock not found"
+    for line in match.group(0).splitlines():
+        if "flock" in line and "repo.lock" in line:
+            assert "flock -s" not in line, (
+                "build_package_mock runs mock on the HOST, sharing /var/lib/mock "
+                "and /var/cache/mock between concurrent processes. Its lock must "
+                f"stay exclusive: {line.strip()}"
+            )
+
+
+def test_createrepo_keeps_the_lock_exclusive() -> None:
+    """The writer must still exclude everyone, or readers see torn metadata."""
+    writer_locks = [
+        line
+        for line in code().splitlines()
+        if "flock" in line and "createrepo_c" in line
+    ]
+    assert writer_locks, "createrepo_c is no longer called under a lock at all"
+    for line in writer_locks:
+        assert "flock -s" not in line, (
+            f"createrepo_c takes a SHARED lock: {line.strip()}\n"
+            "It rewrites the metadata concurrent builds are reading."
+        )
+
+
+def test_every_build_gets_its_own_chroot() -> None:
+    """The isolation the shared lock relies on.
+
+    Drop --uniqueext and concurrent builds collide in /var/lib/mock, which is
+    the failure the exclusive lock was mistakenly guarding against.
+    """
+    assert "--uniqueext=" in podman_backend(), (
+        "mock is invoked without --uniqueext, so concurrent builds would share "
+        "one chroot. Either restore it or restore the exclusive lock."
+    )
+
+
+def test_shared_locks_do_not_exclude_each_other(tmp_path: Path) -> None:
+    """The property itself, on real flock.
+
+    Two shared holders run at once; an exclusive one cannot join them.  Guards
+    against a future `flock` wrapper or busybox variant where -s is ignored.
+    """
+    lock = tmp_path / "repo.lock"
+    lock.touch()
+    script = f"""
+set -e
+flock -s {lock!s} -c 'sleep 2' &
+sleep 0.3
+# A second SHARED holder must get in immediately.
+timeout 1 flock -s {lock!s} -c 'echo SHARED_OK'
+# An EXCLUSIVE holder must not, while the first is still sleeping.
+if timeout 1 flock -x {lock!s} -c 'echo EXCLUSIVE_GOT_IN'; then :; fi
+wait
+"""
+    proc = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert "SHARED_OK" in proc.stdout, (
+        f"a second shared holder was blocked: {proc.stdout!r} {proc.stderr!r}"
+    )
+    assert "EXCLUSIVE_GOT_IN" not in proc.stdout, (
+        "an exclusive holder acquired the lock while a shared one held it"
+    )


### PR DESCRIPTION
## `--jobs` has never been real

`build-chain.sh --jobs N` starts N worker processes per tier. Every one of them ran `mock --rebuild` inside:

```bash
flock /local-repo/repo.lock -c "mock ... --rebuild ..."
```

An **exclusive** lock, around the single most expensive step in the run. So `--jobs` selected how many workers *waited*, not how many built. The entire 670-package desktop backlog has been compiling one package at a time, on every run, since the flag was added.

## The justification no longer holds — and never did here

The comment read: serialize *"because they share mock chroot initialization"*. They don't, on three counts, none of which this PR introduces:

| claim | reality |
|---|---|
| shared chroot | `--uniqueext=<pkg>` gives every package its own at `/var/lib/mock/<config>-<pkg>` — that is what the flag is for |
| shared `/var/lib/mock` | it lives **inside** the per-build container and is discarded with it; concurrent builds cannot see each other's chroots at all |
| shared `/var/cache/mock` | bind-mounted only when `MOCK_CACHE_DIR` is set, and `build-hummingbird-desktops.yml` does not set it |

What genuinely needs serialising is `createrepo_c --update`, which **rewrites** the metadata mock is **reading**. That is a reader/writer split, not a global mutex:

- builds take the lock **shared** (`flock -s`)
- the metadata update keeps it **exclusive**

## Scope

Deliberately limited to `build_package_podman`. `build_package_mock` runs mock straight on the host, where `/var/lib/mock` and `/var/cache/mock` *are* shared between concurrent processes — its exclusive lock is doing real work and stays. A test pins that it isn't "fixed" too.

## `--jobs`

Workflow goes from a hardcoded `2` to `$(nproc)`. `2` was correct while the lock was exclusive — extra workers could only queue behind it, so raising it bought nothing but memory. With builds actually concurrent, the core count is the ceiling.

## Testing

`tests/test_mock_builds_run_concurrently.py` — 5 tests, mutation-verified four ways: reverting the podman lock to exclusive, making the host-mock lock shared, making the createrepo lock shared, and dropping `--uniqueext`. The last test drives **real `flock`** rather than the script text, so a wrapper or busybox variant where `-s` is silently ignored fails too.

Suite 251 → 256.

These pins exist because getting it backwards is invisible in both directions: an exclusive build lock is merely slow, and a shared metadata lock merely corrupts a repo occasionally. Neither surfaces as a failure anywhere else — which is exactly how the exclusive lock survived this long.

## What this does not fix

Throughput has more ceilings above this one, filed separately rather than bundled:

1. **Tier barriers.** Tiers are dependency *levels* and run strictly sequentially, so a 108-package tier's slowest straggler blocks all 30 packages of the next one. A DAG wavefront — run anything whose dependencies are built — removes the barrier.
2. **One runner per dispatch.** 5 desktops × 56 tiers are driven from a single `ubuntu-latest` job. A matrix over desktops would give 5 concurrent runners, converging through R2 since the local repo is seeded from it.
3. **Runner size.** 4 vCPU caps `$(nproc)` at 4.

## Verification

A canary on `niri-00` (32 packages) took **19m24s** serialized. Re-running the same tier after this lands measures the change directly, same tier, same runner class.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->