### PR TITLE
fix(hummingbird): drop python-build; it is a frontend and nothing needs it

### DIFF
--- a/build-order-hummingbird-desktops.yml
+++ b/build-order-hummingbird-desktops.yml
@@ -47,8 +47,6 @@ tiers:
         distgit: python-wheel
   - name: bootstrap-02
     packages:
-      - path: src/hummingbird/python-build
-        distgit: python-build
       - path: src/hummingbird/python-hatchling
         distgit: python-hatchling
   - name: bootstrap-03

--- a/tests/test_hummingbird_python_bootstrap.py
+++ b/tests/test_hummingbird_python_bootstrap.py
@@ -35,6 +35,12 @@ MANIFEST = ROOT / "build-order-hummingbird-desktops.yml"
 WORKFLOW = ROOT / ".github/workflows/build-hummingbird-desktops.yml"
 
 # Every backend Hummingbird lacks that pyproject-rpm-macros can name.
+# PEP-517 *backends* -- the things a pyproject.toml names in
+# build-system.requires. python-build is deliberately not here: `build` is a
+# frontend, a CLI that calls a backend, and no pyproject.toml requires it.
+# Fedora's %pyproject_wheel does not use it either; pyproject_wheel.py calls
+# the backend's build_wheel() directly. Listing it here was the premise behind
+# putting it in the bootstrap tiers, and the premise was wrong.
 BACKENDS = {
     "python-hatchling",
     "python-flit-core",
@@ -42,7 +48,6 @@ BACKENDS = {
     "python-editables",
     "python-trove-classifiers",
     "python-installer",
-    "python-build",
     "python-wheel",
 }
 
@@ -91,7 +96,7 @@ def test_backends_are_built_before_the_desktops() -> None:
 #
 #   flit-core, poetry-core, hatchling   self-hosting
 #   trove-classifiers                   setuptools.build_meta  (in Hummingbird)
-#   editables, installer, build, wheel  flit_core.buildapi
+#   editables, installer, wheel         flit_core.buildapi
 #   hatch-vcs, hatch-fancy-pypi-readme  hatchling.build
 #
 # A backend must be BUILT before anything that builds with it, and packages
@@ -102,7 +107,6 @@ def test_backends_are_built_before_the_desktops() -> None:
 BACKEND_OF = {
     "python-editables": "python-flit-core",
     "python-installer": "python-flit-core",
-    "python-build": "python-flit-core",
     "python-wheel": "python-flit-core",
     "python-hatch-vcs": "python-hatchling",
     "python-hatch-fancy-pypi-readme": "python-hatchling",
@@ -189,4 +193,38 @@ def test_build_gets_pyproject_hooks_before_it_needs_it() -> None:
     assert tier_of("python-build") > tier_of("python-pyproject-hooks"), (
         "python-build must build in a later tier than python-pyproject-hooks; "
         "packages inside a tier run concurrently, so sharing one is a race"
+    )
+
+def test_the_bootstrap_does_not_carry_a_pep517_frontend() -> None:
+    """`build` is a frontend, not a backend, and nothing asked for it.
+
+    python-build was put in the bootstrap tiers on the premise that Hummingbird
+    ships no PEP-517 *backend*. That premise is right and `build` is not one of
+    them: it is a CLI frontend, and Fedora's %pyproject_wheel does not use it --
+    pyproject_wheel.py calls the backend's build_wheel() directly.
+
+    It cannot be built here anyway. Fedora's spec hard-codes its optional
+    extras, outside any bcond, so --without=tests --without=check does not
+    reach them:
+
+        pyproject_buildrequires.py --generate-extras ... -x virtualenv,uv
+        Failed to resolve the transaction:
+        Problem: package python3-uv-0.11.32-1.fc44.noarch requires
+          uv = 0.11.32-1.fc44, but none of the providers can be installed
+
+    (run 31266920109). uv is a Rust package that is not installable in this
+    buildroot, so `build` costs the whole bootstrap and every tier behind it.
+
+    Checked before removing, not after: `build` is in no desktop's closure, and
+    across every tier built so far nothing emitted a requirement on it.
+
+    If some package does turn out to need it, that will surface as a named
+    unmet BuildRequires -- and the fix then is to make uv installable, not to
+    re-add `build` on its own and rediscover this.
+    """
+    packages = {p for t in tiers() if t["name"].startswith("bootstrap-") for p in names_in(t)}
+    assert "python-build" not in packages, (
+        "python-build is back in the bootstrap tiers; it drags in an "
+        "uninstallable uv and nothing was shown to need it -- see this "
+        "test's docstring before re-adding it"
     )


### PR DESCRIPTION
`python-build` is the last thing failing the Python bootstrap. It cannot be built here, and it did not need to be in the list at all.

## Why it cannot be built

Fedora's spec hard-codes its optional extras, **outside any bcond**, so #271's `--without=tests --without=check` does not reach them. From [run 31266920109](https://github.com/tuna-os/tunaos-packages/actions/runs/31266920109):

```
pyproject_buildrequires.py --generate-extras ... -x virtualenv,uv
Failed to resolve the transaction:
Problem: package python3-uv-0.11.32-1.fc44.noarch from fedora-44-python-updates
  requires uv = 0.11.32-1.fc44, but none of the providers can be installed
```

`uv` is a Rust package that is not installable in this buildroot. Building it would be a project of its own, and **every tier behind bootstrap-02 waits on it**.

Worth noting what did work in that run: `--without=tests --without=check` removed `-g test` from the invocation entirely, so #271's bcond change is doing its job. This is a different mechanism.

## Why it did not belong

It went in on the premise that Hummingbird ships no PEP-517 **backend**. The premise is correct; `build` is not one of them. It is a *frontend* — a CLI that calls a backend — and no `pyproject.toml` names it in `build-system.requires`. Fedora's `%pyproject_wheel` does not use it either: `pyproject_wheel.py` calls the backend's `build_wheel()` directly.

Checked before removing rather than after:

- `build` is in no desktop's source or binary closure in the gap report.
- Across every tier built so far, nothing emitted a requirement on it. The only `Requires-Dist (build)` lines in any log are python-build's own metadata.

The `BACKENDS` set in the test module listed it — that is where the wrong premise was written down, and it is corrected here too, with the frontend/backend distinction spelled out so it does not come back by inference.

## What stays

`python-pyproject-hooks` stays. It builds cleanly, it is already published, and `%pyproject_buildrequires` reported it unsatisfied in this very buildroot — so unlike `build`, there is direct evidence something wants it.

If some package does turn out to need `build`, it will say so by name in an unmet BuildRequires. The fix then is to make `uv` installable, not to re-add `build` alone and rediscover this.

## Run state this lands on

| tier | result in 31266920109 |
|---|---|
| bootstrap-00 | 3/3 |
| bootstrap-01 | 4/4 (`pyproject-hooks` from #278 built) |
| bootstrap-02 | `python-build` failed; `hatchling` already published |
| bootstrap-03 | never reached |

A build is dispatched from this branch across all four bootstrap tiers with publishing on.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->