### PR TITLE
fix(hummingbird): order the bootstrap tiers by each package's real PEP-517 backend

### DIFF
--- a/build-order-hummingbird-desktops.yml
+++ b/build-order-hummingbird-desktops.yml
@@ -29,30 +29,32 @@ r2_path: hummingbird/20251124-x86_64
 tiers:
   - name: bootstrap-00
     packages:
-      - path: src/hummingbird/python-editables
-        distgit: python-editables
-      - path: src/hummingbird/python-hatchling
-        distgit: python-hatchling
       - path: src/hummingbird/python-flit-core
         distgit: python-flit-core
-      - path: src/hummingbird/python-installer
-        distgit: python-installer
+      - path: src/hummingbird/python-poetry-core
+        distgit: python-poetry-core
       - path: src/hummingbird/python-trove-classifiers
         distgit: python-trove-classifiers
   - name: bootstrap-01
     packages:
+      - path: src/hummingbird/python-editables
+        distgit: python-editables
+      - path: src/hummingbird/python-installer
+        distgit: python-installer
       - path: src/hummingbird/python-build
         distgit: python-build
+      - path: src/hummingbird/python-wheel
+        distgit: python-wheel
+  - name: bootstrap-02
+    packages:
+      - path: src/hummingbird/python-hatchling
+        distgit: python-hatchling
+  - name: bootstrap-03
+    packages:
       - path: src/hummingbird/python-hatch-vcs
         distgit: python-hatch-vcs
       - path: src/hummingbird/python-hatch-fancy-pypi-readme
         distgit: python-hatch-fancy-pypi-readme
-  - name: bootstrap-02
-    packages:
-      - path: src/hummingbird/python-wheel
-        distgit: python-wheel
-      - path: src/hummingbird/python-poetry-core
-        distgit: python-poetry-core
   - name: gnome-00
     packages:
       - path: src/hummingbird/abseil-cpp

--- a/tests/test_hummingbird_python_bootstrap.py
+++ b/tests/test_hummingbird_python_bootstrap.py
@@ -86,21 +86,57 @@ def test_backends_are_built_before_the_desktops() -> None:
         )
 
 
-def test_hatchling_precedes_the_packages_that_build_with_it() -> None:
-    """Ordering inside the bootstrap block.
+# Each package's declared PEP-517 backend, read out of its own sdist
+# pyproject.toml rather than guessed:
+#
+#   flit-core, poetry-core, hatchling   self-hosting
+#   trove-classifiers                   setuptools.build_meta  (in Hummingbird)
+#   editables, installer, build, wheel  flit_core.buildapi
+#   hatch-vcs, hatch-fancy-pypi-readme  hatchling.build
+#
+# A backend must be BUILT before anything that builds with it, and packages
+# inside one tier run concurrently -- so "earlier tier", not "earlier in the
+# list". The first cut of this file had editables and installer sharing a tier
+# with flit-core, and hatchling sharing one with the trove-classifiers and
+# editables it needs; both would have failed on the first dispatch.
+BACKEND_OF = {
+    "python-editables": "python-flit-core",
+    "python-installer": "python-flit-core",
+    "python-build": "python-flit-core",
+    "python-wheel": "python-flit-core",
+    "python-hatch-vcs": "python-hatchling",
+    "python-hatch-fancy-pypi-readme": "python-hatchling",
+}
 
-    hatch-vcs and hatch-fancy-pypi-readme build with hatchling, so they cannot
-    share its tier -- packages inside one tier run concurrently.
-    """
+
+def test_each_backend_is_built_before_its_dependents() -> None:
     order = [t["name"] for t in tiers()]
     by_name = {t["name"]: names_in(t) for t in tiers()}
-    where = lambda pkg: next(  # noqa: E731
-        i for i, n in enumerate(order) if pkg in by_name[n]
-    )
-    hatchling = where("python-hatchling")
-    for dependent in ("python-hatch-vcs", "python-hatch-fancy-pypi-readme"):
-        assert where(dependent) > hatchling, (
-            f"{dependent} builds with hatchling but is not in a later tier"
+
+    def tier_of(pkg: str) -> int:
+        return next(i for i, n in enumerate(order) if pkg in by_name[n])
+
+    for pkg, backend in BACKEND_OF.items():
+        assert tier_of(pkg) > tier_of(backend), (
+            f"{pkg} declares build-backend {backend!r} but is in tier "
+            f"'{order[tier_of(pkg)]}', not after '{order[tier_of(backend)]}'. "
+            "Packages inside a tier run concurrently, so sharing one is the "
+            "same as building it first."
+        )
+
+
+def test_hatchling_follows_its_own_runtime_deps() -> None:
+    """%pyproject_buildrequires emits runtime deps too, not just the backend."""
+    order = [t["name"] for t in tiers()]
+    by_name = {t["name"]: names_in(t) for t in tiers()}
+
+    def tier_of(pkg: str) -> int:
+        return next(i for i, n in enumerate(order) if pkg in by_name[n])
+
+    for dep in ("python-editables", "python-trove-classifiers"):
+        assert tier_of("python-hatchling") > tier_of(dep), (
+            f"hatchling requires {dep} at runtime, so it must build in a later "
+            "tier than it"
         )
 
 


### PR DESCRIPTION
Follow-up to #268, which merged while its branch was locked in the merge queue so this correction could not go in with it. **#268's tier split is wrong and would fail on the first dispatch** — this fixes it before any build round is spent on it.

## What I got wrong

#268 grouped the backends by inspection of static `BuildRequires`. But every one of these packages uses `%pyproject_buildrequires`, which resolves the backend from the sdist's own `pyproject.toml` at build time — invisible in the spec. So I read `build-backend` out of each sdist directly:

| package | declared `build-backend` |
|---|---|
| flit-core, poetry-core, hatchling | self-hosting |
| trove-classifiers | `setuptools.build_meta` (setuptools is already in Hummingbird) |
| editables, installer, build, wheel | `flit_core.buildapi` |
| hatch-vcs, hatch-fancy-pypi-readme | `hatchling.build` |

A backend has to be **built** before anything that builds with it, and packages inside one tier run **concurrently** — so sharing a tier is the same as not building it first. #268 had:

- `editables` and `installer` in **flit-core's own tier**, though both declare `flit_core.buildapi`
- `hatchling` in the same tier as the `editables` and `trove-classifiers` that `%pyproject_buildrequires` emits for it

Both would have failed on the first run.

## Corrected

| tier | packages |
|---|---|
| `bootstrap-00` | flit-core, poetry-core, trove-classifiers |
| `bootstrap-01` | editables, installer, build, wheel |
| `bootstrap-02` | hatchling |
| `bootstrap-03` | hatch-vcs, hatch-fancy-pypi-readme |

## Testing

The single hatchling ordering assert is replaced by two: one drives a package → backend table so every edge is checked, the other pins that hatchling follows the runtime deps its BuildRequires generation pulls in. Both mutation-verified by putting the packages back where #268 had them — each fails.

Suite 255 → 256. yamllint clean, manifest formatting untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->