### PR TITLE
fix(hummingbird): build every requested tier, not just up to the first failure

### DIFF
--- a/.github/workflows/build-hummingbird-desktops.yml
+++ b/.github/workflows/build-hummingbird-desktops.yml
@@ -154,11 +154,37 @@ jobs:
           ARGS=(--manifest "${MANIFEST}" --mock-config hummingbird-ci
                 --local-repo "$PWD/local-repo-hummingbird" --jobs "$(nproc)")
           if [[ "${{ inputs.force }}" == "true" ]]; then ARGS+=(--force); fi
+          # Keep going after a tier that had failures, and fail the step at
+          # the end instead.
+          #
+          # The step runs under `set -e`, so a tier exiting non-zero used to
+          # abort the loop and every later tier was simply never attempted.
+          # A dispatch therefore yielded exactly one tier no matter how many
+          # were asked for: gnome-01 stopped at 30 of 33 with gnome-02..09
+          # untouched (run 31277092125), then gnome-02 stopped at 11 of 14
+          # with gnome-03..09 untouched (run 31279618402).
+          #
+          # A tier's failures rarely block the whole tail. gnome-02's three
+          # were libglvnd, libheif and samba; most of what follows does not
+          # BuildRequire any of them. Anything that genuinely does will fail
+          # on its own and say so, which is information rather than harm --
+          # and publishing is copy-not-sync, so nothing already built is lost.
+          #
+          # The step still fails if any tier did, so a red run stays red.
+          rc=0
+          failed_tiers=()
           for tier in "${TIERS[@]}"; do
             echo "::group::tier ${tier}"
-            ./scripts/build-chain.sh "${ARGS[@]}" --tier "${tier}"
+            ./scripts/build-chain.sh "${ARGS[@]}" --tier "${tier}" || {
+              rc=1
+              failed_tiers+=("${tier}")
+            }
             echo "::endgroup::"
           done
+          if (( rc )); then
+            echo "::error::tiers with failures: ${failed_tiers[*]}"
+          fi
+          exit "${rc}"
 
       # !cancelled(): publish what BUILT even when some packages in the tier
       # failed. Tier gnome-00's first real run built 108 of 124 packages and

--- a/tests/test_build_tiers_does_not_stop_at_the_first_failure.py
+++ b/tests/test_build_tiers_does_not_stop_at_the_first_failure.py
@@ -1,0 +1,60 @@
+"""One tier's failures must not cancel every tier after it.
+
+The `Build tiers` step runs under `set -e`. A tier exiting non-zero aborted
+the loop, so a dispatch yielded exactly one tier no matter how many were
+asked for:
+
+    run 31277092125  gnome-01  30 of 33   gnome-02..09 never attempted
+    run 31279618402  gnome-02  11 of 14   gnome-03..09 never attempted
+
+A tier's failures rarely block the whole tail -- gnome-02's three were
+libglvnd, libheif and samba, and most of what follows does not BuildRequire
+any of them. Anything that genuinely does will fail on its own and say so.
+
+The step must still fail when any tier did, or a red run silently goes green,
+which is a far worse bug than the one being fixed. Both halves are pinned.
+"""
+
+import re
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO / ".github/workflows/build-hummingbird-desktops.yml"
+
+
+def build_tiers_script() -> str:
+    steps = yaml.safe_load(WORKFLOW.read_text())["jobs"]["build"]["steps"]
+    return next(s for s in steps if s.get("name") == "Build tiers")["run"]
+
+
+def test_a_failing_tier_does_not_abort_the_loop():
+    script = build_tiers_script()
+    invocation = re.search(r"\./scripts/build-chain\.sh[^\n]*", script).group(0)
+    assert invocation.rstrip().endswith("|| {"), (
+        "build-chain.sh is called bare inside the loop; under `set -e` the "
+        f"first failing tier aborts every tier after it. Got: {invocation!r}"
+    )
+
+
+def test_the_step_still_fails_when_a_tier_failed():
+    """The dangerous half of this change is turning a red run green."""
+    script = build_tiers_script()
+    assert "rc=1" in script, "no failure is recorded"
+    assert re.search(r"exit \"?\$\{?rc\}?\"?", script), (
+        "the step does not exit non-zero after a failing tier, so a run with "
+        "failed packages would report success"
+    )
+
+
+def test_the_failing_tiers_are_named():
+    script = build_tiers_script()
+    assert "failed_tiers" in script and "::error::" in script, (
+        "failing tiers are not named in the step output; with the loop now "
+        "continuing, the summary is the only place the set is visible"
+    )
+
+
+def test_rc_starts_clean():
+    assert re.search(r"\brc=0\b", build_tiers_script()), "rc is never initialised"


### PR DESCRIPTION
The `Build tiers` step runs under `set -e`, so a tier exiting non-zero aborted the loop and every later tier was never attempted. A dispatch yielded exactly **one** tier no matter how many were asked for:

| run | asked for | built | never attempted |
|---|---|---|---|
| [31277092125](https://github.com/tuna-os/tunaos-packages/actions/runs/31277092125) | gnome-01..09 | gnome-01, 30 of 33 | gnome-02..09 |
| [31279618402](https://github.com/tuna-os/tunaos-packages/actions/runs/31279618402) | gnome-02..09 | gnome-02, 11 of 14 | gnome-03..09 |

That is the dominant cost of a build right now — not the failures themselves, which are a handful of packages, but the eight tiers behind them that never got a chance. Every dispatch tonight cost ~15 minutes of setup and R2 seeding to attempt a single tier.

## The change

Keep going, record the failures, fail the step at the end and name the tiers.

A tier's failures rarely block the whole tail: `gnome-02`'s three were `libglvnd`, `libheif` and `samba`, and most of what follows does not BuildRequire any of them. Anything that genuinely does will fail on its own and name itself — information rather than harm. Publishing is copy-not-sync, so nothing already built is lost either way.

## The half that matters more

**The step still exits non-zero if any tier failed.** Swallowing it would turn a red run green, which is a considerably worse bug than the one being fixed, and it is the obvious way to get this wrong. There is a test on that specifically.

## Testing

4 tests, mutation-verified two ways:

| mutation | result |
|---|---|
| restore the bare invocation | 2 fail |
| swallow the exit status (`exit 0`) | 1 fail |

Suite 454 → 458.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->