### PR TITLE
fix(build-chain): fetch lookaside sources recorded in the legacy md5 format

### DIFF
--- a/scripts/build-chain.sh
+++ b/scripts/build-chain.sh
@@ -367,19 +367,45 @@ prepare_sources() {
     if [[ -f "$sources_file" ]]; then
         local lookaside_name entry_name entry_hash
         lookaside_name="$(basename "$abs_pkg_dir")"
+        local entry_algo
         while IFS= read -r line; do
-            [[ "$line" =~ ^SHA512\ \((.+)\)\ =\ ([0-9a-f]{128})$ ]] || continue
-            entry_name="${BASH_REMATCH[1]}"
-            entry_hash="${BASH_REMATCH[2]}"
+            # Two formats, both current in Rawhide today.
+            #
+            #   SHA512 (foo-1.0.tar.gz) = <128 hex>     the modern one
+            #   <32 hex>  foo-1.0.tar.gz                the legacy md5 one
+            #
+            # Matching only the first silently skips the second -- `continue`
+            # on a line that is not an error -- and the package then dies in
+            # rpmbuild with "Bad file: /builddir/SOURCES/...: No such file or
+            # directory", which names the tarball but not the reason.
+            #
+            # That is what happened to lockdev and redhat-menus in gnome-00 of
+            # run 31272392927. Both still carry md5 sources files; both are
+            # old packages nobody has re-uploaded, and there are more like them
+            # across a 1248-package manifest.
+            if [[ "$line" =~ ^SHA512\ \((.+)\)\ =\ ([0-9a-f]{128})$ ]]; then
+                entry_name="${BASH_REMATCH[1]}"
+                entry_hash="${BASH_REMATCH[2]}"
+                entry_algo="sha512"
+            elif [[ "$line" =~ ^([0-9a-f]{32})\ \ (.+)$ ]]; then
+                entry_hash="${BASH_REMATCH[1]}"
+                entry_name="${BASH_REMATCH[2]}"
+                entry_algo="md5"
+            else
+                continue
+            fi
             [[ -f "${builddir}/SOURCES/${entry_name}" ]] && continue
-            echo "==> [${pkg_name}] Fetching ${entry_name} from the Fedora lookaside cache..."
+            echo "==> [${pkg_name}] Fetching ${entry_name} from the Fedora lookaside cache (${entry_algo})..."
+            # The lookaside path carries the algorithm, so the legacy entries
+            # live under .../md5/<hash>/... and not under sha512.
             curl -fsSL --retry 3 \
                 -o "${builddir}/SOURCES/${entry_name}" \
-                "https://src.fedoraproject.org/lookaside/pkgs/rpms/${lookaside_name}/${entry_name}/sha512/${entry_hash}/${entry_name}" || {
+                "https://src.fedoraproject.org/lookaside/pkgs/rpms/${lookaside_name}/${entry_name}/${entry_algo}/${entry_hash}/${entry_name}" || {
                 err "lookaside fetch failed for ${entry_name} (${pkg_name})"
                 return 1
             }
-            echo "${entry_hash}  ${builddir}/SOURCES/${entry_name}" | sha512sum --check --quiet - || {
+            echo "${entry_hash}  ${builddir}/SOURCES/${entry_name}" \
+                | "${entry_algo}sum" --check --quiet - || {
                 err "lookaside checksum mismatch for ${entry_name} (${pkg_name})"
                 return 1
             }

--- a/tests/test_lookaside_legacy_sources.py
+++ b/tests/test_lookaside_legacy_sources.py
@@ -1,0 +1,102 @@
+"""Fedora dist-git has two `sources` formats and both are current.
+
+    SHA512 (foo-1.0.tar.gz) = <128 hex>     the modern one
+    <32 hex>  foo-1.0.tar.gz                the legacy md5 one
+
+The lookaside fetch matched only the first. A legacy line hit `continue` --
+indistinguishable from a comment or a blank -- so nothing was downloaded, and
+the package died much later in rpmbuild with:
+
+    error: Bad file: /builddir/SOURCES/lockdev-1.0.4.20111007git.tar.gz:
+      No such file or directory
+
+which names the tarball but not the reason. lockdev and redhat-menus failed
+exactly that way in gnome-00 of run 31272392927, and their real sources files
+in Rawhide today are:
+
+    c0015d1bcd155b51df688467ed34137f  lockdev-1.0.4.20111007git.tar.gz
+    494af105a03e3679505ceb44c3cb6a77  redhat-menus-12.0.2.tar.gz
+
+Old packages nobody has re-uploaded. There are more across 1248 of them.
+"""
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "build-chain.sh"
+
+
+def sources_block() -> str:
+    src = SCRIPT.read_text()
+    start = src.index("local sources_file=")
+    end = src.index('done < "$sources_file"', start)
+    return src[start:end]
+
+
+def parse_with_the_real_shell(sources_text: str):
+    """Run the script's own two patterns, so the test cannot drift from them."""
+    block = sources_block()
+    patterns = re.findall(r'\[\[ "\$line" =~ (\^.+?\$) \]\]', block)
+    assert len(patterns) == 2, f"expected two sources-line patterns, found {patterns}"
+    script = f"""
+        set -u
+        while IFS= read -r line; do
+            if [[ "$line" =~ {patterns[0]} ]]; then
+                echo "sha512 ${{BASH_REMATCH[1]}} ${{BASH_REMATCH[2]}}"
+            elif [[ "$line" =~ {patterns[1]} ]]; then
+                echo "md5 ${{BASH_REMATCH[2]}} ${{BASH_REMATCH[1]}}"
+            fi
+        done
+    """
+    out = subprocess.run(["bash", "-c", script], input=sources_text,
+                         capture_output=True, text=True, check=True).stdout
+    return [line.split() for line in out.strip().splitlines() if line.strip()]
+
+
+def test_modern_sha512_line_is_parsed():
+    got = parse_with_the_real_shell(
+        "SHA512 (iso-codes-v4.20.1.tar.gz) = " + "a" * 128 + "\n"
+    )
+    assert got == [["sha512", "iso-codes-v4.20.1.tar.gz", "a" * 128]]
+
+
+def test_legacy_md5_line_is_parsed():
+    """The regression. Real line from rawhide's lockdev."""
+    got = parse_with_the_real_shell(
+        "c0015d1bcd155b51df688467ed34137f  lockdev-1.0.4.20111007git.tar.gz\n"
+    )
+    assert got == [["md5", "lockdev-1.0.4.20111007git.tar.gz",
+                    "c0015d1bcd155b51df688467ed34137f"]]
+
+
+def test_both_formats_in_one_file():
+    got = parse_with_the_real_shell(
+        "SHA512 (new.tar.gz) = " + "b" * 128 + "\n"
+        "494af105a03e3679505ceb44c3cb6a77  redhat-menus-12.0.2.tar.gz\n"
+    )
+    assert [g[0] for g in got] == ["sha512", "md5"]
+
+
+def test_junk_lines_are_still_skipped():
+    assert parse_with_the_real_shell("\n# a comment\nnot a sources line\n") == []
+
+
+def test_the_url_carries_the_algorithm():
+    """Legacy entries live under .../md5/<hash>/..., not under sha512."""
+    block = sources_block()
+    assert "${entry_algo}/${entry_hash}" in block, (
+        "the lookaside URL hardcodes an algorithm, so legacy md5 entries are "
+        "fetched from a sha512 path that does not exist"
+    )
+
+
+def test_the_checksum_is_verified_with_the_matching_tool():
+    block = sources_block()
+    assert '"${entry_algo}sum"' in block, (
+        "the checksum check hardcodes sha512sum, which cannot verify an md5 "
+        "entry and would reject every legacy source"
+    )


### PR DESCRIPTION
Fedora dist-git has **two** `sources` formats and both are current in Rawhide:

```
SHA512 (foo-1.0.tar.gz) = <128 hex>     the modern one
<32 hex>  foo-1.0.tar.gz                the legacy md5 one
```

The lookaside fetch matched only the first. A legacy line hit `continue` — indistinguishable from a comment or a blank — so nothing was downloaded, and the package died much later in rpmbuild with:

```
error: Bad file: /builddir/SOURCES/lockdev-1.0.4.20111007git.tar.gz:
  No such file or directory
```

which names the tarball but not the reason, several hundred log-lines away from the skipped line that caused it.

## Where it showed up

`gnome-00` of [run 31272392927](https://github.com/tuna-os/tunaos-packages/actions/runs/31272392927) — **108 of 116 packages built**, and `lockdev` and `redhat-menus` failed exactly this way. I checked their real `sources` files rather than assuming:

```
c0015d1bcd155b51df688467ed34137f  lockdev-1.0.4.20111007git.tar.gz
494af105a03e3679505ceb44c3cb6a77  redhat-menus-12.0.2.tar.gz
```

Both md5. Both old packages nobody has re-uploaded. Across 1248 of them there will be more.

## The change

Both formats are parsed, and the algorithm is **carried through** rather than assumed in two further places that would each have failed on their own:

- the lookaside URL is `.../md5/<hash>/...` for legacy entries, not `.../sha512/...`
- verification has to use `md5sum`; `sha512sum` cannot check an md5 digest and would reject every legacy source it did manage to download

## Testing

`tests/test_lookaside_legacy_sources.py` — 6 tests. They **extract the two regexes from the script and run them under real bash**, so the test cannot drift from the patterns it is meant to pin.

Mutation-verified three ways:

| mutation | result |
|---|---|
| sha512-only matching | 4 fail |
| hardcoded `sha512` in the URL path | 1 fail |
| hardcoded `sha512sum` for verification | 1 fail |

Suite 308 → 314.

## Not the only cause in that tier

The other six gnome-00 failures (`dconf`, `libldac`, `iso-codes`, `libuser`, `mozjs140`, `v4l-utils`) are separate and still being read; `iso-codes` is a `%files`/`%find_lang` problem, not a missing source. This fixes the class that was silent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->