### PR TITLE
fix(gap): run the BuildRequires fold when the queue drains, not sometimes

### DIFF
--- a/scripts/measure-hummingbird-gap.py
+++ b/scripts/measure-hummingbird-gap.py
@@ -229,56 +229,95 @@ def closure(roots, reference, have, source_index=None):
         else:
             absent_roots.append(root)
     queue = list(resolved_roots)
-    while queue:
-        name = queue.pop()
-        if name in seen:
-            continue
-        seen.add(name)
-        info = packages.get(name)
-        if info is None:
-            absent_roots.append(name)
-            continue
-        for requirement in info["requires"]:
-            if requirement in have:
-                continue
-            if requirement.startswith(RICH_DEP_PREFIX):
-                continue
-            candidates = provides.get(requirement)
-            if not candidates:
-                unresolved.setdefault(requirement, []).append(name)
-                continue
-            provider = choose_provider(requirement, candidates)
-            if provider not in seen:
-                queue.append(provider)
 
-        if not queue and source_index is not None:
-            # Runtime frontier is exhausted. Fold in the BuildRequires of every
-            # source package behind what we have reached; anything new restarts
-            # the runtime walk above, which is why this sits inside the loop.
-            #
-            # folded_sources keeps this from rescanning the whole of `seen`
-            # every time the queue drains -- with 23k SRPMs that turns a linear
-            # walk quadratic.
-            for binary in sorted(seen):
-                info = packages.get(binary)
-                if info is None:
+    def walk_runtime() -> None:
+        while queue:
+            name = queue.pop()
+            if name in seen:
+                continue
+            seen.add(name)
+            info = packages.get(name)
+            if info is None:
+                absent_roots.append(name)
+                continue
+            for requirement in info["requires"]:
+                if requirement in have:
                     continue
-                source = srpm_name(info.get("srpm"))
-                if source is None or source in folded_sources:
+                if requirement.startswith(RICH_DEP_PREFIX):
                     continue
-                folded_sources.add(source)
-                for requirement in source_index.get(source, ()):
-                    if requirement in have or requirement in seen:
-                        continue
-                    if requirement.startswith(RICH_DEP_PREFIX):
-                        continue
-                    candidates = provides.get(requirement)
-                    if not candidates:
-                        unresolved.setdefault(requirement, []).append(source)
-                        continue
-                    provider = choose_provider(requirement, candidates)
-                    if provider not in seen:
-                        queue.append(provider)
+                candidates = provides.get(requirement)
+                if not candidates:
+                    unresolved.setdefault(requirement, []).append(name)
+                    continue
+                provider = choose_provider(requirement, candidates)
+                if provider not in seen:
+                    queue.append(provider)
+
+    def fold_buildrequires() -> None:
+        """Queue the providers of every BuildRequires: not yet reached.
+
+        folded_sources keeps this from rescanning the whole of `seen` each
+        time the runtime frontier drains -- with 23k SRPMs that turns a linear
+        walk quadratic.
+        """
+        for binary in sorted(seen):
+            info = packages.get(binary)
+            if info is None:
+                continue
+            source = srpm_name(info.get("srpm"))
+            if source is None or source in folded_sources:
+                continue
+            folded_sources.add(source)
+            for requirement in source_index.get(source, ()):
+                if requirement in have or requirement in seen:
+                    continue
+                if requirement.startswith(RICH_DEP_PREFIX):
+                    continue
+                candidates = provides.get(requirement)
+                if not candidates:
+                    unresolved.setdefault(requirement, []).append(source)
+                    continue
+                provider = choose_provider(requirement, candidates)
+                if provider not in seen:
+                    queue.append(provider)
+
+    # Alternate to a fixpoint. The two halves are separate passes rather than
+    # one loop with the fold hanging off the end of the body, because that is
+    # what the previous shape was and it dropped the last fold every time:
+    #
+    #     while queue:
+    #         name = queue.pop()
+    #         if name in seen:
+    #             continue          # <-- jumps past the fold below
+    #         ...
+    #         if not queue and source_index is not None:
+    #             ...fold...
+    #
+    # When the queue drained on an already-seen name -- a duplicate, which is
+    # common -- control went back to `while queue:`, found it empty and left,
+    # with the newest sources never folded. Whether a desktop got its build
+    # dependencies came down to whether the last pop happened to be a
+    # duplicate, and that is why it looked like a per-desktop problem: cosmic
+    # reached `vala` and ordered dconf after it at tier 11, gnome did not
+    # reach it at all and sorted dconf into tier 0 with no build dependencies,
+    # where it failed against Rawhide's Python 3.15 (see #287).
+    while True:
+        walk_runtime()
+        if source_index is None:
+            break
+        fold_buildrequires()
+        if not queue:
+            break
+        walk_runtime()
+        if not queue:
+            # The fold produced nothing new on the last pass; another fold
+            # cannot either, since folded_sources only grows.
+            if all(
+                srpm_name(packages[b].get("srpm")) in folded_sources
+                for b in seen
+                if b in packages and packages[b].get("srpm")
+            ):
+                break
     return seen, absent_roots, unresolved
 
 

