### PR TITLE
fix(libldac): use Fedora's cmake macros, not EPEL's cmake3

### DIFF
--- a/src/deps/libldac/libldac.spec
+++ b/src/deps/libldac/libldac.spec
@@ -16,7 +16,7 @@ Source0:        %{url}/releases/download/v%{version}/%{archivename}-%{version}.t
 # Upstream source throws error in a big-endian arch, see #1677491
 ExcludeArch:    s390x
 
-BuildRequires:  cmake3
+BuildRequires:  cmake
 BuildRequires:  gcc
 
 %package        devel
@@ -36,14 +36,14 @@ developing applications that use %{name}.
 %autosetup -n %{archivename}
 
 %build
-%cmake3 \
+%cmake \
     -DLDAC_SOFT_FLOAT=OFF \
     -DINSTALL_LIBDIR=%{_libdir}
 
-%cmake3_build
+%cmake_build
 
 %install
-%cmake3_install
+%cmake_install
 
 %ldconfig_scriptlets
 

--- a/tests/test_local_specs_use_fedora_cmake.py
+++ b/tests/test_local_specs_use_fedora_cmake.py
@@ -1,0 +1,52 @@
+"""Locally-maintained specs must use Fedora's cmake macros, not EL's.
+
+`cmake3` and `%cmake3*` come from EPEL, where cmake 2 was still the default
+and cmake 3 needed a separate name. On Fedora the package is `cmake` and the
+macros are `%cmake`, `%cmake_build`, `%cmake_install`. There is no `cmake3` in
+any repo the Hummingbird buildroot has, so a spec asking for it dies before
+rpmbuild starts:
+
+    Failed to resolve the transaction:
+    No match for argument: cmake3
+
+which is what happened to src/deps/libldac in gnome-00 of run 31274954342 --
+the last failure in that tier that was not either a legacy-md5 sources file
+(#286) or a %find_lang problem.
+
+The distinction is easy to miss because the spec builds fine on EL and the
+error names the argument rather than the spec. Specs imported from dist-git
+are Fedora's own and are not checked here; this is about the ones this
+repository maintains.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+LOCAL_SPEC_DIRS = ["src/deps", "src/hummingbird", "src/gnome-50", "src/xfce-wayland"]
+
+EL_ONLY = re.compile(r"(?:^BuildRequires:\s*cmake3\b|^%cmake3(?:_build|_install)?\b)", re.M)
+
+
+def local_specs():
+    for prefix in LOCAL_SPEC_DIRS:
+        root = REPO / prefix
+        if root.is_dir():
+            yield from sorted(root.glob("*/*.spec"))
+
+
+def test_there_are_local_specs_to_check():
+    assert list(local_specs()), "no local specs found; the glob is wrong"
+
+
+@pytest.mark.parametrize("spec", list(local_specs()), ids=lambda p: p.parent.name)
+def test_spec_does_not_use_el_cmake3(spec):
+    offenders = EL_ONLY.findall(spec.read_text())
+    assert not offenders, (
+        f"{spec.relative_to(REPO)} uses EL's cmake3 ({offenders}); the "
+        "Hummingbird buildroot has no cmake3 and dnf fails with "
+        "'No match for argument: cmake3'. Use cmake / %cmake / %cmake_build / "
+        "%cmake_install."
+    )


### PR DESCRIPTION
`libldac` was the last `gnome-00` failure that was not either a legacy-md5 `sources` file (#286) or a `%find_lang` problem. It never reached rpmbuild:

```
Failed to resolve the transaction:
No match for argument: cmake3
```

`cmake3` and `%cmake3*` are EPEL, where cmake 2 was the default and cmake 3 needed a separate name. On Fedora the package is `cmake` and the macros are `%cmake` / `%cmake_build` / `%cmake_install`. Nothing in the Hummingbird buildroot provides `cmake3`, and nothing will.

This spec is maintained in this repository rather than imported from dist-git — its changelog still carries *"Fix cmake out-of-source FTBFS for F33/rawhide"* — so the EL heritage came along with it and stayed. Easy to miss, because the spec builds fine on EL and the error names the argument rather than the spec.

## Testing

`tests/test_local_specs_use_fedora_cmake.py` checks every locally-maintained spec, **parametrised per package** so a future offender is named rather than hidden in a single pass/fail over the tree. Specs imported from dist-git are Fedora's own and are not checked.

Mutation-verified by restoring `cmake3`: fails exactly the `libldac` case.

## Where this leaves gnome-00

| package | status |
|---|---|
| 108 packages | built and published |
| `dconf`, `libuser`, `mozjs140`, `v4l-utils` | built once F44 is a buildroot input (#290) |
| `lockdev`, `redhat-menus` | #286 |
| **`libldac`** | **this PR** |
| `iso-codes` | `%find_lang` produces no `iso-codes.lang` — still open |

With #286, #290 and this, `gnome-00` is 115 of 116.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->