### PR TITLE
fix(hummingbird): select a desktop's tiers by content, not by tier name

### DIFF
--- a/.github/workflows/build-hummingbird-desktops.yml
+++ b/.github/workflows/build-hummingbird-desktops.yml
@@ -18,14 +18,22 @@ on:
   workflow_dispatch:
     inputs:
       desktop:
-        description: Desktop whose tiers to build (prefix of the tier name)
+        description: Desktop to build (resolved to tiers via the gap report)
         type: choice
         options: [gnome, kde, cosmic, niri, xfce, all]
         default: gnome
       tiers:
         description: >
           Comma-separated tier names to build, e.g. "gnome-00,gnome-01".
-          Empty means every tier matching `desktop`.
+          Taken verbatim -- no bootstrap tiers are prepended, so a single
+          tier can be re-run on its own. Empty means resolve `desktop`.
+        type: string
+        default: ""
+      exclude_tiers:
+        description: >
+          Comma-separated tiers to drop from the selection. Lets a shared
+          trunk be built once and the per-desktop remainders run in parallel
+          against it.
         type: string
         default: ""
       publish:
@@ -83,53 +91,26 @@ jobs:
 
       - name: Select tiers
         id: tiers
+        env:
+          # Through the environment, not `${{ }}` inside the script: these are
+          # dispatch inputs and they are not shell.
+          IN_DESKTOP: ${{ inputs.desktop }}
+          IN_TIERS: ${{ inputs.tiers }}
+          IN_EXCLUDE: ${{ inputs.exclude_tiers }}
         run: |
-          python3 - <<'PY' >> "$GITHUB_OUTPUT"
-          import os, yaml
-          manifest = yaml.safe_load(open(os.environ["MANIFEST"]))
-          requested = [t.strip() for t in "${{ inputs.tiers }}".split(",") if t.strip()]
-          desktop = "${{ inputs.desktop }}"
-          names = [t["name"] for t in manifest["tiers"]]
-          if requested:
-              missing = [t for t in requested if t not in names]
-              if missing:
-                  raise SystemExit(f"no such tier(s): {missing}")
-              selected = requested
-          elif desktop == "all":
-              selected = names
-          else:
-              selected = [n for n in names if n.startswith(desktop + "-")]
-          if not selected:
-              raise SystemExit(f"no tiers match desktop={desktop}")
-          # The Python build backends come first, always, whatever was asked
-          # for. Hummingbird ships pyproject-rpm-macros, python3-devel,
-          # setuptools, packaging, pytest, pathspec and pluggy -- but NOT ONE
-          # PEP-517 backend: no hatchling, flit-core, poetry-core, wheel,
-          # installer, build, editables or trove-classifiers (measured against
-          # the target's own primary.xml, 3384 distinct names).
-          #
-          # So %pyproject_buildrequires emits e.g. python3-hatchling, dnf finds
-          # it only in Rawhide, and Rawhide's build is for Python 3.15 while
-          # Hummingbird is on 3.14 (docs/hummingbird-desktop-gap.md, Finding 3:
-          # "different libpython3.x.so.1.0"). The 3.15 backend then demands
-          # python3.15dist(packaging), the installed packaging provides
-          # python3.14dist(...), and the transaction is unresolvable:
-          #
-          #   cannot install both python3-packaging-26.2-4.fc45.noarch from
-          #   fedora and python3-packaging-26.2-4.1.hum1.noarch from @System
-          #
-          # That is what failed all 8 python-* packages of niri-00 in runs
-          # 31231968581, 31242725235 and 31248093019 -- identically each time,
-          # and it is not specific to those 8. Every Python package in the
-          # 670-package gap builds through a PEP-517 backend.
-          #
-          # Skipped when explicitly requested, so a bootstrap tier can still be
-          # re-run on its own.
-          boot = [n for n in names if n.startswith("bootstrap-")]
-          if not requested:
-              selected = boot + [n for n in selected if n not in boot]
-          print("list=" + ",".join(selected))
-          PY
+          # Not a name-prefix match. The manifest deduplicates packages across
+          # desktops, so a tier named gnome-* holds packages XFCE needs too and
+          # `xfce-*` covers a fraction of XFCE. select-desktop-tiers.py resolves
+          # the desktop through the gap report's own package list, and fails if
+          # anything it needs is in no tier -- see the module docstring.
+          list=$(python3 scripts/select-desktop-tiers.py \
+            --manifest "${MANIFEST}" \
+            --gap-report docs/hummingbird-desktop-gap.json \
+            --desktop "${IN_DESKTOP}" \
+            --tiers "${IN_TIERS}" \
+            --exclude-tiers "${IN_EXCLUDE}")
+          echo "selected $(tr ',' '\n' <<< "$list" | wc -l) tiers: $list"
+          echo "list=$list" >> "$GITHUB_OUTPUT"
 
       - name: Import Fedora Rawhide packaging for the selected tiers
         run: |

