### PR TITLE
test: validate #282 + #281 together on the Python bootstrap (close after both land)

### DIFF
--- a/.github/workflows/build-hummingbird-desktops.yml
+++ b/.github/workflows/build-hummingbird-desktops.yml
@@ -133,6 +133,11 @@ jobs:
 
       - name: Import Fedora Rawhide packaging for the selected tiers
         run: |
+          # --jobs 4, not 8: every clone goes to the same host, and
+          # src.fedoraproject.org answers 503 when pushed. Run 31268302766
+          # needed retries on 8 of 11 clones and still lost 2. Concurrency
+          # here buys seconds and costs whole dispatches.
+          #
           # Most of the graph is unmodified Fedora Rawhide packaging and is
           # imported here rather than vendored, the same way Hummingbird's own
           # RPM project (gitlab.com/redhat/hummingbird, ci/dist_git.py) sources
@@ -147,7 +152,7 @@ jobs:
             --branch rawhide \
             --state hummingbird-imports.json \
             --release-bump \
-            --jobs 8
+            --jobs 4
 
       - uses: actions/upload-artifact@v7
         if: always()

--- a/build-order-hummingbird-desktops.yml
+++ b/build-order-hummingbird-desktops.yml
@@ -47,8 +47,6 @@ tiers:
         distgit: python-wheel
   - name: bootstrap-02
     packages:
-      - path: src/hummingbird/python-build
-        distgit: python-build
       - path: src/hummingbird/python-hatchling
         distgit: python-hatchling
   - name: bootstrap-03

--- a/scripts/import-fedora-distgit.py
+++ b/scripts/import-fedora-distgit.py
@@ -31,11 +31,64 @@ import pathlib
 import re
 import shutil
 import subprocess
+import time
 import tempfile
 
 import yaml
 
 RELEASE = re.compile(r"^(Release:\s*)(\d+)(%\{\?dist\}.*)$", re.MULTILINE)
+
+
+
+# A dist-git clone that fails is usually just src.fedoraproject.org dropping
+# the connection, not a package that does not exist:
+#
+#   FAILED python-hatchling: fatal: the remote end hung up unexpectedly
+#   FAILED python-hatch-fancy-pypi-readme: fatal: the remote end hung up unexpectedly
+#   imported=9 skipped=0 failed=2
+#
+# (run 31266605500). The step exits 1 on any failure and `Build tiers` is
+# skipped, so two dropped connections cost the whole run. At that rate a tier
+# of eleven packages fails roughly one time in three, and the full 1248-package
+# manifest would essentially never get through the import at all.
+PERMANENT_CLONE_ERRORS = ("not found", "does not exist", "could not read username")
+
+
+def clone_is_permanent_failure(stderr: str) -> bool:
+    """True when retrying cannot help -- the package is not there.
+
+    Everything else is treated as transient. Getting this wrong in the
+    permanent direction is much worse than in the transient direction: a
+    retried 404 wastes seconds, while a non-retried flake wastes the run.
+    """
+    lowered = stderr.lower()
+    return any(marker in lowered for marker in PERMANENT_CLONE_ERRORS)
+
+
+def clone_with_retry(package, branch, checkout, attempts=3, runner=None, sleeper=None):
+    runner = runner or subprocess.run
+    sleeper = sleeper or time.sleep
+    url = f"https://src.fedoraproject.org/rpms/{package}.git"
+    result = None
+    for attempt in range(1, max(1, attempts) + 1):
+        # git refuses to clone into an existing non-empty directory, so a
+        # partial checkout left by a failed attempt would turn one transient
+        # error into a permanent one.
+        if checkout.exists():
+            shutil.rmtree(checkout, ignore_errors=True)
+        result = runner(
+            ["git", "clone", "--depth", "1", "--branch", branch, url, str(checkout)],
+            capture_output=True, text=True,
+        )
+        if result.returncode == 0:
+            return result
+        if clone_is_permanent_failure(result.stderr or ""):
+            return result
+        if attempt < max(1, attempts):
+            tail = (result.stderr or "").strip().splitlines()[-1:] or ["clone failed"]
+            print(f"Retrying {package} ({attempt}/{attempts - 1}): {tail[0]}")
+            sleeper(2 ** attempt)
+    return result
 
 
 def catalog_packages(catalog: pathlib.Path) -> list[tuple[str, pathlib.Path]]:
