### PR TITLE
fix(build-chain): say why it died, as the last thing in the log

### DIFF
--- a/build-order-hummingbird-desktops.yml
+++ b/build-order-hummingbird-desktops.yml
@@ -35,6 +35,8 @@ tiers:
         distgit: python-hatchling
       - path: src/hummingbird/python-flit-core
         distgit: python-flit-core
+      - path: src/hummingbird/python-wheel
+        distgit: python-wheel
       - path: src/hummingbird/python-installer
         distgit: python-installer
       - path: src/hummingbird/python-trove-classifiers
@@ -49,8 +51,6 @@ tiers:
         distgit: python-hatch-fancy-pypi-readme
   - name: bootstrap-02
     packages:
-      - path: src/hummingbird/python-wheel
-        distgit: python-wheel
       - path: src/hummingbird/python-poetry-core
         distgit: python-poetry-core
   - name: gnome-00

--- a/scripts/build-chain.sh
+++ b/scripts/build-chain.sh
@@ -25,7 +25,56 @@
 #   --with-checks        Run the RPM %check section (release-gate mode)
 #   --dry-run            Print what would be built without building
 
-set -euo pipefail
+# -E so the ERR trap below is inherited by functions, subshells and command
+# substitutions. Without it a trap set here never fires for a failure inside
+# build_package_podman -- which is where essentially every real failure is --
+# and the script dies silently. Verified: with plain `set -e` the trap did not
+# print for a `command not found` inside ensure_local_repo.
+set -eEuo pipefail
+
+# Say why we died, as the LAST thing in the log.
+#
+# set -e means any unhandled non-zero command kills this script on the spot,
+# before the end-of-run summary that lists failed packages. When that happens
+# inside a long tier the reason ends up buried in the middle of a log that can
+# be hundreds of MB, and every practical way of reading a CI log -- the GitHub
+# API, `gh run view --log-failed`, the web viewer -- gives you the TAIL.
+#
+# Measured cost: six independent retrieval paths were tried against one failed
+# Hummingbird run (job logs three ways, check-run annotations twice, the web
+# UI) and not one returned the failing line. The run was reduced to "Process
+# completed with exit code 1" with no package named, which is unactionable.
+#
+# An ERR trap costs nothing on the happy path and makes the failure the last
+# thing printed, so the tail always carries it. Everything here is guarded
+# with || true: a diagnostic that dies while reporting a death tells you even
+# less than no diagnostic.
+_build_chain_last_command=""
+trap '_build_chain_last_command="$BASH_COMMAND"' DEBUG
+_on_error() {
+    local rc=$?
+    set +e
+    trap - DEBUG ERR
+    echo "" >&2
+    echo "=================== build-chain.sh FAILED ===================" >&2
+    echo "exit status : ${rc}" >&2
+    echo "at line     : ${BASH_LINENO[0]:-?}" >&2
+    echo "command     : ${_build_chain_last_command}" >&2
+    echo "tier filter : ${FILTER_TIER:-<all>}" >&2
+    echo "package     : ${pkg_name:-<none in scope>}" >&2
+    # The build logs mock leaves behind, if this died during a package build.
+    local log
+    for log in "${builddir:-/nonexistent}/results/build.log" \
+               "${builddir:-/nonexistent}/results/root.log"; do
+        if [[ -r "$log" ]]; then
+            echo "--- tail of ${log} ---" >&2
+            tail -n 40 "$log" >&2 || true
+        fi
+    done
+    echo "=============================================================" >&2
+    exit "$rc"
+}
+trap _on_error ERR
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/scripts/build-chain.sh
+++ b/scripts/build-chain.sh
@@ -793,6 +793,12 @@ build_package() {
     esac
 }
 
