### PR TITLE
fix(mock): pin Fedora 44 for Python so the buildroot stops mixing 3.14 and 3.15

### DIFF
--- a/docs/hummingbird-desktop-gap.md
+++ b/docs/hummingbird-desktop-gap.md
@@ -176,6 +176,84 @@ pass, then a second full pass.  The mock config keeps Fedora Rawhide as a
 priority-99 buildroot fallback precisely so the first pass has headers to build
 against; Rawhide is never a repository on a produced image.
 
+## Finding 6 — the gap is a runtime closure, and Python pays for it
+
+Re-measured 2026-08-08, after tier `niri-00` failed eight python-\* packages
+identically in runs 31231968581, 31242725235 and 31248093019.  Hummingbird's
+index had moved on (revision `1786137625`, primary sha256
+`3c2eaf99d82289b58747895801df4d7a9e5fbe4328899d7e93626b5ffb0f0c68`, 16617
+`(name, evr, arch)` tuples) but the Python column had not:
+
+| | hummingbird | Fedora Rawhide (45) | Fedora 44 |
+|---|---|---|---|
+| python3 | 3.14.6-2.2.hum1 | 3.15.0~rc1-1.fc45 | 3.14.6-1.fc44 |
+
+Rawhide has been through the Python 3.15 rebuild; Hummingbird has not.  Every
+noarch Python module carries `Requires: python(abi) = <x.y>`, so this is not a
+soft version skew — **8919 of Rawhide's 66644 binary packages transitively
+require `python(abi) = 3.15`** and cannot enter this buildroot at all.
+
+Hummingbird ships a *partial* Python stack: `pyproject-rpm-macros`,
+`python-srpm-macros 3.14`, `python3-devel`, `python3-setuptools 83.0.0`,
+`python3-pip 26.2`, `python3-packaging`, `python3-pytest`, `python3-pathspec`,
+`python3-pluggy` — and not one PEP 517 build backend.  No `flit-core`,
+`hatchling`, `poetry-core`, `wheel`, `installer`, `build`, `editables`,
+`trove-classifiers`, `Cython` or `expandvars`.  So `%pyproject_buildrequires`
+emits a capability whose only provider is a Rawhide 3.15 build, and dnf5 says:
+
+```
+python3-flit-core-3.12.0-12.fc45.noarch requires python(abi) = 3.15,
+  but none of the providers can be installed
+installed package python3-pip-26.2-0.1.hum1.noarch requires python(abi) = 3.14
+```
+
+**Why the build order never listed them.** `measure-hummingbird-gap.py`
+computes `closure()` over runtime `Requires:` only.  BuildRequires are used to
+*order* that set, never to extend it — `tier_sources().link()` drops a
+requirement whose provider is not already in the runtime-derived build set:
+
+```python
+dependency = binary_to_source.get(provider)
+...
+if dependency and dependency in sources and dependency != source:
+    edges[source].add(dependency)
+```
+
+A build backend never appears in any runtime closure, so it was never a
+candidate.  Reading the same Rawhide *source* index the tier ordering already
+uses, **60 build-only providers carrying `python(abi)` are needed by the 670
+packages and are in neither Hummingbird nor the build order** — `Cython`,
+`gi-docgen` (30 consumers), `python-docutils` (14), `python-sphinx` (12),
+`python-wheel` (10), `python-build` (8), `python-dbusmock` (8),
+`python-setuptools_scm` (7) and so on.  This is not specific to `niri-00`; it
+reaches every desktop.
+
+**Why building them all is not the answer on its own.** Fedora's specs
+BuildRequire their test suites, and `--nocheck` skips `%check` without removing
+a single `BuildRequires`.  Taking the transitive BuildRequires closure of just
+the eight `niri-00` packages, following only edges that Rawhide cannot satisfy
+because of the ABI split, yields **640 source packages** — `python-build` alone
+pulls `filelock`, `pyproject-hooks`, `pytest-mock`, `pytest-rerunfailures`,
+`pytest-xdist`, `setuptools_scm`, `virtualenv` and `uv`.  That is a Python mass
+rebuild, not a tier.
+
+**What was pinned instead.**  638 of those 640 already exist in Fedora 44 at
+`python(abi) = 3.14` — the same interpreter version Hummingbird ships.  (The
+two that do not are `python-roman-numerals` and `python-vcs-versioning`, both
+new in Rawhide's Sphinx chain.)  So `mock/hummingbird-ci.cfg` pins Fedora 44 at
+priority 50, `includepkgs=python3-*,flit`: below Hummingbird, so the
+interpreter, setuptools, pip and pytest still come from the target; above
+Rawhide, so a 3.14 module beats a 3.15 one; and confined by `includepkgs`, so
+no Fedora 44 C library can enter the chroot and the soname split in Finding 3
+is untouched.  With that pin, none of the eight — and none of the PEP 517
+bootstrap tiers added alongside them — has a remaining unsatisfiable
+`python(abi)` BuildRequires.
+
+The pin is temporary by construction: it must be removed when Hummingbird's own
+`python3` reaches 3.15, or it would build 3.14 modules for a 3.15 target.
+`tests/test_hummingbird_python_abi_pin.py` asserts the priority ordering, the
+`includepkgs` confinement and the presence of that expiry note.
+
 ## What was NOT verified
 
 Honesty about the boundary of the measurement:
@@ -193,3 +271,16 @@ Honesty about the boundary of the measurement:
   else shortest name" (`choose_provider`).  A different choice would move a few
   source packages in or out of the list.
 * `x86_64` only.  `aarch64` is a separate index and has not been measured.
+* Finding 6 is index arithmetic, not a build.  **No mock chroot was created and
+  no package was rebuilt with the Fedora 44 pin in place.**  What is verified is
+  that every `python(abi)`-carrying BuildRequires of the eight `niri-00`
+  packages and of the PEP 517 bootstrap tiers has a provider in Fedora 44 at
+  `python(abi) = 3.14` whose version satisfies the recorded constraint
+  (`poetry-core >= 2` → 2.3.0, `cython >= 3.2` → 3.2.4, `flit-core >= 3.11 < 4`
+  → 3.12.0, `blinker >= 1.4` → 1.9.0, `cssselect >= 0.7` → 1.4.0).  Whether
+  dnf5 composes the transaction the priority table predicts can only be
+  established by a real run of the workflow.
+* Finding 6's `python(abi)` reachability is computed with the same
+  `choose_provider` rule as the rest of this document, and treats
+  `(A if B)`-guarded rich dependencies as inert — every one of them in this set
+  is `(python3dist(tomli) if python3-devel < 3.11)`, which is false here.

--- a/mock/hummingbird-ci.cfg
+++ b/mock/hummingbird-ci.cfg
@@ -18,14 +18,56 @@
 # build tools into the chroot for anything Hummingbird does not itself ship —
 # which, per docs/hummingbird-desktop-gap.md, is the entire desktop stack.
 #
-# Repository priority (lower wins in dnf):
-#   1  local-build   RPMs produced by earlier tiers of this same run
-#   10 hummingbird   the target's own signed RPMs — the ABI we must match
-#   99 rawhide       (inherited) BuildRequires: fallback only
+# Rawhide is the right base for everything EXCEPT Python.  Hummingbird has not
+# followed Rawhide through the Python 3.15 rebuild:
 #
-# Fedora Rawhide is a BUILDROOT input, never a repository on a produced image.
-# It supplies -devel headers for packages Hummingbird has no build of yet; the
-# runtime RPM that ships is always the one built here.
+#     python3   3.14.6-2.2.hum1        3.15.0~rc1-1.fc45
+#
+# Every noarch Python module carries `Requires: python(abi) = <x.y>`, so a
+# module built in Rawhide is not installable next to Hummingbird's interpreter.
+# Measured 2026-08-08 against Rawhide's own index: 8919 of its 66644 binary
+# packages transitively need python(abi) = 3.15 and therefore cannot enter this
+# chroot at all.  That is what fails the eight python-* packages of tier
+# niri-00 (runs 31231968581, 31242725235, 31248093019): %pyproject_buildrequires
+# emits e.g. python3dist(flit-core), the only provider is Rawhide's 3.15 build,
+# and dnf5 reports
+#
+#     python3-flit-core ... requires python(abi) = 3.15, but none of the
+#     providers can be installed
+#     installed package python3-pip-26.2-0.1.hum1.noarch requires
+#     python(abi) = 3.14
+#
+# Fedora 44 is the release whose interpreter is python3-3.14.6 — the same
+# upstream version Hummingbird ships — with a complete Python 3.14 module set
+# behind it.  It is pinned here for the Python namespace ONLY.  `includepkgs`
+# is what confines it: no F44 C library can enter the chroot, so the glibc /
+# libxml2 / openssl soname split that docs/hummingbird-desktop-gap.md Finding 3
+# records is untouched, and an F44 module with a compiled extension against an
+# old soname fails to resolve loudly instead of installing quietly.
+#
+# `flit` is listed by name because F44 renamed the binary; it still
+# Provides: python3-flit, which python-wheel BuildRequires.
+#
+# Remove this pin when Hummingbird's own python3 reaches 3.15 — leaving it in
+# past that point would build 3.14 modules for a 3.15 target.
+# tests/test_hummingbird_python_abi_pin.py guards the invariants below.
+#
+# Repository priority (lower wins in dnf):
+#   1  local-build      RPMs produced by earlier tiers of this same run
+#   10 hummingbird      the target's own signed RPMs — the ABI we must match
+#   50 fedora-44-python Python 3.14 modules, buildroot only, includepkgs-confined
+#   99 rawhide          (inherited) BuildRequires: fallback only
+#
+# Hummingbird stays at 10 so its own python3, setuptools, pip, packaging and
+# pytest keep winning: dnf's priority filter drops a package name entirely from
+# the lower-priority repo, so F44 can never shadow the interpreter or downgrade
+# setuptools (F44 has 80.10.2, Hummingbird 83.0.0, and python-propcache
+# BuildRequires >= 82.0.1).
+#
+# Fedora Rawhide and Fedora 44 are BUILDROOT inputs, never repositories on a
+# produced image.  They supply -devel headers and build backends for packages
+# Hummingbird has no build of yet; the runtime RPM that ships is always the one
+# built here.
 include('/etc/mock/fedora-rawhide-x86_64.cfg')
 config_opts['root'] = 'hummingbird-ci'
 config_opts['rpmbuild_networking'] = False
@@ -44,6 +86,22 @@ baseurl=https://packages.redhat.com/api/pulp-content/public-hummingbird/$basearc
 gpgcheck=0
 enabled=1
 priority=10
+
+[fedora-44-python]
+name=Fedora 44 - Python 3.14 build inputs only
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-44&arch=$basearch
+gpgcheck=0
+enabled=1
+priority=50
+includepkgs=python3-*,flit
+
+[fedora-44-python-updates]
+name=Fedora 44 updates - Python 3.14 build inputs only
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f44&arch=$basearch
+gpgcheck=0
+enabled=1
+priority=50
+includepkgs=python3-*,flit
 """
 config_opts['plugin_conf']['bind_mount_enable'] = True
 config_opts['plugin_conf']['bind_mount_opts']['dirs'].append(('/local-repo', '/local-repo'))

--- a/tests/test_hummingbird_python_abi_pin.py
+++ b/tests/test_hummingbird_python_abi_pin.py
@@ -1,0 +1,142 @@
+"""Hummingbird is on Python 3.14; Rawhide is on 3.15.  Guard the pin that bridges them.
+
+`mock/hummingbird-ci.cfg` layers Fedora Rawhide under Hummingbird's own
+repository, which is right for everything except Python: Hummingbird ships
+python3-3.14.6 and has not followed Rawhide through the 3.15 rebuild.  Every
+noarch Python module carries `Requires: python(abi) = <x.y>`, so Rawhide's
+modules cannot be installed beside Hummingbird's interpreter.  Measured
+2026-08-08 against Rawhide's own index, 8919 of its 66644 binary packages
+transitively need `python(abi) = 3.15`.
+
+That is what fails the eight python-* packages of tier niri-00 (runs
+31231968581, 31242725235, 31248093019): `%pyproject_buildrequires` emits e.g.
+`python3dist(flit-core)`, the only provider is Rawhide's 3.15 build, and the
+transaction cannot resolve.
+
+Fedora 44 is the release whose interpreter is python3-3.14.6 — the same
+upstream version Hummingbird ships.  It is pinned for the Python namespace
+only.  Two properties make that safe, and both are asserted here:
+
+* `includepkgs` confines the repository, so no F44 C library can enter the
+  chroot and the glibc / libxml2 / openssl soname split recorded in
+  docs/hummingbird-desktop-gap.md Finding 3 is untouched;
+* the priority sits strictly between Hummingbird's and Rawhide's, so F44 beats
+  Rawhide's 3.15 modules but can never shadow Hummingbird's own interpreter,
+  setuptools, pip, packaging or pytest.
+"""
+from __future__ import annotations
+
+import configparser
+import fnmatch
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG = ROOT / "mock/hummingbird-ci.cfg"
+
+# mock's fedora-rawhide-x86_64.cfg leaves its repos at dnf's default priority.
+RAWHIDE_PRIORITY = 99
+
+PINNED = ("fedora-44-python", "fedora-44-python-updates")
+
+# Names the pin must never be able to supply.  Every one is a package where
+# Hummingbird and Fedora 44 differ by a soname or a symbol version, so pulling
+# the F44 build into the chroot would produce RPMs that do not run on the
+# target.  Sources: docs/hummingbird-desktop-gap.md Findings 1 and 3.
+FORBIDDEN = (
+    "glibc",
+    "libxml2",
+    "openssl",
+    "openssl-libs",
+    "fontconfig",
+    "glib2",
+    "systemd",
+    "gcc",
+    "rust",
+    "gtk4",
+    "qt6-qtbase",
+    "python3",
+)
+
+
+def dnf_conf() -> configparser.ConfigParser:
+    """Parse the .repo stanzas this config appends to dnf.conf."""
+    text = CONFIG.read_text()
+    blocks = re.findall(r'config_opts\[.dnf\.conf.\]\s*\+=\s*"""(.*?)"""', text, re.S)
+    assert blocks, "hummingbird-ci.cfg appends no dnf.conf repositories"
+    parser = configparser.ConfigParser()
+    parser.read_string("\n".join(blocks))
+    return parser
+
+
+@pytest.fixture(scope="module")
+def conf() -> configparser.ConfigParser:
+    return dnf_conf()
+
+
+def test_a_python_314_repository_is_pinned(conf) -> None:
+    """Without it every %pyproject_buildrequires resolves a 3.15 backend."""
+    for repo in PINNED:
+        assert conf.has_section(repo), (
+            f"{repo} is gone from mock/hummingbird-ci.cfg, so the only provider "
+            f"of python3dist(flit-core), python3dist(hatchling), "
+            f"python3dist(poetry-core) and python3dist(cython) is Rawhide's "
+            f"Python 3.15 build, which cannot install beside Hummingbird's 3.14"
+        )
+        assert conf.get(repo, "enabled") == "1", f"{repo} is disabled"
+
+
+def test_the_pin_is_confined_to_the_python_namespace(conf) -> None:
+    """includepkgs is the whole safety argument for adding an older Fedora."""
+    for repo in PINNED:
+        raw = conf.get(repo, "includepkgs", fallback="").strip()
+        assert raw, (
+            f"{repo} has no includepkgs, so an entire Fedora 44 — two releases "
+            f"of build tools behind the target — can satisfy any BuildRequires "
+            f"Hummingbird happens to miss"
+        )
+        globs = [g.strip() for g in raw.split(",") if g.strip()]
+        assert "*" not in globs, f"{repo} includepkgs is unrestricted"
+        for name in FORBIDDEN:
+            matched = [g for g in globs if fnmatch.fnmatchcase(name, g)]
+            assert not matched, (
+                f"{repo} includepkgs {matched} would let Fedora 44's {name} "
+                f"into the buildroot; Hummingbird and F44 differ there by a "
+                f"soname or symbol version (gap doc, Findings 1 and 3)"
+            )
+
+
+def test_the_pin_outranks_rawhide_but_never_hummingbird(conf) -> None:
+    """Priority order is what keeps the interpreter Hummingbird's own."""
+    hummingbird = conf.getint("hummingbird", "priority")
+    local = conf.getint("local-build", "priority")
+    for repo in PINNED:
+        pinned = conf.getint(repo, "priority")
+        assert pinned > hummingbird, (
+            f"{repo} priority {pinned} is at least as good as hummingbird's "
+            f"{hummingbird}; dnf would drop Hummingbird's python3, setuptools "
+            f"and pip in favour of Fedora 44's older builds"
+        )
+        assert pinned < RAWHIDE_PRIORITY, (
+            f"{repo} priority {pinned} does not beat Rawhide's default "
+            f"{RAWHIDE_PRIORITY}, so dnf keeps choosing the Python 3.15 "
+            f"modules that cannot be installed"
+        )
+        assert local < pinned, (
+            "packages this run already built must keep winning over Fedora 44"
+        )
+
+
+def test_the_pin_records_why_it_exists_and_when_to_drop_it() -> None:
+    """A version pin with no stated expiry outlives its reason."""
+    text = CONFIG.read_text()
+    assert "3.15" in text and "3.14" in text, (
+        "the config does not name the two Python versions it is bridging"
+    )
+    assert "Remove this pin" in text, (
+        "nothing in the config says when the Fedora 44 pin stops being correct "
+        "— it must go when Hummingbird's own python3 reaches 3.15, or it will "
+        "silently build 3.14 modules for a 3.15 target"
+    )


### PR DESCRIPTION
## What failed

Tier `niri-00`'s eight `python-*` packages have failed identically in every run since 2026-08-07 — 31231968581, 31242725235, 31248093019.

#268 named the cause correctly (Hummingbird ships no PEP 517 build backend) and added `bootstrap-00..02` to build them. Re-measuring the indexes says that is **necessary but not sufficient**, and that the bootstrap tiers cannot come up on their own.

## Root cause, re-measured 2026-08-08

Hummingbird's index (revision `1786137625`, primary sha256 `3c2eaf99…`, 16617 `(name, evr, arch)` tuples) tops out at `python3-3.14.6-2.2.hum1`. Rawhide is on `3.15.0~rc1-1.fc45`.

| | hummingbird | Rawhide (45) | Fedora 44 |
|---|---|---|---|
| python3 | 3.14.6-2.2.hum1 | 3.15.0~rc1-1.fc45 | 3.14.6-1.fc44 |

Every noarch Python module carries `Requires: python(abi) = <x.y>`, so this is not soft skew: **8919 of Rawhide's 66644 binary packages transitively need `python(abi) = 3.15`** and cannot enter this chroot at all.

Reading Rawhide's *source* index — the one `measure-hummingbird-gap.py` already uses for tier ordering — **60 build-only providers carrying `python(abi)` are needed by the 670-package graph and are in neither Hummingbird nor the build order**: `Cython`, `gi-docgen` (30 consumers), `python-docutils` (14), `python-sphinx` (12), `python-wheel` (10), `python-build` (8), `python-dbusmock` (8), `python-setuptools_scm` (7), and more. This is not specific to `niri-00`; it reaches every desktop.

The gap analysis cannot see them. `closure()` is over runtime `Requires:`; BuildRequires only *order* that set, and `tier_sources().link()` drops a requirement whose provider is not already in it:

```python
dependency = binary_to_source.get(provider)
...
if dependency and dependency in sources and dependency != source:
    edges[source].add(dependency)
```

A build backend appears in no runtime closure, so it was never a candidate.

## Why #268's bootstrap tiers do not close the gap

After #268, **five of the eight are still blocked**, and **five of #268's own thirteen are blocked too**:

| still-unsatisfiable BuildRequires | needed by |
|---|---|
| `Cython` | frozenlist, lxml, propcache |
| `python-expandvars` | frozenlist, propcache |
| `python-pytest-mock` | tzlocal, **python-build**, **python-poetry-core** |
| `python-pytest-xdist` | propcache, **python-build** |
| `python-pytest-asyncio` | aiohappyeyeballs |
| `python-blinker`, `python-jwt` | oauthlib (`%bcond extras %{undefined rhel}` → on here) |
| `python-beautifulsoup4`, `python-cssselect`, `python-html5lib`, `python-lxml-html-clean` | lxml (same bcond) |
| `python-testpath` | **python-flit-core** |
| `python-setuptools_scm` | **python-hatch-vcs**, **python-build** |
| `python-flit` | **python-wheel** |
| `filelock`, `pyproject-hooks`, `pytest-rerunfailures`, `virtualenv`, `uv` | **python-build** |
| `fastjsonschema`, `lark`, `tomli-w`, `virtualenv` | **python-poetry-core** |

Fedora's specs BuildRequire their test suites, and `--nocheck` skips `%check` without removing a single `BuildRequires`. Following only the edges Rawhide cannot satisfy because of the ABI split, the transitive closure of just the eight is **640 source packages**. That is a Python mass rebuild, not a tier.

## The fix

**638 of those 640 already exist in Fedora 44 at `python(abi) = 3.14`** — and F44's interpreter is `python3-3.14.6`, the same upstream version Hummingbird ships. (The two that do not are `python-roman-numerals` and `python-vcs-versioning`, both new in Rawhide's Sphinx chain.)