--- a/tests/test_closure_folds_after_the_queue_drains.py
+++ b/tests/test_closure_folds_after_the_queue_drains.py
@@ -1,0 +1,120 @@
+"""The BuildRequires fold must run when the runtime queue drains.
+
+It used to hang off the end of the runtime loop body, after an early
+`continue`:
+
+    while queue:
+        name = queue.pop()
+        if name in seen:
+            continue                     # <-- jumps past the fold below
+        seen.add(name)
+        ...
+        if not queue and source_index is not None:
+            ...fold...
+
+When the queue drained on an already-seen name -- a duplicate, which is
+common, since every shared library is queued by many packages -- control went
+straight back to `while queue:`, found it empty, and left. The newest sources
+were never folded.
+
+Whether a desktop got its build dependencies at all came down to whether the
+last pop happened to be a duplicate, which is why it looked like a
+per-desktop problem: measured against Fedora Rawhide, cosmic reached `vala`
+and ordered `dconf` after it at tier 11, while gnome never reached it and
+sorted `dconf` into tier 0 with no build dependencies -- where it failed
+against Rawhide's Python 3.15 (#287).
+
+The fix is structural: walk and fold are separate passes alternating to a
+fixpoint, so no early exit in one can skip the other.
+"""
+
+import importlib.util
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+spec = importlib.util.spec_from_file_location(
+    "gap", REPO / "scripts" / "measure-hummingbird-gap.py"
+)
+GAP = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(GAP)
+
+
+def reference(packages):
+    provides = {}
+    for name in packages:
+        provides.setdefault(name, set()).add(name)
+    return {"packages": packages, "provides": provides}
+
+
+def pkg(srpm, requires=()):
+    return {"srpm": f"{srpm}-1-1.fc45.src.rpm", "requires": list(requires)}
+
+
+def test_the_last_fold_is_not_skipped_by_a_duplicate_pop():
+    """The regression, reduced.
+
+    `app` runtime-requires `libа` twice over, so the queue drains on a
+    duplicate. Its BuildRequires `tool` must still be reached.
+    """
+    packages = {
+        "app": pkg("app", ["lib"]),
+        "lib": pkg("lib", []),
+        "tool": pkg("tool", []),
+    }
+    # Queue `lib` from two places so the final pop is an already-seen name.
+    packages["app"]["requires"] = ["lib", "lib"]
+    source_index = {"app": ["tool"]}
+    seen, absent, unresolved = GAP.closure(
+        ["app"], reference(packages), set(), source_index
+    )
+    assert "tool" in seen, (
+        "the BuildRequires fold was skipped because the queue drained on a "
+        "duplicate -- this is the bug that hid ~90% of the build closure"
+    )
+
+
+def test_fold_reaches_transitively():
+    """A build tool's own build tool must be reached too."""
+    packages = {
+        "app": pkg("app"),
+        "tool": pkg("tool"),
+        "tool-of-tool": pkg("tool-of-tool"),
+    }
+    source_index = {"app": ["tool"], "tool": ["tool-of-tool"]}
+    seen, _, _ = GAP.closure(["app"], reference(packages), set(), source_index)
+    assert {"tool", "tool-of-tool"} <= seen
+
+
+def test_what_the_target_ships_still_stops_the_walk():
+    packages = {"app": pkg("app"), "tool": pkg("tool")}
+    seen, _, _ = GAP.closure(
+        ["app"], reference(packages), {"tool"}, {"app": ["tool"]}
+    )
+    assert "tool" not in seen, "a package the target already ships must not be built"
+
+
+def test_without_a_source_index_the_behaviour_is_runtime_only():
+    """Pinned so a caller with no source reference is unaffected."""
+    packages = {"app": pkg("app", ["lib"]), "lib": pkg("lib"), "tool": pkg("tool")}
+    seen, _, _ = GAP.closure(["app"], reference(packages), set(), None)
+    assert seen == {"app", "lib"}
+
+
+def test_it_terminates_on_a_buildrequires_cycle():
+    """glib2 BuildRequires gobject-introspection BuildRequires glib2."""
+    packages = {"a": pkg("a"), "b": pkg("b")}
+    seen, _, _ = GAP.closure(
+        ["a"], reference(packages), set(), {"a": ["b"], "b": ["a"]}
+    )
+    assert seen == {"a", "b"}
+
+
+def test_an_unresolvable_buildrequires_is_reported_not_dropped():
+    packages = {"app": pkg("app")}
+    seen, _, unresolved = GAP.closure(
+        ["app"], reference(packages), set(), {"app": ["nothing-provides-this"]}
+    )
+    assert "nothing-provides-this" in unresolved, (
+        "a BuildRequires nothing provides must be reported; silence there is "
+        "how 413 missing capabilities went unnoticed"
+    )