--- a/scripts/select-desktop-tiers.py
+++ b/scripts/select-desktop-tiers.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Resolve a desktop name to the tiers that actually build it.
+
+`build-order-hummingbird-desktops.yml` groups packages into tiers named after
+the desktop that *introduced* them, not after every desktop that needs them.
+A package shared by GNOME and XFCE lands in a `gnome-*` tier and appears
+nowhere else, because the manifest deduplicates across desktops.
+
+So selecting tiers by name prefix builds a small fraction of a desktop and
+reports success.  Measured against the 78-tier manifest:
+
+    desktop   tiers named <desktop>-*   tiers actually needed
+    xfce                            9                     28
+    cosmic                          9                     21
+    kde                            19                     31
+    niri                           14                     42
+
+XFCE needs 248 source packages; nine of them are in `xfce-*` tiers.  A run of
+`desktop: xfce` builds those nine and the other 239 are silently skipped --
+which is not a build failure, it is a build that never attempts the work.
+
+This resolves the other direction: take the desktop's `source_packages_to_build`
+from the gap report and select every tier holding at least one of them.  If any
+needed package lives in no tier at all, that is an error rather than a shorter
+list, because a short list is indistinguishable from a correct one at the point
+where it matters.
+"""
+
+import argparse
+import json
+import sys
+
+import yaml
+
+BOOTSTRAP_PREFIX = "bootstrap-"
+
+
+def tier_packages(tier):
+    """Source-package names in a tier.
+
+    `distgit:` names the Fedora package to import; entries with a reviewed
+    spec directory in this repository carry no `distgit:` and are named by
+    the last component of their path.
+    """
+    names = set()
+    for pkg in tier["packages"]:
+        names.add(pkg.get("distgit") or pkg["path"].rsplit("/", 1)[-1])
+    return names
+
+
+def select(manifest, report, desktop, requested=None, exclude=()):
+    tiers = manifest["tiers"]
+    names = [t["name"] for t in tiers]
+    contents = {t["name"]: tier_packages(t) for t in tiers}
+    bootstrap = [n for n in names if n.startswith(BOOTSTRAP_PREFIX)]
+
+    if requested:
+        missing = [t for t in requested if t not in names]
+        if missing:
+            raise SystemExit(f"no such tier(s): {missing}")
+        # An explicit list is taken verbatim: it is how a single tier gets
+        # re-run on its own, including a bootstrap tier.
+        selected = list(requested)
+    elif desktop == "all":
+        selected = list(names)
+    else:
+        if desktop not in report["desktops"]:
+            raise SystemExit(
+                f"desktop {desktop!r} not in gap report; have: "
+                + ", ".join(sorted(report["desktops"]))
+            )
+        need = set(report["desktops"][desktop]["source_packages_to_build"])
+        selected = bootstrap + [
+            n for n in names
+            if not n.startswith(BOOTSTRAP_PREFIX) and (contents[n] & need)
+        ]
+        covered = set().union(*(contents[n] for n in selected)) if selected else set()
+        unplaced = need - covered
+        if unplaced:
+            raise SystemExit(
+                f"{len(unplaced)} package(s) {desktop} needs are in no tier of "
+                f"the manifest: {', '.join(sorted(unplaced)[:20])}"
+                + (" ..." if len(unplaced) > 20 else "")
+            )
+
+    if exclude:
+        selected = [n for n in selected if n not in set(exclude)]
+    if not selected:
+        raise SystemExit(f"no tiers selected for desktop={desktop}")
+    # Order follows the manifest, which is the build order. Selecting a subset
+    # must not reorder it.
+    return selected
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--manifest", required=True)
+    ap.add_argument("--gap-report", required=True)
+    ap.add_argument("--desktop", default="gnome")
+    ap.add_argument(
+        "--tiers", default="",
+        help="comma-separated tier names; overrides --desktop when non-empty",
+    )
+    ap.add_argument(
+        "--exclude-tiers", default="",
+        help="comma-separated tiers to drop from the result, for splitting a "
+             "shared trunk out of a per-desktop run",
+    )
+    args = ap.parse_args(argv)
+
+    manifest = yaml.safe_load(open(args.manifest))
+    report = json.load(open(args.gap_report))
+    requested = [t.strip() for t in args.tiers.split(",") if t.strip()]
+    exclude = [t.strip() for t in args.exclude_tiers.split(",") if t.strip()]
+    print(",".join(select(manifest, report, args.desktop, requested, exclude)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_hummingbird_python_bootstrap.py
+++ b/tests/test_hummingbird_python_bootstrap.py
@@ -143,19 +143,38 @@ def test_hatchling_follows_its_own_runtime_deps() -> None:
 def test_the_workflow_runs_the_bootstrap_tiers_first() -> None:
     """Selecting `desktop: gnome` must still get the backends.
 
