### PR TITLE
fix(libldac): let CMake configure a project older than its minimum policy

### DIFF
--- a/src/deps/libldac/libldac.spec
+++ b/src/deps/libldac/libldac.spec
@@ -36,7 +36,19 @@ developing applications that use %{name}.
 %autosetup -n %{archivename}
 
 %build
+# libldac's upstream CMakeLists.txt opens with a cmake_minimum_required below
+# 3.5, and current CMake refuses it outright:
+#
+#   CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
+#     Compatibility with CMake < 3.5 has been removed from CMake.
+#     Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
+#
+# The flag is CMake's own prescribed escape hatch, and it is the right one
+# here: the project is a small codec library that has not been touched
+# upstream in years, so raising its declared minimum is not something we can
+# do without carrying a patch against a dead tree.
 %cmake \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
     -DLDAC_SOFT_FLOAT=OFF \
     -DINSTALL_LIBDIR=%{_libdir}
 


### PR DESCRIPTION
The last unbuilt package in `gnome-00`.

#291 got `libldac` past the buildroot — it now fetches its tarball, builds the SRPM and starts mock — and it fails one step later, in `%build`:

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

Upstream's `CMakeLists.txt` declares a minimum below 3.5, and current CMake refuses it rather than warning.

The flag is CMake's own prescribed escape hatch, and it is the right one here rather than the alternatives it lists: `libldac` is a small codec library with no upstream activity in years, so raising its declared minimum means carrying a patch against a dead tree for no behavioural gain.

## What this completes

| `gnome-00` | |
|---|---|
| built and published | 115 |
| `libldac` | this PR |
| **total** | **116** |

That is the **first tier of the first desktop complete**. Worth stating precisely because it has been the gating tier all along: every other GNOME tier, and much of KDE, Cosmic, XFCE and niri, sits behind it.

The other 115 are already in R2, so proving this costs a single package build — dispatched from this branch.

## The path it took

Five separate causes had to be cleared to get this tier to 116, each diagnosed from a log rather than inferred:

| cause | fix |
|---|---|
| Rawhide ABI clash (python 3.15 / perl 5.44) | #290 |
| legacy md5 `sources` silently skipped | #286 |
| EPEL `cmake3` in a local spec | #291 |
| CMake minimum policy | this PR |
| `iso-codes` `%find_lang` | resolved in passing — see #292, closable |

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->