So `mock/hummingbird-ci.cfg` pins Fedora 44 for the Python namespace only:

```
priority=50
includepkgs=python3-*,flit
```

* **Below Hummingbird (10)** — the interpreter, `setuptools 83.0.0`, `pip`, `packaging` and `pytest` still come from the target. dnf's priority filter drops a package name entirely from the lower-priority repo, so F44's `setuptools 80.10.2` can never satisfy `python-propcache`'s `BuildRequires >= 82.0.1` in place of Hummingbird's 83.0.0.
* **Above Rawhide (99)** — a 3.14 module beats a 3.15 one.
* **`includepkgs` is the whole safety argument.** No F44 C library can enter the chroot, so the glibc / libxml2 / openssl soname split in the gap doc's Finding 3 is untouched, and an F44 module with a compiled extension against an old soname fails to resolve loudly rather than installing quietly. `flit` is listed by name because F44 renamed the binary; it still `Provides: python3-flit`, which `python-wheel` BuildRequires.

With the pin, **none of the eight and none of #268's thirteen bootstrap packages has a remaining unsatisfiable `python(abi)` BuildRequires.** Recorded version constraints check out too: `poetry-core >= 2` → 2.3.0, `cython >= 3.2` → 3.2.4, `flit-core >= 3.11, < 4` → 3.12.0, `blinker >= 1.4` → 1.9.0, `cssselect >= 0.7` → 1.4.0.