-    The tier filter is a name prefix, so bootstrap-* matches no desktop and
-    would otherwise be skipped by every ordinary dispatch.
+    bootstrap-* is named after no desktop, so any selection that goes by tier
+    name skips it and every Python package in the run then builds against a
+    backend that is not there.
+
+    Asserted against the selection itself rather than against the text of the
+    workflow step: the step used to hold the logic inline and now shells out to
+    scripts/select-desktop-tiers.py, and the property is true of the answer
+    either way.
     """
-    select = next(
-        s
-        for s in yaml.safe_load(WORKFLOW.read_text())["jobs"]["build"]["steps"]
-        if s.get("name") == "Select tiers"
-    )["run"]
-    assert 'startswith("bootstrap-")' in select, (
-        "the Select tiers step does not single out the bootstrap tiers, so "
-        "`desktop: gnome` selects only gnome-* and builds no backends"
+    import importlib.util
+    import json
+
+    spec = importlib.util.spec_from_file_location(
+        "sdt", ROOT / "scripts" / "select-desktop-tiers.py"
     )
-    assert "boot + [" in select, "bootstrap tiers are not prepended to the selection"
+    sdt = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(sdt)
+
+    manifest = yaml.safe_load(MANIFEST.read_text())
+    report = json.loads((ROOT / "docs" / "hummingbird-desktop-gap.json").read_text())
+    boot = [t["name"] for t in manifest["tiers"] if t["name"].startswith("bootstrap-")]
+    assert boot, "the manifest has no bootstrap tiers to order first"
+
+    for desktop in report["desktops"]:
+        selected = sdt.select(manifest, report, desktop)
+        assert selected[: len(boot)] == boot, (
+            f"desktop={desktop} does not start with the bootstrap tiers, so the "
+            "PEP-517 backends are missing when its Python packages build"
+        )
+
+    # And an explicit tier list still bypasses them, so one tier can be re-run.
+    assert sdt.select(manifest, report, "gnome", requested=[boot[0]]) == [boot[0]]
 
 
 def test_build_gets_pyproject_hooks_before_it_needs_it() -> None:

--- a/tests/test_select_desktop_tiers.py
+++ b/tests/test_select_desktop_tiers.py
@@ -1,0 +1,158 @@
+"""The tier selection has to find the tiers a desktop needs, not the tiers
+named after it.
+
+The regression these pin is quiet by construction: selecting `xfce-*` for XFCE
+returns a non-empty list, builds it, and succeeds, having attempted 9 of the
+248 source packages XFCE needs. Nothing in the run says so. So the tests here
+care less about the happy path than about the two ways the answer can be wrong
+without looking wrong -- a short list, and a list that silently drops packages
+the manifest never placed.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "select-desktop-tiers.py"
+MANIFEST = REPO / "build-order-hummingbird-desktops.yml"
+GAP = REPO / "docs" / "hummingbird-desktop-gap.json"
+
+sys.path.insert(0, str(REPO / "scripts"))
+
+
+def _select(**kw):
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("sdt", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+MOD = _select()
+
+
+def tiers(names_to_packages):
+    return {
+        "tiers": [
+            {"name": n, "packages": [{"path": f"src/x/{p}", "distgit": p} for p in ps]}
+            for n, ps in names_to_packages
+        ]
+    }
+
+
+def report(**desktops):
+    return {"desktops": {d: {"source_packages_to_build": ps} for d, ps in desktops.items()}}
+
+
+def test_picks_tiers_by_content_not_by_name():
+    m = tiers([
+        ("bootstrap-00", ["flit"]),
+        ("gnome-00", ["glib", "gtk"]),
+        ("xfce-00", ["xfwm"]),
+    ])
+    r = report(xfce=["glib", "xfwm"])
+    # glib lives in a gnome-* tier and XFCE needs it.
+    assert MOD.select(m, r, "xfce") == ["bootstrap-00", "gnome-00", "xfce-00"]
+
+
+def test_name_prefix_alone_would_have_missed_most_of_it():
+    """The specific shape of the bug, stated as a test rather than a comment."""
+    m = tiers([
+        ("gnome-00", ["a", "b", "c"]),
+        ("xfce-00", ["d"]),
+    ])
+    r = report(xfce=["a", "b", "c", "d"])
+    selected = MOD.select(m, r, "xfce")
+    by_name = [n for n in ("gnome-00", "xfce-00") if n.startswith("xfce-")]
+    assert selected == ["gnome-00", "xfce-00"]
+    assert by_name == ["xfce-00"]  # what the old selection returned
+
+
+def test_unplaced_package_is_an_error_not_a_shorter_list():
+    m = tiers([("gnome-00", ["glib"])])
+    r = report(xfce=["glib", "never-packaged"])
+    with pytest.raises(SystemExit) as e:
+        MOD.select(m, r, "xfce")
+    assert "never-packaged" in str(e.value)
+
+
+def test_explicit_tiers_are_verbatim_including_bootstrap():
+    m = tiers([("bootstrap-00", ["flit"]), ("gnome-00", ["glib"])])
+    r = report(gnome=["glib"])
+    assert MOD.select(m, r, "gnome", requested=["gnome-00"]) == ["gnome-00"]
+
+
+def test_unknown_explicit_tier_is_rejected():
+    m = tiers([("gnome-00", ["glib"])])
+    with pytest.raises(SystemExit):
+        MOD.select(m, report(gnome=["glib"]), "gnome", requested=["gnome-99"])
+
+
+def test_selection_keeps_manifest_order():
+    """Manifest order *is* build order. Tier names sort in an order that has
+    nothing to do with it -- cosmic-00 depends on gnome-00 and sorts before
+    it -- so anything that normalises the list breaks the builds downstream
+    of it rather than the selection itself."""
+    m = tiers([
+        ("bootstrap-00", ["flit"]),
+        ("gnome-00", ["a"]),
+        ("cosmic-00", ["b"]),
+        ("niri-00", ["c"]),
+        ("kde-00", ["d"]),
+    ])
+    r = report(kde=["d", "a", "b", "c"])
+    got = MOD.select(m, r, "kde")
+    assert got == ["bootstrap-00", "gnome-00", "cosmic-00", "niri-00", "kde-00"]
+    assert got != sorted(got)
+
+
+def test_exclude_splits_a_shared_trunk_off():
+    m = tiers([
+        ("bootstrap-00", ["flit"]),
+        ("gnome-00", ["a"]),
+        ("kde-00", ["c"]),
+    ])
+    r = report(kde=["a", "c"])
+    full = MOD.select(m, r, "kde")
+    rest = MOD.select(m, r, "kde", exclude=["bootstrap-00", "gnome-00"])
+    assert full == ["bootstrap-00", "gnome-00", "kde-00"]
+    assert rest == ["kde-00"]
+
+
+def test_packages_without_distgit_are_named_by_path():
+    m = {"tiers": [{"name": "gnome-00", "packages": [{"path": "src/deps/libebur128"}]}]}
+    r = report(gnome=["libebur128"])
+    assert MOD.select(m, r, "gnome") == ["gnome-00"]
+
+
+def test_every_desktop_in_the_real_manifest_resolves_completely():
+    """No package any desktop needs may be absent from the manifest."""
+    m = yaml.safe_load(MANIFEST.read_text())
+    r = json.loads(GAP.read_text())
+    contents = {t["name"]: MOD.tier_packages(t) for t in m["tiers"]}
+    for desktop in r["desktops"]:
+        selected = MOD.select(m, r, desktop)  # raises if anything is unplaced
+        covered = set().union(*(contents[n] for n in selected))
+        need = set(r["desktops"][desktop]["source_packages_to_build"])
+        assert need <= covered, desktop
+        named = [n for n in selected if n.startswith(desktop + "-")]
+        assert len(selected) > len(named), (
+            f"{desktop} resolved to only its own tiers -- either the manifest "
+            "stopped deduplicating or the selection regressed to a prefix match"
+        )
+
+
+def test_cli_prints_a_comma_separated_list():
+    out = subprocess.run(
+        [sys.executable, str(SCRIPT), "--manifest", str(MANIFEST),
+         "--gap-report", str(GAP), "--desktop", "xfce"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert out.startswith("bootstrap-00,")
+    assert "," in out and " " not in out


### PR DESCRIPTION
## The bug

`desktop: xfce` selected the tiers *named* `xfce-*`. The manifest deduplicates packages across desktops, so a package XFCE and GNOME both need lives in a `gnome-*` tier and appears nowhere else.

| desktop | tiers named `<desktop>-*` | tiers actually needed |
|---|---|---|
| xfce | 9 | 28 |
| cosmic | 9 | 21 |
| kde | 19 | 31 |
| niri | 14 | 42 |

XFCE needs **248** source packages. Nine of them are in `xfce-*` tiers.

So a `desktop: xfce` run built nine, skipped 239, and **exited 0**. Nothing in the log distinguishes that from having built XFCE. A wrong answer that fails is cheap; this one succeeded.

## The change

`scripts/select-desktop-tiers.py` goes the other way round: take the desktop's `source_packages_to_build` straight from the gap report, select every tier holding at least one of them, in manifest order, bootstrap tiers first.

If a package a desktop needs is in **no** tier, that is an error rather than a shorter list — a short list is indistinguishable from a correct one at exactly the moment it matters.

`--exclude-tiers` is the throughput half. GNOME's 14 tiers are a subset of all four other desktops' selections, so the shared trunk can be built and published once and the four remainders run in parallel against it:

| run | tiers | packages |
|---|---|---|
| trunk (= GNOME complete) | 14 | 308 |
| then xfce | 15 | 294 |
| then cosmic | 10 | 291 |
| then kde | 19 | 233 |
| then niri | 29 | 695 |

Serialised that is 3010 package-builds; as trunk-then-parallel it is 308 + max(695) ≈ 1000.

Dispatch inputs move into the environment instead of being interpolated into the shell.

## Testing

`tests/test_select_desktop_tiers.py` — 9 unit tests + 1 CLI test. Mutation-verified three ways:

- regress to a prefix match → 6 fail
- drop the unplaced-package error → 1 fail
- sort the result instead of keeping manifest order → 1 fail

That last one needed a stronger fixture than the first draft: tier names sort in an order unrelated to build order (`cosmic-00` sorts before `gnome-00`, and depends on it), so the original fixture passed under `sorted()` by coincidence.

`test_the_workflow_runs_the_bootstrap_tiers_first` asserted on the *text* of the inline step this replaces. It now asserts the property of the selection, for every desktop in the gap report, which is what it was trying to say.

Suite 269 → 275.

## Note on scope

This does not build anything. It makes `desktop: <name>` mean what it reads as, and makes the trunk/parallel split expressible.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->