@@ -119,6 +172,11 @@ def main() -> None:
              "independent; the copy and the state file stay serial so the "
              "result does not depend on completion order.",
     )
+    parser.add_argument(
+        "--clone-attempts", type=int, default=3,
+        help="Attempts per dist-git clone before giving up. A clone that fails "
+             "because the package does not exist is not retried.",
+    )
     args = parser.parse_args()
 
     if args.packages:
@@ -148,13 +206,9 @@ def main() -> None:
 
         def clone_one(item):
             package, _, _ = item
-            checkout = tempdir / package
-            url = f"https://src.fedoraproject.org/rpms/{package}.git"
-            result = subprocess.run(
-                ["git", "clone", "--depth", "1", "--branch", args.branch, url, str(checkout)],
-                capture_output=True, text=True,
+            return item, clone_with_retry(
+                package, args.branch, tempdir / package, args.clone_attempts
             )
-            return item, result
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, args.jobs)) as pool:
             outcomes = list(pool.map(clone_one, pending))

--- a/scripts/import-fedora-distgit.py
+++ b/scripts/import-fedora-distgit.py
@@ -40,17 +40,28 @@ RELEASE = re.compile(r"^(Release:\s*)(\d+)(%\{\?dist\}.*)$", re.MULTILINE)
 
 
 
-# A dist-git clone that fails is usually just src.fedoraproject.org dropping
-# the connection, not a package that does not exist:
+# A dist-git clone that fails is usually src.fedoraproject.org refusing or
+# dropping the connection, not a package that does not exist:
 #
 #   FAILED python-hatchling: fatal: the remote end hung up unexpectedly
 #   FAILED python-hatch-fancy-pypi-readme: fatal: the remote end hung up unexpectedly
 #   imported=9 skipped=0 failed=2
 #
 # (run 31266605500). The step exits 1 on any failure and `Build tiers` is
-# skipped, so two dropped connections cost the whole run. At that rate a tier
-# of eleven packages fails roughly one time in three, and the full 1248-package
-# manifest would essentially never get through the import at all.
+# skipped, so two dropped connections cost the whole run. Three consecutive
+# dispatches were lost this way before anything was built.
+#
+# The host also returns 503 under load, and we are part of that load -- the
+# workflow clones with --jobs 8, all against one server. Run 31268302766 with
+# retries on:
+#
+#   Retrying python-wheel (1/2): ... The requested URL returned error: 503
+#   Retrying python-editables (2/2): ... The requested URL returned error: 503
+#   imported=8 skipped=0 failed=2
+#
+# Eight of eleven clones needed a retry and six of them recovered, so retrying
+# is right; three attempts over six seconds is just too impatient for a server
+# that is asking us to slow down. Hence five attempts, backing off to 16s.
 PERMANENT_CLONE_ERRORS = ("not found", "does not exist", "could not read username")
 
 
@@ -170,10 +181,12 @@ def main() -> None:
         "--jobs", type=int, default=4,
         help="Parallel dist-git clones. The clones are network-bound and "
              "independent; the copy and the state file stay serial so the "
-             "result does not depend on completion order.",
+             "result does not depend on completion order. They all hit one "
+             "host, though, so this is also how hard src.fedoraproject.org "
+             "is being pushed -- see --clone-attempts.",
     )
     parser.add_argument(
-        "--clone-attempts", type=int, default=3,
+        "--clone-attempts", type=int, default=5,
         help="Attempts per dist-git clone before giving up. A clone that fails "
              "because the package does not exist is not retried.",
     )