This complements #268 rather than replacing it. Building our own 3.14 backends is still worth doing — they land in `local-build` at priority 1 and outrank F44 thereafter — and the bootstrap tiers now have a resolvable buildroot to build in.

## What is NOT verified

**Index arithmetic, not a build.** No mock chroot was created and no RPM was rebuilt. Whether dnf5 composes the transaction the priority table predicts can only be settled by a real dispatch of the workflow. `docs/hummingbird-desktop-gap.md` Finding 6 records both the measurement and this boundary.

Also unaddressed, and measured here for whoever picks it up: the same class of failure hits later tiers through non-`python3-`-prefixed build tools that Rawhide also poisons — `gi-docgen` (30 consumers), `asciidoc` (5), `xwayland-run` (5), `go-vendor-tools` (4), `blueprint-compiler` (3), `marshalparser` (1). All six are noarch and present in F44 at `python(abi) = 3.14`; adding them to `includepkgs` is a one-line follow-up, deliberately left out of this PR to keep the pin scoped to what the eight need. `fontforge` is in the same list but compiled, so it wants a closer look.

## Tests

```
$ python3 -m pytest tests/ -q --ignore=tests/test_gate_verify_consistency.py \
    --ignore=tests/test_probe_target_dependencies.py --ignore=tests/test_tideforge.py
259 passed in 3.78s
```

