### PR TITLE
fix(hummingbird): build python-pyproject-hooks, which nothing shipped

### DIFF
--- a/build-order-hummingbird-desktops.yml
+++ b/build-order-hummingbird-desktops.yml
@@ -41,12 +41,14 @@ tiers:
         distgit: python-editables
       - path: src/hummingbird/python-installer
         distgit: python-installer
-      - path: src/hummingbird/python-build
-        distgit: python-build
+      - path: src/hummingbird/python-pyproject-hooks
+        distgit: python-pyproject-hooks
       - path: src/hummingbird/python-wheel
         distgit: python-wheel
   - name: bootstrap-02
     packages:
+      - path: src/hummingbird/python-build
+        distgit: python-build
       - path: src/hummingbird/python-hatchling
         distgit: python-hatchling
   - name: bootstrap-03

--- a/tests/test_hummingbird_python_bootstrap.py
+++ b/tests/test_hummingbird_python_bootstrap.py
@@ -156,3 +156,37 @@ def test_the_workflow_runs_the_bootstrap_tiers_first() -> None:
         "`desktop: gnome` selects only gnome-* and builds no backends"
     )
     assert "boot + [" in select, "bootstrap tiers are not prepended to the selection"
+
+
+def test_build_gets_pyproject_hooks_before_it_needs_it() -> None:
+    """`build` requires pyproject_hooks at runtime, and nothing shipped it.
+
+    Measured, not inferred -- run 31265856203, bootstrap-01, after flit-core
+    had already built and been picked up:
+
+        Handling flit-core >= 3.11 from build-system.requires
+        Requirement satisfied: flit-core>=3.11
+           (installed: flit-core 3.12.0)
+        Handling pyproject_hooks from hook generated metadata: Requires-Dist (build)
+        Requirement not satisfied: pyproject_hooks
+
+    It is a plain Requires-Dist, so no bcond and no --nocheck reaches it: the
+    only fix is to build it. docs/hummingbird-desktop-gap.md lists it among
+    what `python-build` pulls, and the manifest then did not contain it --
+    which is the gap the report exists to close, left open in the one tier
+    every other tier waits on.
+    """
+    order = [t["name"] for t in tiers()]
+    by_name = {t["name"]: names_in(t) for t in tiers()}
+
+    def tier_of(pkg: str) -> int:
+        return next(i for i, n in enumerate(order) if pkg in by_name[n])
+
+    assert any("python-pyproject-hooks" in by_name[n] for n in order), (
+        "python-pyproject-hooks is in no tier, so python-build cannot resolve "
+        "its BuildRequires however the tiers are ordered"
+    )
+    assert tier_of("python-build") > tier_of("python-pyproject-hooks"), (
+        "python-build must build in a later tier than python-pyproject-hooks; "
+        "packages inside a tier run concurrently, so sharing one is a race"
+    )


### PR DESCRIPTION
## What failed

`python-build`, in bootstrap-01 of [run 31265856203](https://github.com/tuna-os/tunaos-packages/actions/runs/31265856203). Not a tier-ordering problem this time — `flit-core` had already built and was picked up:

```
Handling flit-core >= 3.11 from build-system.requires
Requirement satisfied: flit-core>=3.11
   (installed: flit-core 3.12.0)
Handling pyproject_hooks from hook generated metadata: Requires-Dist (build)
Requirement not satisfied: pyproject_hooks
```

`pyproject_hooks` is a plain `Requires-Dist` of `build`. No bcond guards it and `--nocheck` does not reach it, so the only way to satisfy it is to build it — and it was in **no tier of the manifest at all**.

`docs/hummingbird-desktop-gap.md` already names it, in the list of what `python-build` pulls. It was written down and not packaged, in the one tier every other tier in the file waits on.

## The change

| tier | before | after |
|---|---|---|
| bootstrap-01 | editables, installer, **build**, wheel | editables, installer, **pyproject-hooks**, wheel |
| bootstrap-02 | hatchling | **build**, hatchling |

`pyproject-hooks`'s backend is `flit_core`, already built in bootstrap-00. `build` moves down a tier because packages inside a tier run concurrently — sharing one with your dependency is a race, not an ordering.

## What this does not fix

The same log shows `%pyproject_buildrequires` invoked as `-g test -x virtualenv,uv`, emitting `pytest`, `pytest-mock`, `pytest-rerunfailures`, `pytest-xdist`, `filelock`, `setuptools_scm`, `virtualenv` and `uv` — and `python3-uv` is uninstallable:

```
Problem: package python3-uv-0.11.32-1.fc44.noarch from fedora-44-python-updates
  requires uv = 0.11.32-1.fc44, but none of the providers can be installed
```

Those are the test group and the optional extras. #271's bcond change is what turns them off. **Both are needed and neither subsumes the other** — this one would still fail on the extras, and #271 alone would still fail on `pyproject_hooks`.

## Progress on the same run, for the record

`bootstrap-00` built **3/3**. The Fedora 44 pin from #272 did resolve the 3.14/3.15 ABI split that had been failing every attempt before it — the repo went 1135 → 1140 packages. bootstrap-01 then built 3 of 4.

## Testing

Mutation-verified two ways: dropping `pyproject-hooks` from the manifest, and putting `build` back in the same tier as it. Both fail the new test.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->