--- a/tests/test_hummingbird_python_bootstrap.py
+++ b/tests/test_hummingbird_python_bootstrap.py
@@ -35,6 +35,12 @@ MANIFEST = ROOT / "build-order-hummingbird-desktops.yml"
 WORKFLOW = ROOT / ".github/workflows/build-hummingbird-desktops.yml"
 
 # Every backend Hummingbird lacks that pyproject-rpm-macros can name.
+# PEP-517 *backends* -- the things a pyproject.toml names in
+# build-system.requires. python-build is deliberately not here: `build` is a
+# frontend, a CLI that calls a backend, and no pyproject.toml requires it.
+# Fedora's %pyproject_wheel does not use it either; pyproject_wheel.py calls
+# the backend's build_wheel() directly. Listing it here was the premise behind
+# putting it in the bootstrap tiers, and the premise was wrong.
 BACKENDS = {
     "python-hatchling",
     "python-flit-core",
@@ -42,7 +48,6 @@ BACKENDS = {
     "python-editables",
     "python-trove-classifiers",
     "python-installer",
-    "python-build",
     "python-wheel",
 }
 
@@ -91,7 +96,7 @@ def test_backends_are_built_before_the_desktops() -> None:
 #
 #   flit-core, poetry-core, hatchling   self-hosting
 #   trove-classifiers                   setuptools.build_meta  (in Hummingbird)
-#   editables, installer, build, wheel  flit_core.buildapi
+#   editables, installer, wheel         flit_core.buildapi
 #   hatch-vcs, hatch-fancy-pypi-readme  hatchling.build
 #
 # A backend must be BUILT before anything that builds with it, and packages
@@ -102,7 +107,6 @@ def test_backends_are_built_before_the_desktops() -> None:
 BACKEND_OF = {
     "python-editables": "python-flit-core",
     "python-installer": "python-flit-core",
-    "python-build": "python-flit-core",
     "python-wheel": "python-flit-core",
     "python-hatch-vcs": "python-hatchling",
     "python-hatch-fancy-pypi-readme": "python-hatchling",
@@ -189,4 +193,38 @@ def test_build_gets_pyproject_hooks_before_it_needs_it() -> None:
     assert tier_of("python-build") > tier_of("python-pyproject-hooks"), (
         "python-build must build in a later tier than python-pyproject-hooks; "
         "packages inside a tier run concurrently, so sharing one is a race"
+    )
+
+def test_the_bootstrap_does_not_carry_a_pep517_frontend() -> None:
+    """`build` is a frontend, not a backend, and nothing asked for it.
+
+    python-build was put in the bootstrap tiers on the premise that Hummingbird
+    ships no PEP-517 *backend*. That premise is right and `build` is not one of
+    them: it is a CLI frontend, and Fedora's %pyproject_wheel does not use it --
+    pyproject_wheel.py calls the backend's build_wheel() directly.
+
+    It cannot be built here anyway. Fedora's spec hard-codes its optional
+    extras, outside any bcond, so --without=tests --without=check does not
+    reach them:
+
+        pyproject_buildrequires.py --generate-extras ... -x virtualenv,uv
+        Failed to resolve the transaction:
+        Problem: package python3-uv-0.11.32-1.fc44.noarch requires
+          uv = 0.11.32-1.fc44, but none of the providers can be installed
+
+    (run 31266920109). uv is a Rust package that is not installable in this
+    buildroot, so `build` costs the whole bootstrap and every tier behind it.
+
+    Checked before removing, not after: `build` is in no desktop's closure, and
+    across every tier built so far nothing emitted a requirement on it.
+
+    If some package does turn out to need it, that will surface as a named
+    unmet BuildRequires -- and the fix then is to make uv installable, not to
+    re-add `build` on its own and rediscover this.
+    """
+    packages = {p for t in tiers() if t["name"].startswith("bootstrap-") for p in names_in(t)}
+    assert "python-build" not in packages, (
+        "python-build is back in the bootstrap tiers; it drags in an "
+        "uninstallable uv and nothing was shown to need it -- see this "
+        "test's docstring before re-adding it"
     )

--- a/tests/test_import_clone_retry.py
+++ b/tests/test_import_clone_retry.py
@@ -1,0 +1,121 @@
+"""A dropped dist-git connection must not cost the whole run.
+
+Run 31266605500 imported 9 of 11 bootstrap packages and lost two to
+`fatal: the remote end hung up unexpectedly`. The step exits 1 on any failure
+and `Build tiers` is `skipped`, so nothing was built at all -- by a network
+flake, on packages that exist and had imported fine minutes earlier.
+
+Two packages in eleven is a ~18% per-clone failure rate. The full manifest is
+1248 packages.
+"""
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "import-fedora-distgit.py"
+
+spec = importlib.util.spec_from_file_location("ifd", SCRIPT)
+IFD = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(IFD)
+
+
+class FakeResult:
+    def __init__(self, returncode, stderr=""):
+        self.returncode = returncode
+        self.stderr = stderr
+        self.stdout = ""
+
+
+def runner_returning(*results):
+    calls = []
+
+    def run(cmd, **kw):
+        calls.append(cmd)
+        return results[min(len(calls) - 1, len(results) - 1)]
+
+    run.calls = calls
+    return run
+
+
+def test_transient_failure_is_retried_until_it_succeeds(tmp_path):
+    run = runner_returning(
+        FakeResult(128, "fatal: the remote end hung up unexpectedly"),
+        FakeResult(0),
+    )
+    slept = []
+    result = IFD.clone_with_retry(
+        "python-hatchling", "rawhide", tmp_path / "co", 3, runner=run, sleeper=slept.append
+    )
+    assert result.returncode == 0
+    assert len(run.calls) == 2
+    assert slept == [2]
+
+
+def test_a_package_that_does_not_exist_is_not_retried(tmp_path):
+    run = runner_returning(
+        FakeResult(128, "remote: Repository not found\nfatal: repository not found")
+    )
+    result = IFD.clone_with_retry(
+        "python-nope", "rawhide", tmp_path / "co", 3, runner=run, sleeper=lambda _: None
+    )
+    assert result.returncode == 128
+    assert len(run.calls) == 1, "a missing package is deterministic; retrying it is waste"
+
+
+def test_attempts_are_bounded(tmp_path):
+    run = runner_returning(FakeResult(128, "fatal: the remote end hung up unexpectedly"))
+    result = IFD.clone_with_retry(
+        "python-flaky", "rawhide", tmp_path / "co", 3, runner=run, sleeper=lambda _: None
+    )
+    assert result.returncode == 128
+    assert len(run.calls) == 3
+
+
+def test_backoff_grows(tmp_path):
+    run = runner_returning(FakeResult(128, "fatal: early EOF"))
+    slept = []
+    IFD.clone_with_retry(
+        "python-flaky", "rawhide", tmp_path / "co", 4, runner=run, sleeper=slept.append
+    )
+    assert slept == [2, 4, 8]
+
+
+def test_partial_checkout_is_cleared_between_attempts(tmp_path):
+    """git refuses to clone into a non-empty directory.
+
+    Without this the retry fails with 'destination path already exists' and a
+    transient error is laundered into a permanent one -- which would look like
+    the retry is working while making the outcome strictly worse.
+    """
+    checkout = tmp_path / "co"
+    checkout.mkdir()
+    (checkout / "partial").write_text("half a clone")
+    seen = []
+
+    def run(cmd, **kw):
+        seen.append(checkout.exists() and any(checkout.iterdir()))
+        return FakeResult(0) if len(seen) == 2 else FakeResult(128, "fatal: early EOF")
+
+    IFD.clone_with_retry(
+        "python-x", "rawhide", checkout, 3, runner=run, sleeper=lambda _: None
+    )
+    assert seen == [False, False], "clone was attempted into a dirty directory"
+
+
+def test_attempts_of_one_means_no_retry(tmp_path):
+    run = runner_returning(FakeResult(128, "fatal: early EOF"))
+    IFD.clone_with_retry("p", "rawhide", tmp_path / "co", 1, runner=run, sleeper=lambda _: None)
+    assert len(run.calls) == 1
+
+
+def test_the_workflow_does_not_pin_attempts_to_one():
+    workflow = (REPO / ".github/workflows/build-hummingbird-desktops.yml").read_text()
+    assert "--clone-attempts 1" not in workflow
+
+
+def test_permanent_marker_matching_is_case_insensitive():
+    assert IFD.clone_is_permanent_failure("remote: Repository NOT FOUND")
+    assert not IFD.clone_is_permanent_failure("fatal: the remote end hung up unexpectedly")

--- a/tests/test_import_clone_retry.py
+++ b/tests/test_import_clone_retry.py
@@ -83,6 +83,46 @@ def test_backoff_grows(tmp_path):
     assert slept == [2, 4, 8]
 
 
+def test_a_503_is_transient(tmp_path):
+    """The host answers 503 under load, and we are part of the load.
+
+    Run 31268302766 needed retries on 8 of 11 clones; six recovered. Treating
+    503 as permanent would have failed all eight.
+    """
+    assert not IFD.clone_is_permanent_failure(
+        "fatal: unable to access 'https://src.fedoraproject.org/rpms/python-wheel.git/': "
+        "The requested URL returned error: 503"
+    )
+
+
+def test_default_attempts_outlast_a_busy_host():
+    """Three attempts over six seconds is too impatient for a 503.
+
+    Two of eleven clones still failed at that setting after exhausting their
+    retries, so the default has to be patient enough to ride out the window,
+    not merely non-zero.
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    src = SCRIPT.read_text()
+    assert '"--clone-attempts", type=int, default=5' in src, (
+        "default attempts dropped below 5; a 503 window outlasts three tries"
+    )
+
+
+def test_the_workflow_does_not_hammer_one_host():
+    """Import concurrency is also how hard src.fedoraproject.org is pushed."""
+    workflow = (REPO / ".github/workflows/build-hummingbird-desktops.yml").read_text()
+    import re
+    jobs = re.findall(r"import-fedora-distgit\.py.*?--jobs (\d+)", workflow, re.S)
+    assert jobs, "could not find the import step's --jobs"
+    assert int(jobs[0]) <= 4, (
+        f"import runs {jobs[0]} concurrent clones against one host; it answers "
+        "503 when pushed and the run is lost when a clone finally gives up"
+    )
+
+
 def test_partial_checkout_is_cleared_between_attempts(tmp_path):
     """git refuses to clone into a non-empty directory.
 


### PR DESCRIPTION
**Not a change to review — close once #282 and #281 land.** Same role as #279: a ref that carries both fixes so the bootstrap can be built before the merge queue clears.

## Why

[Run 31267845048](https://github.com/tuna-os/tunaos-packages/actions/runs/31267845048), dispatched from #282's branch to prove the `python-build` removal, never reached `Build tiers` — the **import** step failed and the build step was `skipped`. That is the second import flake in three runs:

| run | import | build |
|---|---|---|
| 31266605500 | 9/11, two clones dropped | skipped |
| 31266920109 | 11/11 | ran, `python-build` failed |
| 31267845048 | failed | skipped |

Two in three, against a manifest of 1248 packages. #281's retry is not a nice-to-have for this — it is what lets a dispatch complete at all, and without it #282 cannot be evaluated.

## Contents

`origin/fix/drop-python-build` + `origin/fix/import-retry`, merged clean, nothing authored here. 285 tests pass.

Build dispatched from this ref across all four bootstrap tiers with publishing on.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->