255 → 259. Those three files fail to *collect* on Python 3.11 (`scripts/tideforge.py:669`, backslash inside an f-string expression, needs 3.12+) — pre-existing on `main` and unrelated; CI's pytest job runs 3.14 and collects them fine.

`tests/test_hummingbird_python_abi_pin.py` is mutation-verified six ways: repos deleted, `includepkgs` widened to `*`, `glib2` slipped into `includepkgs`, priority 5 (shadows Hummingbird), priority 99 (ties Rawhide), expiry note removed. Each mutation fails the suite; the restored config passes.

## Note on the #263 canary

The PR body for #263 asks for the `niri-00` canary to be re-dispatched to validate the `/builddir` ownership fix. **That validation is not meaningful until this lands.** #263 fixed an unreadable `root.log` that defeated a dnf5 retry guard, but the eight packages in that tier fail during dependency resolution for the ABI reason above — they would fail again with a perfectly readable `root.log`, and the canary would report red for a reason unrelated to what #263 changed. Not re-dispatched as part of this work.

## Expiry

The pin is temporary by construction. It must be removed when Hummingbird's own `python3` reaches 3.15, or it will silently build 3.14 modules for a 3.15 target. The config says so and the test asserts the note is there.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRSDAebSdGAkzqSegNn1jx)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->