### PR DESCRIPTION
## The bug

The BuildRequires fold hung off the end of the runtime loop body, **after an early `continue`**:

```python
while queue:
    name = queue.pop()
    if name in seen:
        continue                     # <-- jumps past the fold below
    seen.add(name)
    ...
    if not queue and source_index is not None:
        ...fold...
```

When the queue drained on an already-seen name — the common case, since every shared library gets queued by many packages — control went back to `while queue:`, found it empty and left. The newest sources were **never folded**.

So whether a desktop got its build dependencies at all came down to whether the last pop happened to be a duplicate. That is why it presented as a per-desktop problem:

| desktop | reaches `vala` | `dconf` tier |
|---|---|---|
| cosmic | yes | **11** — correctly after `vala` (10) |
| gnome | **no** | **0** — no build dependencies at all |

and `dconf` in `gnome-00` is exactly where it failed against Rawhide's Python 3.15 (#287).

Walk and fold are now separate passes alternating to a fixpoint, so an early exit in one cannot skip the other.

## What this changes, and it is not small

Measured against Rawhide with the same inputs as the committed report:

| desktop | sources before | sources after |
|---|---|---|
| gnome | 298 | **2927** |
| xfce | 248 | **2873** |

The transitive BuildRequires closure of a desktop is roughly **ten times** what has been measured so far. The 680- and 1248-package manifests were both artifacts of a truncated walk.

## This PR deliberately does not regenerate the manifest

A tenfold larger build order is a decision about strategy, not a mechanical consequence to land unattended — and the numbers above are the argument for making that decision differently.

Every failure in `gnome-00` was a **Rawhide** package whose ABI does not match Hummingbird's: Python 3.15 vs 3.14, perl 5.44 vs 5.42. Fedora **44** — already configured in `mock/hummingbird-ci.cfg`, already Python 3.14 — carries matching copies of the same packages, and is currently confined to `includepkgs=python3-*,flit`.

Widening that buildroot input is a far smaller change than building 2900 packages per desktop, and it addresses the actual failure rather than routing around it. That is a call for a human to make, so I have left the manifest alone.

## Testing

`tests/test_closure_folds_after_the_queue_drains.py` — 6 tests. The regression one reduces to three packages and a duplicate pop. Mutation-verified by restoring the old shape: it fails that test and nothing else.

Suite 308 → 314.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->