### PR TITLE
feat(hummingbird): make it a Tideforge target and give it Tideforge's caching

### DIFF
--- a/.github/workflows/build-hummingbird-desktops.yml
+++ b/.github/workflows/build-hummingbird-desktops.yml
@@ -47,7 +47,6 @@ on:
 
 env:
   R2_BUCKET: bluefin
-  R2_REPO_PATH: hummingbird/20251124-x86_64
   MANIFEST: build-order-hummingbird-desktops.yml
   # Fedora + mock toolchain (mock/Containerfile). The tag names the chroot the
   # image was first built for, not the chroot it can build; mock pulls the
@@ -59,8 +58,35 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 360
+    strategy:
+      matrix:
+        # The target this builds for, named rather than implied. It selects the
+        # mock config below and the R2 path is read from the target's own entry
+        # in manifests/package-factory.yaml, so this is the value the run turns
+        # on and not a label.
+        #
+        # It is also what makes hummingbird a covered target:
+        # validate-package-factory.py refuses a target no gate job exercises,
+        # which is how openSUSE sat declared-but-unbuilt for months (#139).
+        target: [hummingbird]
     steps:
       - uses: actions/checkout@v7
+
+      - name: Resolve the target's R2 path from the package factory manifest
+        id: target
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          # Single source of truth. This path was duplicated here and in
+          # manifests/hummingbird-desktops.yaml, which is the sort of pair that
+          # silently disagrees.
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import os, yaml
+          factory = yaml.safe_load(open("manifests/package-factory.yaml"))
+          target = factory["targets"][os.environ["TARGET"]]
+          print("r2_path=" + target["r2_path"])
+          PY
+          echo "resolved r2_path for ${TARGET}"
 
       - name: Install build tools
         run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm gpg gpgconf python3-yaml
@@ -87,7 +113,7 @@ jobs:
           mkdir -p local-repo-hummingbird
           # Seed from R2 so a resumed run does not rebuild what an earlier tier
           # already published. Non-fatal: the first run has nothing to seed.
-          rclone copy "r2:${R2_BUCKET}/${R2_REPO_PATH}/" local-repo-hummingbird/ || true
+          rclone copy "r2:${R2_BUCKET}/${{ steps.target.outputs.r2_path }}/" local-repo-hummingbird/ || true
 
       - name: Select tiers
         id: tiers
@@ -142,7 +168,42 @@ jobs:
           path: hummingbird-imports.json
           if-no-files-found: warn
 
+      # Caching, matching what the rest of Tideforge does. None of this
+      # existed for the desktop builds, which is why every dispatch paid for
+      # the same downloads again: the buildroot each package resolves, and
+      # every upstream tarball in the tier.
+      #
+      # build-chain.sh has honoured both variables for a while; the workflow
+      # simply never set them.
+      - name: Cache the mock chroot and its dnf downloads
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          # Keyed on the chroot definition and the tier set, not the run: a
+          # re-dispatch of the same tiers should hit. github.run_id makes each
+          # run's save unique so concurrent runs do not race, and the
+          # restore-keys walk back to the most recent compatible entry.
+          key: hummingbird-mock-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ steps.tiers.outputs.list }}-${{ github.run_id }}
+          restore-keys: |
+            hummingbird-mock-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ steps.tiers.outputs.list }}-
+            hummingbird-mock-${{ hashFiles('mock/hummingbird-ci.cfg') }}-
+
+      - name: Cache upstream source tarballs
+        uses: actions/cache@v6
+        with:
+          path: .sources-cache
+          # Content of the sources is pinned by the specs, which come from the
+          # import; key on the manifest so a regenerated build order gets a
+          # fresh store rather than an ever-growing one.
+          key: hummingbird-sources-${{ hashFiles('build-order-hummingbird-desktops.yml') }}-${{ github.run_id }}
+          restore-keys: |
+            hummingbird-sources-${{ hashFiles('build-order-hummingbird-desktops.yml') }}-
+            hummingbird-sources-
+
       - name: Build tiers
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+          RPM_SOURCES_CACHE: ${{ github.workspace }}/.sources-cache
         run: |
           IFS=',' read -ra TIERS <<< "${{ steps.tiers.outputs.list }}"
           # One worker per core. This was hardcoded to 2, which was the right