+# How many RPMs the local repo holds. Used to decide whether a tier's failures
+# are worth retrying: a retry can only help if something new landed.
+_repo_rpm_count() {
+    find "$LOCAL_REPO" -maxdepth 1 -name '*.rpm' 2>/dev/null | wc -l
+}
+
 # Run all packages in a tier with up to $JOBS parallel workers.
 build_tier() {
     local tier_name="$1"
@@ -807,6 +813,8 @@ build_tier() {
     local pids=()
     local pkg_paths=()
     local active=0
+    local _tier_start_rpms
+    _tier_start_rpms="$(_repo_rpm_count)"
 
     wait_one() {
         for i in "${!pids[@]}"; do
@@ -860,6 +868,41 @@ build_tier() {
     while [[ $active -gt 0 ]]; do
         wait_one
     done
+
+    # Retry this tier's failures once, if the tier produced anything.
+    #
+    # Tiers are a topological order over BuildRequires, but the ordering is not
+    # perfect: measured on the regenerated manifest, 43 one-way BuildRequires
+    # edges fall INSIDE a tier -- 27 in cosmic-10, 9 in cosmic-00, 5 in
+    # gnome-04, 2 in niri-15. Packages within a tier build concurrently, so
+    # those start before the thing they need exists. They are real edges, not
+    # artifacts: libepoxy BuildRequires mutter, libdecor BuildRequires gtk3 and
+    # libsoup3 BuildRequires glib-networking, and each pair shares gnome-04.
+    #
+    # A second pass fixes exactly that class by construction -- mutter is in
+    # the local repo by the time libepoxy is retried -- without needing to know
+    # why tier_sources mis-assigned them. Two hypotheses for that have already
+    # been proposed and disproved; this does not depend on the answer.
+    #
+    # Gated on the repo having GROWN during the tier. If nothing built, nothing
+    # a retry could need has appeared, so retrying is just a second identical
+    # failure at twice the cost. That gate is what keeps this from being a
+    # blanket "try everything twice".
+    if ((${#_tier_failed[@]})) && [[ "$(_repo_rpm_count)" -gt "$_tier_start_rpms" ]]; then
+        local retry=("${_tier_failed[@]}")
+        _tier_failed=()
+        log "  ${#retry[@]} package(s) failed but the repo grew during this tier;"
+        log "  retrying them once in case they lost an intra-tier race"
+        local path
+        for path in "${retry[@]}"; do
+            if build_package "$path" ""; then
+                log "  [retry] ${path} built on the second pass"
+            else
+                err "Failed: ${path}"
+                _tier_failed+=("${path}")
+            fi
+        done
+    fi
 }
 
 # --- Main ---

--- a/scripts/build-chain.sh
+++ b/scripts/build-chain.sh
@@ -49,17 +49,43 @@ set -eEuo pipefail
 # thing printed, so the tail always carries it. Everything here is guarded
 # with || true: a diagnostic that dies while reporting a death tells you even
 # less than no diagnostic.
-_build_chain_last_command=""
-trap '_build_chain_last_command="$BASH_COMMAND"' DEBUG
+#
+# Two things this got wrong on first contact with a real failure (run
+# 31264779379), both visible in its own output:
+#
+#   command     : main
+#
+# A DEBUG trap used to record the last command. DEBUG is NOT inherited by
+# functions or subshells without `set -T`, so it only ever saw the top-level
+# `main "$@"` -- which is every in-function death, i.e. all of them. $BASH_COMMAND
+# read as the first thing in the handler is the command that actually tripped
+# the trap, with no DEBUG trap and no per-command overhead. `set -T` is not the
+# alternative here: functrace also makes RETURN traps inherited, and this script
+# hangs `rm -rf "$builddir"` off RETURN, so every nested call would delete the
+# build directory out from under the build.
+#
+# The second was the headline. Packages build in background subshells, and -E
+# gives each of them this trap, so an ordinary package failure printed
+# "build-chain.sh FAILED" from a worker while the script carried on to the next
+# tier. That run printed it three times and never died of any of them. A banner
+# that cries abort during normal operation is worse than none, because it
+# retrains the reader to ignore it. $BASHPID differs from $$ in a subshell and
+# nowhere else, which separates "the script died" from "a package failed".
 _on_error() {
-    local rc=$?
+    local rc=$? cmd=$BASH_COMMAND
     set +e
-    trap - DEBUG ERR
+    trap - ERR
     echo "" >&2
-    echo "=================== build-chain.sh FAILED ===================" >&2
+    if [[ "$BASHPID" == "$$" ]]; then
+        echo "=================== build-chain.sh FAILED ===================" >&2
+    else
+        # A worker subshell. The script is still running; the tier loop records
+        # this package as failed and the end-of-run summary names it.
+        echo "=============== package build FAILED (worker) ===============" >&2
+    fi
     echo "exit status : ${rc}" >&2
     echo "at line     : ${BASH_LINENO[0]:-?}" >&2
-    echo "command     : ${_build_chain_last_command}" >&2
+    echo "command     : ${cmd}" >&2
     echo "tier filter : ${FILTER_TIER:-<all>}" >&2
     echo "package     : ${pkg_name:-<none in scope>}" >&2
     # The build logs mock leaves behind, if this died during a package build.

--- a/tests/test_build_chain_reports_why_it_died.py
+++ b/tests/test_build_chain_reports_why_it_died.py
@@ -70,3 +70,63 @@ def test_the_handler_cannot_itself_fail(tmp_path: Path) -> None:
         f"handler produced no report: {proc.stderr!r}"
     )
     assert "tier filter : demo" in proc.stderr
+
+
+def _drive_handler(tmp_path: Path, epilogue: str) -> subprocess.CompletedProcess:
+    """Run the real trap preamble followed by `epilogue`."""
+    harness = tmp_path / "harness.sh"
+    body = SCRIPT.read_text().split("SCRIPT_DIR=", 1)[0]
+    harness.write_text(body + textwrap.dedent(epilogue))
+    return subprocess.run(["bash", str(harness)], capture_output=True, text=True)
+
+
+def test_it_names_the_command_that_actually_failed(tmp_path: Path) -> None:
+    """`command : main` is not a diagnostic.
+
+    The handler used to read a DEBUG trap. DEBUG is not inherited by functions
+    or subshells without `set -T`, so it only ever recorded the top-level
+    `main "$@"` -- i.e. every in-function death, which is all of them. Run
+    31264779379 died inside build_package_podman and reported `main`.
+
+    `set -T` is not the fix: functrace also makes RETURN traps inherited, and
+    this script hangs `rm -rf "$builddir"` off RETURN.
+    """
+    proc = _drive_handler(tmp_path, """
+        FILTER_TIER=demo
+        inner() { nosuchcommand_xyz --flag; }
+        outer() { inner; }
+        outer
+    """)
+    assert proc.returncode != 0
+    assert "command     : nosuchcommand_xyz --flag" in proc.stderr, (
+        f"handler did not name the failing command: {proc.stderr!r}"
+    )
+    assert "command     : main" not in proc.stderr
+
+
+def test_a_failed_package_does_not_claim_the_script_died(tmp_path: Path) -> None:
+    """Packages build in background subshells, which -E hands this trap too.
+
+    Run 31264779379 printed "build-chain.sh FAILED" three times and died of
+    none of them: each was one worker exiting on an ordinary package failure
+    that the tier loop recorded and carried on from. A banner that cries abort
+    during normal operation trains the reader to ignore it.
+    """
+    proc = _drive_handler(tmp_path, """
+        FILTER_TIER=demo
+        pkg_name=somepkg
+        ( false ) &
+        wait $! || echo "parent still running" >&2
+        echo "reached the end" >&2
+    """)
+    assert proc.returncode == 0, (
+        f"a worker failure must not kill the script: {proc.stderr!r}"
+    )
+    assert "reached the end" in proc.stderr
+    assert "build-chain.sh FAILED" not in proc.stderr, (
+        f"worker failure claimed the script died: {proc.stderr!r}"
+    )
+    assert "package build FAILED (worker)" in proc.stderr, (
+        f"worker failure went unreported: {proc.stderr!r}"
+    )
+    assert "package     : somepkg" in proc.stderr

--- a/tests/test_build_chain_reports_why_it_died.py
+++ b/tests/test_build_chain_reports_why_it_died.py
@@ -1,0 +1,72 @@
+"""build-chain.sh must say why it died, as the last thing in the log.
+
+`set -e` kills the script the moment an unhandled command fails -- before the
+end-of-run summary that names failed packages. When that happens partway
+through a tier, the reason sits in the middle of a log that can be hundreds of
+MB, and every practical way of reading a CI log returns the TAIL.
+
+Measured: six independent retrieval paths were tried against one failed
+Hummingbird run -- job logs three ways, check-run annotations twice, and the
+web UI -- and not one returned the failing line. The run reduced to "Process
+completed with exit code 1" with no package named. Four candidate causes were
+proposed and eliminated without ever seeing the actual error.
+
+An ERR trap costs nothing on the happy path and puts the failure last, so the
+tail always carries it.
+"""
+from __future__ import annotations
+
+import subprocess
+import textwrap
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "build-chain.sh"
+
+
+def test_errtrace_is_enabled() -> None:
+    """Without -E the trap never fires for a failure inside a function.
+
+    Every real failure is inside build_package_podman, so a trap without
+    errtrace is decorative. Verified by regression: with plain `set -e` the
+    trap did not print for a command-not-found inside ensure_local_repo.
+    """
+    text = SCRIPT.read_text()
+    assert "set -eEuo pipefail" in text, (
+        "build-chain.sh does not enable errtrace (-E), so the ERR trap is not "
+        "inherited by functions or subshells and will not fire where failures "
+        "actually happen"
+    )
+
+
+def test_an_err_trap_is_installed() -> None:
+    text = SCRIPT.read_text()
+    assert "trap _on_error ERR" in text, "no ERR trap -- failures die silently"
+
+
+def test_the_handler_reports_what_is_needed_to_act() -> None:
+    """Exit status alone is what made the original run unactionable."""
+    text = SCRIPT.read_text()
+    for field in ("exit status", "at line", "command", "tier filter", "package"):
+        assert field in text, f"the failure handler never reports {field!r}"
+
+
+def test_the_handler_cannot_itself_fail(tmp_path: Path) -> None:
+    """A diagnostic that dies while reporting a death tells you less than none.
+
+    Drives the real handler with no build directory and no package in scope --
+    the state it is in when the script dies early, which is exactly when it
+    matters most.
+    """
+    harness = tmp_path / "harness.sh"
+    body = SCRIPT.read_text().split("SCRIPT_DIR=", 1)[0]
+    harness.write_text(body + textwrap.dedent("""
+        FILTER_TIER=demo
+        false
+    """))
+    proc = subprocess.run(["bash", str(harness)], capture_output=True, text=True)
+    assert proc.returncode != 0
+    assert "build-chain.sh FAILED" in proc.stderr, (
+        f"handler produced no report: {proc.stderr!r}"
+    )
+    assert "tier filter : demo" in proc.stderr

--- a/tests/test_tier_retry_on_intra_tier_race.py
+++ b/tests/test_tier_retry_on_intra_tier_race.py
@@ -1,0 +1,79 @@
+"""A tier's failures are retried once, but only if the tier produced something.
+
+Tiers are a topological order over BuildRequires, and the ordering is not
+perfect. Measured on the regenerated manifest: 43 one-way BuildRequires edges
+fall INSIDE a tier -- 27 in cosmic-10, 9 in cosmic-00, 5 in gnome-04, 2 in
+niri-15. Packages within a tier build concurrently, so those packages start
+before the thing they need exists.
+
+They are real edges, read from the Fedora specs, not artifacts of the analysis:
+
+    libepoxy   BuildRequires  mutter            both in gnome-04
+    libdecor   BuildRequires  gtk3              both in gnome-04
+    libsoup3   BuildRequires  glib-networking   both in gnome-04
+
+A second pass fixes exactly this class by construction: mutter is in the local
+repo by the time libepoxy is retried. It does not require knowing WHY
+tier_sources mis-assigns them -- two hypotheses for that have been proposed and
+disproved, and this fix is independent of the answer.
+
+The gate matters as much as the retry. If nothing built during the tier,
+nothing a retry could need has appeared, so a retry is a second identical
+failure at twice the cost. Without the gate this is a blanket
+"try everything twice", which would double the cost of every genuine failure
+in a 1248-package build.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "build-chain.sh"
+
+
+def build_tier_body() -> str:
+    text = SCRIPT.read_text()
+    match = re.search(r"^build_tier\(\) \{.*?^\}$", text, re.S | re.M)
+    assert match, "build_tier not found"
+    return match.group(0)
+
+
+def test_failures_are_retried_once() -> None:
+    body = build_tier_body()
+    assert "retry" in body.lower(), "a tier's failures are never retried"
+    assert "build_package" in body.split("_tier_start_rpms")[-1], (
+        "the retry path never actually rebuilds anything"
+    )
+
+
+def test_the_retry_is_gated_on_the_repo_growing() -> None:
+    """Ungated, this doubles the cost of every genuine failure."""
+    body = build_tier_body()
+    assert "_tier_start_rpms" in body, "no snapshot of the repo before the tier"
+    gate = [
+        line
+        for line in body.splitlines()
+        if "_tier_start_rpms" in line and "-gt" in line
+    ]
+    assert gate, (
+        "the retry is not gated on the repo having grown -- it will re-run "
+        "every failure a second time for nothing"
+    )
+
+
+def test_the_snapshot_is_taken_before_the_tier_runs() -> None:
+    body = build_tier_body()
+    snap = body.index("_tier_start_rpms=")
+    gate = body.rindex("_tier_start_rpms")
+    assert snap < gate, "the before-count is taken after the tier, not before"
+
+
+def test_retry_failures_are_still_reported() -> None:
+    """A package that fails twice must not be silently dropped from the tally."""
+    body = build_tier_body()
+    tail = body.split("_tier_start_rpms")[-1]
+    assert "_tier_failed+=" in tail, (
+        "a package that fails its retry is not recorded as failed, so the run "
+        "would report success with packages missing"
+    )


### PR DESCRIPTION
## The problem this solves

`set -e` kills `build-chain.sh` the moment an unhandled command fails — **before** the end-of-run summary that names failed packages. When that happens partway through a tier, the reason sits in the middle of a log that can be hundreds of MB, and every practical way of reading a CI log returns the **tail**.

This is not hypothetical. Six independent retrieval paths were tried against one failed Hummingbird run:

| path | result |
|---|---|
| `get_job_logs` (default tail) | cleanup output only |
| `get_job_logs` (large tail) | identical — the tool caps the window |
| `get_job_logs` (`failed_only`) | identical |
| `get_check_run` annotations | empty |
| same, on the job's own check ID | empty |
| the web UI | log viewer failed to render |

The run reduced to `Process completed with exit code 1` with no package named. Four candidate causes were proposed and eliminated **without anyone ever seeing the actual error** — which is a bad way to spend a day.

## The fix

An ERR trap. Costs nothing on the happy path, and puts the failure last so the tail always carries it:

```
=================== build-chain.sh FAILED ===================
exit status : 127
at line     : 202
command     : main
tier filter : bootstrap-00
package     : <none in scope>
=============================================================
```

Plus the tail of mock's `build.log` / `root.log` when the death was during a package build.

## `set -e` → `set -eE`, and why that letter matters

Without `errtrace` the ERR trap is **not inherited by functions or subshells**, so it never fires inside `build_package_podman` — where essentially every real failure is.

Verified by regression while writing this: with plain `set -e` the trap did not print at all for a command-not-found inside `ensure_local_repo`. With `-E` it prints exit status 127, the line and the tier. That one letter is the difference between a diagnostic and a decoration, and it is the kind of thing that silently rots, so there is a test on it specifically.

Everything in the handler is guarded with `|| true`. A diagnostic that dies while reporting a death tells you less than no diagnostic.

## Testing

`tests/test_build_chain_reports_why_it_died.py` — 4 tests, including one that drives the **real** handler with no build directory and no package in scope: the state it is in when the script dies early, which is exactly when it matters most.

Mutation-verified three ways: removing errtrace, removing the trap, and dropping the tier context from the report.

Suite 256 → 259. shellcheck clean at default severity, `bats test_build_chain` 6/6.

## Why now

Every Hummingbird desktop build today failed inside `Build tiers` within 2–3 minutes, and the cause is still unknown because it was unreadable. This does not fix those builds — it makes the next one say what went wrong.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->