@@ -151,7 +212,7 @@ jobs:
           # bought nothing and just burned memory. That lock is now shared, so
           # workers genuinely build at the same time and the core count is the
           # real ceiling.
-          ARGS=(--manifest "${MANIFEST}" --mock-config hummingbird-ci
+          ARGS=(--manifest "${MANIFEST}" --mock-config "${{ matrix.target }}-ci"
                 --local-repo "$PWD/local-repo-hummingbird" --jobs "$(nproc)")
           if [[ "${{ inputs.force }}" == "true" ]]; then ARGS+=(--force); fi
           # Keep going after a tier that had failures, and fail the step at
@@ -213,8 +274,8 @@ jobs:
           createrepo_c --update local-repo-hummingbird
           # copy, not sync: a partial tier run must never delete packages an
           # earlier tier published. Removal is a deliberate, separate action.
-          rclone copy local-repo-hummingbird/ "r2:${R2_BUCKET}/${R2_REPO_PATH}/"
-          rclone copy public.gpg "r2:${R2_BUCKET}/${R2_REPO_PATH}/"
+          rclone copy local-repo-hummingbird/ "r2:${R2_BUCKET}/${{ steps.target.outputs.r2_path }}/"
+          rclone copy public.gpg "r2:${R2_BUCKET}/${{ steps.target.outputs.r2_path }}/"
 
       - uses: actions/upload-artifact@v7
         if: always()

--- a/manifests/package-factory.yaml
+++ b/manifests/package-factory.yaml
@@ -46,6 +46,40 @@ targets:
     r2_path: apt/debian/{suite}/{arch}
     repository: apt
     probe_image: docker.io/library/debian:sid
+  hummingbird:
+    # Hummingbird is a target of a different shape from the rest, and the
+    # differences are load-bearing rather than cosmetic.
+    #
+    # It is not a distribution we can pull: there is no hummingbird container
+    # image. It is an external RPM repository (Red Hat's public-hummingbird),
+    # and mock/hummingbird-ci.cfg reaches it by including Fedora Rawhide's
+    # chroot config and layering that repository over it at priority 10.
+    #
+    # `scaffold`, deliberately, and not because the builds do not work -- they
+    # do; the desktop gate has published over a thousand packages. It is
+    # scaffold because probe_image cannot yet tell the truth for this target.
+    # The probe answers "is this dependency available", and the only image
+    # that boots a Hummingbird-shaped root is the Fedora Rawhide base beneath
+    # it, which answers yes for packages Hummingbird does not ship. A probe
+    # that lies is worse than a probe that is absent, so no recipe should opt
+    # into targets: [hummingbird] until this points at something Hummingbird-
+    # shaped -- an image built from the target's own repository.
+    status: scaffold
+    format: rpm
+    # The chroot is Fedora Rawhide with the target's repository on top, so
+    # this is what a probe would boot. It is recorded for provenance; see the
+    # note above for why it is not yet trustworthy to probe against.
+    probe_image: registry.fedoraproject.org/fedora:rawhide
+    architectures: [x86_64]
+    # Not under rpm/: this path is already published and holds the packages
+    # the desktop builds have produced. Moving it would orphan them.
+    r2_path: hummingbird/20251124-x86_64
+    repository: rpm-md
+    # Buildroot inputs only, never repositories on a produced image. Fedora
+    # Rawhide supplies -devel headers and build backends Hummingbird has no
+    # build of yet; Fedora 44 supplies the Python namespace at the target's
+    # own ABI (3.14, where Rawhide is 3.15).
+    build_repositories: [fedora-rawhide, fedora-44]
   opensuse-tumbleweed:
     status: scaffold
     format: rpm

--- a/scripts/build-chain.sh
+++ b/scripts/build-chain.sh
@@ -340,19 +340,43 @@ prepare_sources() {
 
     # Download tarballs. Run spectool inside BUILD_IMAGE (has rpmdevtools)
     # so the host doesn't need rpmdevtools — it's Fedora-only.
+    #
+    # $RPM_SOURCES_CACHE, when set, is a host directory that outlives the run.
+    # The mock backend has honoured it for a long time; this path did not, so
+    # every dispatch re-downloaded every upstream tarball -- and this is the
+    # path the Hummingbird desktop builds take, where a tier is a hundred-odd
+    # packages and a full desktop is over a thousand.
+    #
+    # Downloads land in the cache and are hard-linked into the builddir, so a
+    # second package needing the same archive costs an inode rather than a
+    # transfer. Falls back to copying across filesystems.
     echo "==> [${pkg_name}] Downloading sources via spectool..."
+    local sources_cache="${RPM_SOURCES_CACHE:-}"
+    local spectool_dest_host="${builddir}/SOURCES"
+    local spectool_dest_container="/builddir/SOURCES"
+    if [[ -n "$sources_cache" ]]; then
+        mkdir -p "$sources_cache"
+        spectool_dest_host="$sources_cache"
+        spectool_dest_container="/sources-cache"
+    fi
     if command -v spectool &>/dev/null; then
-        spectool -g -C "${builddir}/SOURCES/" "$spec"
+        spectool -g -C "${spectool_dest_host}" "$spec"
     else
         podman run --rm \
             --pull=always \
             -v "${builddir}:/builddir:Z" \
+            ${sources_cache:+-v "${sources_cache}:/sources-cache:Z"} \
             "${BUILD_IMAGE}" \
-            spectool -g -C /builddir/SOURCES/ "/builddir/SPECS/$(basename "$spec")"
+            spectool -g -C "${spectool_dest_container}" "/builddir/SPECS/$(basename "$spec")"
     fi || {
         echo "ERROR: spectool failed for ${pkg_name}" >&2
         return 1
     }
+    if [[ -n "$sources_cache" ]]; then
+        find "$sources_cache" -maxdepth 1 -type f \
+            -exec ln -f {} "${builddir}/SOURCES/" \; 2>/dev/null \
+            || cp "$sources_cache"/* "${builddir}/SOURCES/" 2>/dev/null || true
+    fi
 
     # Fetch dist-git lookaside sources. A package imported from Fedora dist-git
     # can list artifacts in its `sources` file that have no URL in the spec at
@@ -409,6 +433,16 @@ prepare_sources() {
                 err "lookaside checksum mismatch for ${entry_name} (${pkg_name})"
                 return 1
             }
+            # Persist it, so the next run and the next package needing the same
+            # archive get it for free. Only after the checksum has passed --
+            # a cache is a much worse place to put a corrupt file than a
+            # builddir that is about to be deleted.
+            if [[ -n "${RPM_SOURCES_CACHE:-}" ]]; then
+                ln -f "${builddir}/SOURCES/${entry_name}" \
+                    "${RPM_SOURCES_CACHE}/${entry_name}" 2>/dev/null \
+                    || cp "${builddir}/SOURCES/${entry_name}" \
+                        "${RPM_SOURCES_CACHE}/${entry_name}" 2>/dev/null || true
+            fi
         done < "$sources_file"
     fi
 }

--- a/scripts/validate-package-factory.py
+++ b/scripts/validate-package-factory.py
@@ -36,6 +36,16 @@ def gate_targets(workflows: list[Path]) -> set[str]:
             exercised.add(match.group(1))
         for match in re.finditer(r"^\s*target:\s*([a-z0-9-]+)\s*$", text, re.MULTILINE):
             exercised.add(match.group(1))
+        # A matrix axis exercises its targets just as much as an include list
+        # does -- `target: [hummingbird]` or a block list under `target:`. Only
+        # recognising the include form meant a job matrixed over targets read
+        # as covering none of them, which is the same false negative this
+        # function exists to prevent, wearing a different hat.
+        for match in re.finditer(r"^\s*target:\s*\[([^\]]+)\]\s*$", text, re.MULTILINE):
+            for name in match.group(1).split(","):
+                name = name.strip().strip("\"'")
+                if re.fullmatch(r"[a-z0-9-]+", name):
+                    exercised.add(name)
     return exercised
 
 
@@ -85,7 +95,7 @@ def main() -> None:
         seen_upstreams.add(upstream_id)
 
     targets = data.get("targets", {})
-    required = {"el10", "ubuntu", "debian", "opensuse-tumbleweed", "arch"}
+    required = {"el10", "ubuntu", "debian", "hummingbird", "opensuse-tumbleweed", "arch"}
     if set(targets) != required:
         fail(f"targets must be exactly {sorted(required)}")
     for target_id, target in targets.items():
@@ -96,7 +106,11 @@ def main() -> None:
                 fail(f"{target_id}: {field} is required")
         if "/" not in target["probe_image"]:
             fail(f"{target_id}: probe_image must be a fully-qualified container image")
-        if not target["r2_path"].startswith(("rpm/", "apt/", "pacman/")):
+        # hummingbird/ is rpm-md like rpm/, but it is an overlay on somebody
+        # else's distribution rather than a TunaOS repository, and its path is
+        # already published with the desktop packages in it. Moving it under
+        # rpm/ to satisfy this check would orphan them.
+        if not target["r2_path"].startswith(("rpm/", "apt/", "pacman/", "hummingbird/")):
             fail(f"{target_id}: r2_path has an unsupported namespace")
         if not all(arch in {"x86_64", "aarch64", "amd64", "arm64"} for arch in target["architectures"]):
             fail(f"{target_id}: unsupported architecture")
@@ -113,6 +127,12 @@ def main() -> None:
         workflows = [
             workflow_directory / "build-tideforge-supported.yml",
             workflow_directory / "build-tideforge-arch.yml",
+            # Hummingbird's desktop packages are dist-git imports rather than
+            # recipes, so they are built by their own workflow -- but a target
+            # exercised somewhere else is still exercised, and leaving this out
+            # would make hummingbird look uncovered when it is the busiest
+            # target in the repository.
+            workflow_directory / "build-hummingbird-desktops.yml",
         ]
     check_gate_coverage(set(targets), workflows)
 

--- a/tests/test_hummingbird_uses_tideforge_caching.py
+++ b/tests/test_hummingbird_uses_tideforge_caching.py
@@ -1,0 +1,92 @@
+"""The desktop builds must use the caches the rest of Tideforge uses.
+
+build-chain.sh has honoured MOCK_CACHE_DIR and RPM_SOURCES_CACHE for a long
+time. The Hummingbird workflow set neither, so every dispatch re-resolved the
+same buildroot for every package and re-downloaded every upstream tarball --
+on a tier of a hundred-odd packages, and a desktop of over a thousand.
+
+RPM_SOURCES_CACHE was additionally only honoured on the mock backend. The
+desktop builds run the podman backend, so even setting it would have done
+nothing until that path learned it too.
+"""
+
+import re
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO / ".github/workflows/build-hummingbird-desktops.yml"
+BUILD_CHAIN = REPO / "scripts/build-chain.sh"
+
+
+def workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text())
+
+
+def build_step() -> dict:
+    steps = workflow()["jobs"]["build"]["steps"]
+    return next(s for s in steps if s.get("name") == "Build tiers")
+
+
+def test_the_build_step_sets_both_cache_variables():
+    env = build_step().get("env", {})
+    assert "MOCK_CACHE_DIR" in env, "the chroot and its dnf downloads are not cached"
+    assert "RPM_SOURCES_CACHE" in env, "upstream tarballs are not cached"
+
+
+def test_both_cache_paths_are_actually_cached_across_runs():
+    """Setting the variable without an actions/cache only moves the directory."""
+    steps = workflow()["jobs"]["build"]["steps"]
+    cached = {
+        s["with"]["path"]
+        for s in steps
+        if str(s.get("uses", "")).startswith("actions/cache") and s.get("with", {}).get("path")
+    }
+    env = build_step()["env"]
+    for var in ("MOCK_CACHE_DIR", "RPM_SOURCES_CACHE"):
+        directory = env[var].rsplit("/", 1)[-1]
+        assert directory in cached, (
+            f"{var} points at {directory}, which no actions/cache step persists; "
+            "the cache would be empty on every run"
+        )
+
+
+def test_cache_keys_are_not_pinned_to_a_single_run():
+    """A key containing only github.run_id can never be restored."""
+    steps = workflow()["jobs"]["build"]["steps"]
+    for s in steps:
+        if not str(s.get("uses", "")).startswith("actions/cache"):
+            continue
+        restore = s["with"].get("restore-keys", "")
+        assert restore.strip(), (
+            f"cache for {s['with']['path']} has no restore-keys; its key includes "
+            "github.run_id, so every run would miss and the cache would never be used"
+        )
+        assert "github.run_id" not in restore, (
+            "restore-keys include github.run_id, which cannot match a previous run"
+        )
+
+
+def test_the_podman_backend_honours_the_sources_cache():
+    """It did not, and that is the backend the desktop builds use."""
+    text = BUILD_CHAIN.read_text()
+    start = text.index("Download tarballs.")
+    end = text.index("Fetch dist-git lookaside sources", start)
+    assert "RPM_SOURCES_CACHE" in text[start:end], (
+        "the podman path's spectool still writes only into the builddir, so "
+        "RPM_SOURCES_CACHE has no effect on the desktop builds"
+    )
+
+
+def test_lookaside_downloads_are_persisted_only_after_verification():
+    text = BUILD_CHAIN.read_text()
+    start = text.index("Fetch dist-git lookaside sources")
+    block = text[start:text.index('done < "$sources_file"', start)]
+    check = block.index("--check --quiet")
+    persist = block.index("RPM_SOURCES_CACHE")
+    assert check < persist, (
+        "a lookaside archive is copied into the shared cache before its "
+        "checksum is verified; a corrupt download would be served to every "
+        "later package and run"
+    )


### PR DESCRIPTION
Two halves of the same thing: the desktop builds were a pipeline *beside* Tideforge rather than part of it, and they paid for that in both contract and throughput.

## Target

`hummingbird` joins `el10`, `ubuntu`, `debian`, `opensuse-tumbleweed` and `arch` in `manifests/package-factory.yaml`. It is a target of a different shape, and the differences are load-bearing, so they are written down rather than smoothed over:

- **It is not a distribution we can pull.** There is no hummingbird container image; it is an external RPM repository, and `mock/hummingbird-ci.cfg` reaches it by *including Fedora Rawhide's chroot config* and layering that repository over it at priority 10.
- **`status: scaffold`** — and not because the builds don't work; they do, with over a thousand packages published. It is scaffold because `probe_image` cannot yet tell the truth here. The probe answers *"is this dependency available"*, and the only image that boots a Hummingbird-shaped root is the Fedora Rawhide base underneath it, which answers **yes** for packages Hummingbird does not ship. A probe that lies is worse than one that is absent, so no recipe should opt into this target until the image is Hummingbird-shaped.
- **`r2_path` stays outside `rpm/`.** That path is already published and holds the desktop packages; moving it to satisfy a namespace check would orphan them. The check learns the namespace instead.

The workflow now **names** the target it builds for, in a matrix, and that value is load-bearing: it selects the mock config, and the R2 path is read from the target's entry rather than duplicated in the workflow `env`.

`gate_targets()` also learns to read a matrix axis. It recognised `target:` in an include list but not `target: [hummingbird]`, so a job matrixed over targets read as covering *none* of them — the same false negative that function exists to prevent, wearing a different hat.

## Caching

`build-chain.sh` has honoured `MOCK_CACHE_DIR` and `RPM_SOURCES_CACHE` for a long time. **This workflow set neither**, so every dispatch re-resolved the same buildroot for every package and re-downloaded every upstream tarball — on tiers of a hundred-odd packages, and desktops of over a thousand.

`RPM_SOURCES_CACHE` additionally only worked on the **mock** backend. The desktop builds run the **podman** backend, where `spectool` wrote straight into the builddir — so even setting it would have done nothing. That path now uses the cache and hard-links out of it, so a second package needing the same archive costs an inode rather than a transfer.

Lookaside downloads are persisted too, **but only after their checksum passes**. A cache is a much worse place for a corrupt file than a builddir that is about to be deleted, and there is a test asserting that order specifically.

Both caches carry `restore-keys`. A key ending in `github.run_id` and nothing else can never be restored — it would look like caching while missing every time — so that is tested too.

## Testing

5 tests, mutation-verified three ways:

| mutation | result |
|---|---|
| drop the env vars | 2 fail |
| drop `restore-keys` | 1 fail |
| persist a lookaside archive before verifying it | 1 fail |

Suite 460 → 465. `validate-package-factory.py`: *valid*, all 6 targets exercised.

## Still to come

The per-package fan-out. `scripts/generate-distributed-workflow.py` already emits one job per tier with `matrix: {package: [...]}` and `fail-fast: false` — the model is there. It passes the repo between tiers as GitHub artifacts, which is fine at its original scale and not at 1284 packages / >1 GB; that wants R2 for the inter-tier state and artifacts only for each tier's new RPMs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->