### PR TITLE
feat(hummingbird): fan tiers out one runner per package, with R2 as the state

### DIFF
--- a/.github/workflows/build-hummingbird-distributed.yml
+++ b/.github/workflows/build-hummingbird-distributed.yml
@@ -1,0 +1,10287 @@
+name: Build Hummingbird desktops (distributed)
+'on':
+  workflow_dispatch:
+    inputs:
+      force:
+        description: Force rebuild even if package exists in repo
+        type: boolean
+        default: false
+env:
+  R2_BUCKET: bluefin
+  LOCAL_REPO: ${{ github.workspace }}/local-repo
+  MOCK_RUNNER_IMAGE: ghcr.io/tuna-os/mock-runner:centos-stream-10
+jobs:
+  seed-repo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Configure rclone
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          '
+      - name: Seed local repo from R2
+        run: 'mkdir -p local-repo
+
+          echo "Downloading existing repo from R2..."
+
+          rclone sync "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" "local-repo/" --exclude "repodata/**" || true
+
+          createrepo_c local-repo
+
+          '
+  build-bootstrap-00:
+    needs: seed-repo
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/python-flit-core
+          - src/hummingbird/python-poetry-core
+          - src/hummingbird/python-trove-classifiers
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier bootstrap-00 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-bootstrap-00-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-bootstrap-00:
+    needs: build-bootstrap-00
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-bootstrap-00-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-bootstrap-01:
+    needs: consolidate-bootstrap-00
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/python-editables
+          - src/hummingbird/python-installer
+          - src/hummingbird/python-pyproject-hooks
+          - src/hummingbird/python-wheel
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier bootstrap-01 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-bootstrap-01-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-bootstrap-01:
+    needs: build-bootstrap-01
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-bootstrap-01-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-bootstrap-02:
+    needs: consolidate-bootstrap-01
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/python-hatchling
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier bootstrap-02 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-bootstrap-02-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-bootstrap-02:
+    needs: build-bootstrap-02
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-bootstrap-02-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-bootstrap-03:
+    needs: consolidate-bootstrap-02
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/python-hatch-vcs
+          - src/hummingbird/python-hatch-fancy-pypi-readme
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier bootstrap-03 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-bootstrap-03-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-bootstrap-03:
+    needs: build-bootstrap-03
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-bootstrap-03-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-gnome-00:
+    needs: consolidate-bootstrap-03
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/abseil-cpp
+          - src/hummingbird/bubblewrap
+          - src/hummingbird/cdparanoia
+          - src/hummingbird/color-filesystem
+          - src/hummingbird/dconf
+          - src/hummingbird/duktape
+          - src/hummingbird/exempi
+          - src/hummingbird/fdk-aac-free
+          - src/hummingbird/fribidi
+          - src/hummingbird/giflib
+          - src/hummingbird/gnome-backgrounds
+          - src/hummingbird/gnome-shell-extensions
+          - src/hummingbird/gnome-user-docs
+          - src/hummingbird/gsm
+          - src/hummingbird/hicolor-icon-theme
+          - src/hummingbird/hidapi
+          - src/hummingbird/highway
+          - src/hummingbird/hunspell
+          - src/hummingbird/hwdata
+          - src/hummingbird/hyphen
+          - src/hummingbird/inih
+          - src/hummingbird/iso-codes
+          - src/hummingbird/lame
+          - src/hummingbird/lcms2
+          - src/hummingbird/libICE
+          - src/hummingbird/libXdmcp
+          - src/hummingbird/libXfixes
+          - src/hummingbird/libXfont2
+          - src/hummingbird/libXinerama
+          - src/hummingbird/libXrandr
+          - src/hummingbird/libXv
+          - src/hummingbird/libXxf86vm
+          - src/hummingbird/libasyncns
+          - src/hummingbird/libatasmart
+          - src/hummingbird/libbytesize
+          - src/hummingbird/libcdio
+          - src/hummingbird/libcue
+          - src/hummingbird/libdatrie
+          - src/hummingbird/libdvdread
+          - src/deps/libebur128
+          - src/deps/libei
+          - src/hummingbird/libevdev
+          - src/hummingbird/libexif
+          - src/hummingbird/libieee1284
+          - src/hummingbird/liblc3
+          - src/deps/libldac
+          - src/hummingbird/libmtp
+          - src/hummingbird/libndp
+          - src/hummingbird/libnvme
+          - src/hummingbird/libogg
+          - src/hummingbird/libpciaccess
+          - src/hummingbird/libplist
+          - src/hummingbird/libsigc++30
+          - src/hummingbird/libtalloc
+          - src/hummingbird/libtdb
+          - src/hummingbird/libudfread
+          - src/hummingbird/libuser
+          - src/hummingbird/libvisual
+          - src/hummingbird/libvpx
+          - src/deps/libxcvt
+          - src/hummingbird/libxkbfile
+          - src/hummingbird/libxshmfence
+          - src/hummingbird/libzen
+          - src/hummingbird/linux-atm
+          - src/hummingbird/lm_sensors
+          - src/hummingbird/lockdev
+          - src/hummingbird/mdadm
+          - src/hummingbird/mobile-broadband-provider-info
+          - src/deps/mod_dnssd
+          - src/hummingbird/mozilla-filesystem
+          - src/deps/mozjs140
+          - src/hummingbird/mtdev
+          - src/hummingbird/noopenh264
+          - src/hummingbird/oath-toolkit
+          - src/hummingbird/opencore-amr
+          - src/hummingbird/openjph
+          - src/hummingbird/opus
+          - src/hummingbird/orc
+          - src/hummingbird/pixman
+          - src/hummingbird/pkcs11-helper
+          - src/hummingbird/python-argcomplete
+          - src/hummingbird/python-pam
+          - src/hummingbird/redhat-menus
+          - src/hummingbird/shared-mime-info
+          - src/deps/simdutf
+          - src/hummingbird/sound-theme-freedesktop
+          - src/hummingbird/soxr
+          - src/hummingbird/spandsp
+          - src/hummingbird/speexdsp
+          - src/hummingbird/spirv-tools
+          - src/hummingbird/sshpass
+          - src/hummingbird/taglib
+          - src/hummingbird/tinyxml2
+          - src/hummingbird/uchardet
+          - src/hummingbird/v4l-utils
+          - src/hummingbird/volume_key
+          - src/hummingbird/vpnc
+          - src/hummingbird/vpnc-script
+          - src/hummingbird/wavpack
+          - src/hummingbird/wayland
+          - src/hummingbird/wsdd
+          - src/hummingbird/xcb-util
+          - src/hummingbird/xdg-dbus-proxy
+          - src/hummingbird/xdg-user-dirs
+          - src/hummingbird/xmodmap
+          - src/hummingbird/xorg-x11-xinit
+          - src/hummingbird/xprop
+          - src/hummingbird/yelp-xsl
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier gnome-00 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-gnome-00-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-gnome-00:
+    needs: build-gnome-00
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-gnome-00-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-gnome-01:
+    needs: consolidate-gnome-00
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/enchant2
+          - src/hummingbird/exiv2
+          - src/hummingbird/flac
+          - src/hummingbird/glibmm2.68
+          - src/deps/gnome-user-share
+          - src/hummingbird/hunspell-en
+          - src/hummingbird/jpegxl
+          - src/hummingbird/libSM
+          - src/hummingbird/libXcursor
+          - src/hummingbird/libXdamage
+          - src/hummingbird/libbluray
+          - src/hummingbird/libcdio-paranoia
+          - src/hummingbird/libdisplay-info
+          - src/hummingbird/libdrm
+          - src/hummingbird/libgphoto2
+          - src/hummingbird/libimobiledevice-glue
+          - src/hummingbird/libmediainfo
+          - src/hummingbird/libphonenumber
+          - src/hummingbird/libtevent
+          - src/hummingbird/libthai
+          - src/hummingbird/libvorbis
+          - src/hummingbird/net-snmp
+          - src/hummingbird/openjpeg
+          - src/hummingbird/openvpn
+          - src/hummingbird/setxkbmap
+          - src/hummingbird/speex
+          - src/hummingbird/vulkan-loader
+          - src/hummingbird/webrtc-audio-processing
+          - src/hummingbird/webrtc-audio-processing1
+          - src/hummingbird/xkbcomp
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier gnome-01 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-gnome-01-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-gnome-01:
+    needs: build-gnome-01
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-gnome-01-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-gnome-02:
+    needs: consolidate-gnome-01
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/libXt
+          - src/hummingbird/libglvnd
+          - src/hummingbird/libheif
+          - src/hummingbird/libtheora
+          - src/hummingbird/libusbmuxd
+          - src/hummingbird/libva
+          - src/hummingbird/libxkbcommon
+          - src/hummingbird/mesa
+          - src/hummingbird/samba
+          - src/hummingbird/sane-backends
+          - src/hummingbird/xkeyboard-config
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier gnome-02 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-gnome-02-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-gnome-02:
+    needs: build-gnome-02
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-gnome-02-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-gnome-03:
+    needs: consolidate-gnome-02
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/hplip
+          - src/hummingbird/libXmu
+          - src/hummingbird/libimobiledevice
+          - src/hummingbird/libshout
+          - src/hummingbird/sane-airscan
+          - src/hummingbird/startup-notification
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier gnome-03 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-gnome-03-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-gnome-03:
+    needs: build-gnome-03
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-gnome-03-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-gnome-04:
+    needs: consolidate-gnome-03
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/ModemManager
+          - src/hummingbird/NetworkManager
+          - src/hummingbird/at-spi2-core
+          - src/hummingbird/bluez
+          - src/deps/cairo
+          - src/hummingbird/colord
+          - src/hummingbird/flite
+          - src/hummingbird/gcr
+          - src/deps/gdk-pixbuf2
+          - src/hummingbird/geoclue2
+          - src/hummingbird/geocode-glib
+          - src/hummingbird/glib-networking
+          - src/deps/glycin
+          - src/gnome-50/gnome-desktop3
+          - src/gnome-50/gnome-settings-daemon
+          - src/gnome-50/gobject-introspection
+          - src/hummingbird/graphene
+          - src/gnome-50/gsettings-desktop-schemas
+          - src/hummingbird/gssdp
+          - src/hummingbird/gstreamer1
+          - src/hummingbird/gstreamer1-plugins-bad-free
+          - src/hummingbird/gstreamer1-plugins-base
+          - src/hummingbird/gtk3
+          - src/gnome-50/gtk4
+          - src/hummingbird/gupnp
+          - src/hummingbird/gupnp-igd
+          - src/hummingbird/gweather-locations
+          - src/hummingbird/json-glib
+          - src/gnome-50/libadwaita
+          - src/deps/libcanberra
+          - src/hummingbird/libcloudproviders
+          - src/deps/libdecor
+          - src/hummingbird/libepoxy
+          - src/hummingbird/libgudev
+          - src/hummingbird/libgusb
+          - src/hummingbird/libgweather
+          - src/deps/libical
+          - src/hummingbird/libinput
+          - src/hummingbird/libmbim
+          - src/hummingbird/libnice
+          - src/hummingbird/libnotify
+          - src/hummingbird/libpcap
+          - src/hummingbird/libproxy
+          - src/hummingbird/libqmi
+          - src/hummingbird/libqrtr-glib
+          - src/hummingbird/librsvg2
+          - src/hummingbird/libsecret
+          - src/hummingbird/libsndfile
+          - src/hummingbird/libsoup3
+          - src/hummingbird/libwacom
+          - src/hummingbird/mpg123
+          - src/gnome-50/mutter
+          - src/deps/pango
+          - src/deps/pipewire
+          - src/hummingbird/polkit
+          - src/hummingbird/ppp
+          - src/hummingbird/pulseaudio
+          - src/hummingbird/pygobject3
+          - src/hummingbird/sbc
+          - src/hummingbird/upower
+          - src/hummingbird/usbmuxd
+          - src/hummingbird/usermode
+          - src/hummingbird/xhost
+          - src/hummingbird/xorg-x11-server-Xwayland
+          - src/hummingbird/xorg-x11-xauth
+          - src/hummingbird/xrdb
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier gnome-04 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-gnome-04-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-gnome-04:
+    needs: build-gnome-04
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-gnome-04-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-gnome-05:
+    needs: consolidate-gnome-04
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/accountsservice
+          - src/hummingbird/adwaita-icon-theme
+          - src/hummingbird/adwaita-icon-theme-legacy
+          - src/hummingbird/cairomm1.16
+          - src/deps/colord-gtk
+          - src/hummingbird/cups-pk-helper
+          - src/hummingbird/gcr3
+          - src/gnome-50/gjs
+          - src/deps/gnome-autoar
+          - src/hummingbird/gnome-browser-connector
+          - src/hummingbird/gnome-color-manager
+          - src/hummingbird/gnome-menus
+          - src/gnome-50/gnome-session
+          - src/deps/gsound
+          - src/hummingbird/ibus
+          - src/hummingbird/iio-sensor-proxy
+          - src/hummingbird/libblockdev
+          - src/deps/libfprint
+          - src/deps/libgexiv2
+          - src/hummingbird/libgsf
+          - src/hummingbird/libgtop2
+          - src/hummingbird/libgxps
+          - src/hummingbird/libhandy
+          - src/hummingbird/libmanette
+          - src/hummingbird/libnma
+          - src/hummingbird/libportal
+          - src/hummingbird/libreport
+          - src/hummingbird/libvncserver
+          - src/hummingbird/osinfo-db-tools
+          - src/hummingbird/pcsc-lite
+          - src/hummingbird/pinentry
+          - src/hummingbird/rest
+          - src/hummingbird/rtkit
+          - src/hummingbird/sso-mib
+          - src/hummingbird/stoken
+          - src/hummingbird/switcheroo-control
+          - src/deps/tecla
+          - src/hummingbird/totem-pl-parser
+          - src/hummingbird/twolame
+          - src/gnome-50/vte291
+          - src/hummingbird/wireplumber
+          - src/hummingbird/xdg-user-dirs-gtk
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier gnome-05 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-gnome-05-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-gnome-05:
+    needs: build-gnome-05
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-gnome-05-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-gnome-06:
+    needs: consolidate-gnome-05
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/NetworkManager-openvpn
+          - src/hummingbird/NetworkManager-ssh
+          - src/hummingbird/NetworkManager-vpnc
+          - src/deps/fprintd
+          - src/hummingbird/freerdp
+          - src/gnome-50/gdm
+          - src/hummingbird/gnome-bluetooth
+          - src/hummingbird/gnome-keyring
+          - src/gnome-50/gnome-online-accounts
+          - src/hummingbird/gstreamer1-plugins-good
+          - src/deps/malcontent
+          - src/hummingbird/openconnect
+          - src/hummingbird/osinfo-db
+          - src/hummingbird/pangomm2.48
+          - src/gnome-50/ptyxis
+          - src/hummingbird/udisks2
+          - src/hummingbird/webkitgtk
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier gnome-06 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-gnome-06-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-gnome-06:
+    needs: build-gnome-06
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-gnome-06-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-gnome-07:
+    needs: consolidate-gnome-06
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/NetworkManager-openconnect
+          - src/deps/evolution-data-server
+          - src/gnome-50/gnome-control-center
+          - src/hummingbird/gnome-disk-utility
+          - src/gnome-50/gnome-initial-setup
+          - src/hummingbird/gnome-remote-desktop
+          - src/hummingbird/gtkmm4.0
+          - src/hummingbird/libosinfo
+          - src/hummingbird/msgraph
+          - src/gnome-50/xdg-desktop-portal
+          - src/hummingbird/yelp
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier gnome-07 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-gnome-07-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-gnome-07:
+    needs: build-gnome-07
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-gnome-07-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-gnome-08:
+    needs: consolidate-gnome-07
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/gnome-50/gnome-shell
+          - src/hummingbird/gnome-system-monitor
+          - src/hummingbird/gvfs
+          - src/deps/localsearch
+          - src/gnome-50/xdg-desktop-portal-gnome
+          - src/hummingbird/xdg-desktop-portal-gtk
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier gnome-08 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-gnome-08-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-gnome-08:
+    needs: build-gnome-08
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-gnome-08-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-gnome-09:
+    needs: consolidate-gnome-08
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/gnome-50/nautilus
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier gnome-09 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-gnome-09-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-gnome-09:
+    needs: build-gnome-09
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-gnome-09-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-kde-00:
+    needs: consolidate-gnome-09
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/7zip
+          - src/hummingbird/PackageKit-Qt
+          - src/hummingbird/aribb24
+          - src/hummingbird/cjson
+          - src/hummingbird/desktop-backgrounds
+          - src/hummingbird/desktop-file-utils
+          - src/hummingbird/docbook-dtds
+          - src/hummingbird/docbook-style-xsl
+          - src/hummingbird/editorconfig
+          - src/hummingbird/google-noto-emoji-fonts
+          - src/hummingbird/i2c-tools
+          - src/hummingbird/imath
+          - src/hummingbird/jsoncpp
+          - src/hummingbird/kde-filesystem
+          - src/hummingbird/kf6
+          - src/hummingbird/libaribcaption
+          - src/hummingbird/libdeflate
+          - src/hummingbird/libdmtx
+          - src/hummingbird/libfyaml
+          - src/hummingbird/libmodplug
+          - src/hummingbird/libmysofa
+          - src/hummingbird/libqalculate
+          - src/hummingbird/librabbitmq
+          - src/hummingbird/libunibreak
+          - src/hummingbird/libutempter
+          - src/hummingbird/libvdpau
+          - src/hummingbird/lpcnetfreedv
+          - src/hummingbird/minizip-ng
+          - src/hummingbird/nss-mdns
+          - src/hummingbird/openapv
+          - src/hummingbird/pugixml
+          - src/hummingbird/qrencode
+          - src/hummingbird/qt6-qtserialport
+          - src/hummingbird/rust-dolby_vision
+          - src/hummingbird/serd
+          - src/hummingbird/snowball
+          - src/hummingbird/socat
+          - src/hummingbird/source-foundry-hack-fonts
+          - src/hummingbird/srt
+          - src/hummingbird/sudo
+          - src/hummingbird/tesseract-tessdata
+          - src/hummingbird/vo-amrwbenc
+          - src/hummingbird/xdg-utils
+          - src/hummingbird/xevd
+          - src/hummingbird/xeve
+          - src/hummingbird/xvidcore
+          - src/hummingbird/zimg
+          - src/hummingbird/zix
+          - src/hummingbird/zxing-cpp
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier kde-00 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-kde-00-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-kde-00:
+    needs: build-kde-00
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-kde-00-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-kde-01:
+    needs: consolidate-kde-00
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/LibRaw
+          - src/hummingbird/f44-backgrounds
+          - src/hummingbird/ilbc
+          - src/hummingbird/kde-settings
+          - src/hummingbird/kf6-attica
+          - src/hummingbird/kf6-breeze-icons
+          - src/hummingbird/kf6-karchive
+          - src/hummingbird/leptonica
+          - src/hummingbird/libass
+          - src/hummingbird/libdvdnav
+          - src/hummingbird/librist
+          - src/hummingbird/libxmlb
+          - src/hummingbird/ocean-sound-theme
+          - src/hummingbird/openexr
+          - src/deps/shaderc
+          - src/hummingbird/sord
+          - src/hummingbird/vid.stab
+          - src/hummingbird/xcb-util-image
+          - src/hummingbird/xcb-util-keysyms
+          - src/hummingbird/xcb-util-renderutil
+          - src/hummingbird/xcb-util-wm
+          - src/hummingbird/zvbi
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier kde-01 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-kde-01-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-kde-01:
+    needs: build-kde-01
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-kde-01-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-kde-02:
+    needs: consolidate-kde-01
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/ddcutil
+          - src/hummingbird/polkit-qt-1
+          - src/hummingbird/signon
+          - src/hummingbird/sratom
+          - src/hummingbird/xcb-util-cursor
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier kde-02 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-kde-02-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-kde-02:
+    needs: build-kde-02
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-kde-02-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-kde-03:
+    needs: consolidate-kde-02
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/kf6-kguiaddons
+          - src/hummingbird/kf6-kidletime
+          - src/hummingbird/qaccessibilityclient
+          - src/hummingbird/qt6-qtshadertools
+          - src/hummingbird/signon-plugin-oauth2
+          - src/hummingbird/xorg-x11-server
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier kde-03 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-kde-03-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-kde-03:
+    needs: build-kde-03
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-kde-03-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-kde-04:
+    needs: consolidate-kde-03
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/SDL3
+          - src/hummingbird/libXaw
+          - src/hummingbird/libplacebo
+          - src/hummingbird/libvpl
+          - src/hummingbird/lilv
+          - src/hummingbird/openxr
+          - src/hummingbird/poly2tri
+          - src/hummingbird/pycairo
+          - src/hummingbird/qt6-qtdeclarative
+          - src/hummingbird/sdl2-compat
+          - src/hummingbird/xorg-x11-drv-libinput
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier kde-04 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-kde-04-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-kde-04:
+    needs: build-kde-04
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-kde-04-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-kde-05:
+    needs: consolidate-kde-04
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/assimp
+          - src/hummingbird/game-music-emu
+          - src/hummingbird/gpsd
+          - src/hummingbird/kf6-bluez-qt
+          - src/hummingbird/kf6-kconfig
+          - src/hummingbird/kf6-ki18n
+          - src/hummingbird/kf6-kimageformats
+          - src/hummingbird/kf6-kitemmodels
+          - src/hummingbird/kf6-kquickcharts
+          - src/hummingbird/kf6-networkmanager-qt
+          - src/hummingbird/kf6-syntax-highlighting
+          - src/hummingbird/layer-shell-qt
+          - src/hummingbird/libaccounts-glib
+          - src/hummingbird/libbs2b
+          - src/hummingbird/libopenmpt
+          - src/hummingbird/libsamplerate
+          - src/hummingbird/passim
+          - src/hummingbird/qt6-qt5compat
+          - src/hummingbird/qt6-qtpositioning
+          - src/hummingbird/qt6-qtquicktimeline
+          - src/hummingbird/qt6-qttools
+          - src/hummingbird/qt6-qtvirtualkeyboard
+          - src/hummingbird/qt6-qtwayland
+          - src/hummingbird/qt6-qtwebsockets
+          - src/hummingbird/tesseract
+          - src/hummingbird/unity-gtk-module
+          - src/hummingbird/xmessage
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier kde-05 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-kde-05-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-kde-05:
+    needs: build-kde-05
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-kde-05-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-kde-06:
+    needs: consolidate-kde-05
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/appstream
+          - src/hummingbird/codec2
+          - src/hummingbird/fwupd
+          - src/hummingbird/kdegraphics-mobipocket
+          - src/hummingbird/kdsoap
+          - src/hummingbird/kf6-kcodecs
+          - src/hummingbird/kf6-kcolorscheme
+          - src/hummingbird/kf6-kcoreaddons
+          - src/hummingbird/kf6-kdbusaddons
+          - src/hummingbird/kf6-kdnssd
+          - src/hummingbird/kf6-kdoctools
+          - src/hummingbird/kf6-kholidays
+          - src/hummingbird/kf6-kirigami
+          - src/hummingbird/kf6-kitemviews
+          - src/hummingbird/kf6-knotifications
+          - src/hummingbird/kf6-kunitconversion
+          - src/hummingbird/kf6-kuserfeedback
+          - src/hummingbird/kf6-kwidgetsaddons
+          - src/hummingbird/kf6-kwindowsystem
+          - src/hummingbird/kf6-solid
+          - src/hummingbird/libaccounts-qt
+          - src/hummingbird/libkexiv2
+          - src/hummingbird/libkscreen
+          - src/hummingbird/qcoro
+          - src/hummingbird/qt6-qtlocation
+          - src/hummingbird/qt6-qtquick3d
+          - src/hummingbird/qt6-qtwebchannel
+          - src/hummingbird/qtkeychain
+          - src/hummingbird/rubberband
+          - src/hummingbird/sddm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier kde-06 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-kde-06-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-kde-06:
+    needs: build-kde-06
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-kde-06-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-kde-07:
+    needs: consolidate-kde-06
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/accounts-qml-module
+          - src/hummingbird/chromaprint
+          - src/hummingbird/ffmpeg
+          - src/hummingbird/kdecoration
+          - src/hummingbird/kdsoap-ws-discovery-client
+          - src/hummingbird/kf6-kauth
+          - src/hummingbird/kf6-kcompletion
+          - src/hummingbird/kf6-kconfigwidgets
+          - src/hummingbird/kf6-kcrash
+          - src/hummingbird/kf6-kjobwidgets
+          - src/hummingbird/kf6-kpackage
+          - src/hummingbird/kf6-kpty
+          - src/hummingbird/kf6-kstatusnotifieritem
+          - src/hummingbird/kf6-ksvg
+          - src/hummingbird/kf6-sonnet
+          - src/hummingbird/knighttime
+          - src/hummingbird/kwayland
+          - src/hummingbird/plasma-activities
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier kde-07 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-kde-07-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-kde-07:
+    needs: build-kde-07
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-kde-07-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-kde-08:
+    needs: consolidate-kde-07
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/kf6-kfilemetadata
+          - src/hummingbird/kf6-kglobalaccel
+          - src/hummingbird/kf6-kiconthemes
+          - src/hummingbird/kf6-kservice
+          - src/hummingbird/kpipewire
+          - src/hummingbird/kwrited
+          - src/hummingbird/plasma-activities-stats
+          - src/hummingbird/qt6-qtwebengine
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier kde-08 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-kde-08-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-kde-08:
+    needs: build-kde-08
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-kde-08-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-kde-09:
+    needs: consolidate-kde-08
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/kf6-kded
+          - src/hummingbird/kf6-kdesu
+          - src/hummingbird/kf6-kirigami-addons
+          - src/hummingbird/kf6-kwallet
+          - src/hummingbird/kf6-kxmlgui
+          - src/hummingbird/kf6-qqc2-desktop-style
+          - src/hummingbird/qqc2-breeze-style
+          - src/hummingbird/qt6-qtwebview
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier kde-09 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-kde-09-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-kde-09:
+    needs: build-kde-09
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-kde-09-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-kde-10:
+    needs: consolidate-kde-09
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/kf6-kbookmarks
+          - src/hummingbird/ksshaskpass
+          - src/hummingbird/qt6-qtmultimedia
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier kde-10 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-kde-10-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-kde-10:
+    needs: build-kde-10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-kde-10-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-kde-11:
+    needs: consolidate-kde-10
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/kf6-kio
+          - src/hummingbird/kf6-prison
+          - src/hummingbird/qt6-qtspeech
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier kde-11 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-kde-11-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-kde-11:
+    needs: build-kde-11
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-kde-11-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-kde-12:
+    needs: consolidate-kde-11
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/kactivitymanagerd
+          - src/hummingbird/kf6-baloo
+          - src/hummingbird/kf6-kcmutils
+          - src/hummingbird/kf6-kdeclarative
+          - src/hummingbird/kf6-knotifyconfig
+          - src/hummingbird/kf6-krunner
+          - src/hummingbird/kf6-ktextwidgets
+          - src/hummingbird/kf6-syndication
+          - src/hummingbird/kglobalacceld
+          - src/hummingbird/kmenuedit
+          - src/hummingbird/plasma-integration
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier kde-12 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-kde-12-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-kde-12:
+    needs: build-kde-12
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-kde-12-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-kde-13:
+    needs: consolidate-kde-12
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/baloo-widgets
+          - src/hummingbird/kaccounts-integration
+          - src/hummingbird/kf6-knewstuff
+          - src/hummingbird/kf6-kparts
+          - src/hummingbird/kio-extras
+          - src/hummingbird/ksystemlog
+          - src/hummingbird/polkit-kde
+          - src/hummingbird/xdg-desktop-portal-kde
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier kde-13 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-kde-13-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-kde-13:
+    needs: build-kde-13
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-kde-13-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-kde-14:
+    needs: consolidate-kde-13
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/ark
+          - src/hummingbird/aurorae
+          - src/hummingbird/dolphin
+          - src/hummingbird/keditbookmarks
+          - src/hummingbird/kf6-frameworkintegration
+          - src/hummingbird/kf6-ktexteditor
+          - src/hummingbird/kf6-purpose
+          - src/hummingbird/kio-fuse
+          - src/hummingbird/konsole
+          - src/hummingbird/libksysguard
+          - src/hummingbird/libplasma
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier kde-14 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-kde-14-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-kde-14:
+    needs: build-kde-14
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-kde-14-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-kde-15:
+    needs: consolidate-kde-14
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/kate
+          - src/hummingbird/kscreenlocker
+          - src/hummingbird/ksystemstats
+          - src/hummingbird/plasma-breeze
+          - src/hummingbird/plasma-discover
+          - src/hummingbird/plasma-keyboard
+          - src/hummingbird/plasma5support
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier kde-15 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-kde-15-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-kde-15:
+    needs: build-kde-15
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-kde-15-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-kde-16:
+    needs: consolidate-kde-15
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/kwin
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier kde-16 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-kde-16-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-kde-16:
+    needs: build-kde-16
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-kde-16-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-kde-17:
+    needs: consolidate-kde-16
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/plasma-workspace
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier kde-17 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-kde-17-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-kde-17:
+    needs: build-kde-17
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-kde-17-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-kde-18:
+    needs: consolidate-kde-17
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/kde-cli-tools
+          - src/hummingbird/plasma-desktop
+          - src/hummingbird/plasma-systemsettings
+          - src/hummingbird/powerdevil
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier kde-18 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-kde-18-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-kde-18:
+    needs: build-kde-18
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-kde-18-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-cosmic-00:
+    needs: consolidate-kde-18
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/acpid
+          - src/hummingbird/adobe-mappings-cmap
+          - src/hummingbird/adobe-mappings-pdf
+          - src/hummingbird/adobe-source-code-pro-fonts
+          - src/hummingbird/adw-gtk3-theme
+          - src/hummingbird/autoconf-archive
+          - src/hummingbird/byacc
+          - src/hummingbird/chrpath
+          - src/hummingbird/cosmic-config-fedora
+          - src/hummingbird/cosmic-wallpapers
+          - src/hummingbird/dejavu-fonts
+          - src/hummingbird/dmidecode
+          - src/hummingbird/docbook5-style-xsl
+          - src/hummingbird/gc
+          - src/hummingbird/gflags
+          - src/hummingbird/google-droid-fonts
+          - src/hummingbird/google-roboto-slab-fonts
+          - src/hummingbird/gtest
+          - src/hummingbird/hdparm
+          - src/hummingbird/isns-utils
+          - src/hummingbird/itstool
+          - src/hummingbird/jbig2dec
+          - src/hummingbird/lato-fonts
+          - src/hummingbird/libell
+          - src/hummingbird/libid3tag
+          - src/hummingbird/libijs
+          - src/hummingbird/liblqr-1
+          - src/hummingbird/libmad
+          - src/hummingbird/libnfs
+          - src/hummingbird/libraw1394
+          - src/hummingbird/libusb-compat-0.1
+          - src/hummingbird/libvarlink
+          - src/hummingbird/lynx
+          - src/hummingbird/mandoc
+          - src/hummingbird/openfec
+          - src/hummingbird/pam_wrapper
+          - src/hummingbird/perl-ExtUtils-MakeMaker
+          - src/hummingbird/perl-Fedora-VSP
+          - src/hummingbird/perl-JSON-PP
+          - src/hummingbird/perl-Math-BigInt
+          - src/hummingbird/perl-Module-Metadata
+          - src/hummingbird/perl-Term-Table
+          - src/hummingbird/perl-Test-Harness
+          - src/hummingbird/perl-Test-Simple
+          - src/hummingbird/perl-generators
+          - src/hummingbird/perl-version
+          - src/hummingbird/pop-icon-theme
+          - src/hummingbird/python-docutils
+          - src/hummingbird/python-imagesize
+          - src/hummingbird/python-linux-procfs
+          - src/hummingbird/python-lxml
+          - src/hummingbird/python-mako
+          - src/hummingbird/python-markdown
+          - src/hummingbird/python-ptyprocess
+          - src/hummingbird/python-pyinotify
+          - src/hummingbird/python-pyudev
+          - src/hummingbird/python-rdflib
+          - src/hummingbird/python-roman-numerals
+          - src/hummingbird/python-setuptools_scm
+          - src/hummingbird/python-sphinx-theme-alabaster
+          - src/hummingbird/qt5-qtsvg
+          - src/hummingbird/rubygem-asciidoctor
+          - src/hummingbird/rust-bindgen-cli
+          - src/hummingbird/rust-cargo-c
+          - src/hummingbird/rust-cbindgen
+          - src/hummingbird/rust-fd-find
+          - src/hummingbird/rust-just
+          - src/hummingbird/rust-mdbook
+          - src/hummingbird/scdoc
+          - src/hummingbird/slang
+          - src/hummingbird/spirv-headers
+          - src/hummingbird/ttembed
+          - src/hummingbird/virt-what
+          - src/hummingbird/vulkan-headers
+          - src/hummingbird/xmlrpc-c
+          - src/hummingbird/xorg-x11-proto-devel
+          - src/hummingbird/xorg-x11-util-macros
+          - src/hummingbird/xwayland-run
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier cosmic-00 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-cosmic-00-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-cosmic-00:
+    needs: build-cosmic-00
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-cosmic-00-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-cosmic-01:
+    needs: consolidate-cosmic-00
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/cosmic-icon-theme
+          - src/hummingbird/dbus-glib
+          - src/hummingbird/docbook-style-dsssl
+          - src/hummingbird/fontawesome4-fonts
+          - src/hummingbird/greetd
+          - src/hummingbird/guile22
+          - src/hummingbird/help2man
+          - src/hummingbird/libXres
+          - src/hummingbird/libdaemon
+          - src/hummingbird/libdb
+          - src/hummingbird/libiec61883
+          - src/hummingbird/libsigc++20
+          - src/hummingbird/libultrahdr
+          - src/hummingbird/mingw-filesystem
+          - src/hummingbird/nkf
+          - src/hummingbird/open-sans-fonts
+          - src/hummingbird/perl-Class-Inspector
+          - src/hummingbird/perl-Clone
+          - src/hummingbird/perl-Compress-Raw-Bzip2
+          - src/hummingbird/perl-Compress-Raw-Zlib
+          - src/hummingbird/perl-Data-Dump
+          - src/hummingbird/perl-Digest-SHA
+          - src/hummingbird/perl-Encode-Locale
+          - src/hummingbird/perl-HTML-Tagset
+          - src/hummingbird/perl-IO-HTML
+          - src/hummingbird/perl-LWP-MediaTypes
+          - src/hummingbird/perl-Module-CoreList
+          - src/hummingbird/perl-Module-Load
+          - src/hummingbird/perl-Params-Check
+          - src/hummingbird/perl-SGMLSpm
+          - src/hummingbird/perl-Text-Unidecode
+          - src/hummingbird/perl-TimeDate
+          - src/hummingbird/perl-Try-Tiny
+          - src/hummingbird/perl-Unicode-EastAsianWidth
+          - src/hummingbird/perl-Unicode-Normalize
+          - src/hummingbird/perl-WWW-RobotRules
+          - src/hummingbird/perl-XML-NamespaceSupport
+          - src/hummingbird/perl-XML-SAX-Base
+          - src/hummingbird/perl-bignum
+          - src/hummingbird/python-pexpect
+          - src/hummingbird/seatd
+          - src/hummingbird/valgrind
+          - src/hummingbird/xorg-x11-xtrans-devel
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier cosmic-01 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-cosmic-01-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-cosmic-01:
+    needs: build-cosmic-01
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-cosmic-01-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-cosmic-02:
+    needs: consolidate-cosmic-01
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/autogen
+          - src/hummingbird/bison
+          - src/hummingbird/flex
+          - src/hummingbird/glslang
+          - src/hummingbird/libpaper
+          - src/hummingbird/mingw-headers
+          - src/hummingbird/perl-Digest-HMAC
+          - src/hummingbird/perl-File-ShareDir
+          - src/hummingbird/perl-HTTP-Date
+          - src/hummingbird/perl-IO-Compress
+          - src/hummingbird/perl-Module-Load-Conditional
+          - src/hummingbird/perl-XML-SAX
+          - src/hummingbird/spirv-llvm-translator
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier cosmic-02 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-cosmic-02-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-cosmic-02:
+    needs: build-cosmic-02
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-cosmic-02-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-cosmic-03:
+    needs: consolidate-cosmic-02
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/augeas
+          - src/hummingbird/iscsi-initiator-utils
+          - src/hummingbird/libclc
+          - src/hummingbird/perl-File-Listing
+          - src/hummingbird/perl-HTTP-Message
+          - src/hummingbird/perl-IPC-Cmd
+          - src/hummingbird/perl-NTLM
+          - src/hummingbird/perl-Net-HTTP
+          - src/hummingbird/perl-libintl-perl
+          - src/hummingbird/swig
+          - src/hummingbird/xmlto
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier cosmic-03 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-cosmic-03-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-cosmic-03:
+    needs: build-cosmic-03
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-cosmic-03-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-cosmic-04:
+    needs: consolidate-cosmic-03
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/libteam
+          - src/hummingbird/ndctl
+          - src/hummingbird/perl-HTML-Parser
+          - src/hummingbird/perl-HTTP-Cookies
+          - src/hummingbird/perl-HTTP-Negotiate
+          - src/hummingbird/texinfo
+          - src/hummingbird/zziplib
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier cosmic-04 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-cosmic-04-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-cosmic-04:
+    needs: build-cosmic-04
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-cosmic-04-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-cosmic-05:
+    needs: consolidate-cosmic-04
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/cln
+          - src/hummingbird/cosmic-randr
+          - src/hummingbird/gpm
+          - src/hummingbird/libconfig
+          - src/hummingbird/mingw-binutils
+          - src/hummingbird/perl-libwww-perl
+          - src/deps/wayland-protocols
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier cosmic-05 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-cosmic-05-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-cosmic-05:
+    needs: build-cosmic-05
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-cosmic-05-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-cosmic-06:
+    needs: consolidate-cosmic-05
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/mingw-crt
+          - src/hummingbird/mingw-gcc
+          - src/hummingbird/mingw-winpthreads
+          - src/hummingbird/perl-XML-Parser
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier cosmic-06 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-cosmic-06-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-cosmic-06:
+    needs: build-cosmic-06
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-cosmic-06-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-cosmic-07:
+    needs: consolidate-cosmic-06
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/DirectX-Headers
+          - src/hummingbird/check
+          - src/hummingbird/glibmm2.4
+          - src/hummingbird/intltool
+          - src/hummingbird/mingw-brotli
+          - src/hummingbird/mingw-libffi
+          - src/hummingbird/mingw-libidn2
+          - src/hummingbird/mingw-libogg
+          - src/hummingbird/mingw-libunistring
+          - src/hummingbird/mingw-pcre2
+          - src/hummingbird/mingw-termcap
+          - src/hummingbird/mingw-win-iconv
+          - src/hummingbird/mingw-zlib
+          - src/hummingbird/mingw-zstd
+          - src/hummingbird/perl-XML-Simple
+          - src/hummingbird/perl-XML-XPath
+          - src/hummingbird/subunit
+          - src/hummingbird/xmltoman
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier cosmic-07 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-cosmic-07-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-cosmic-07:
+    needs: build-cosmic-07
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-cosmic-07-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-cosmic-08:
+    needs: consolidate-cosmic-07
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/cosmic-bg
+          - src/hummingbird/cosmic-idle
+          - src/hummingbird/cosmic-notifications
+          - src/hummingbird/cosmic-panel
+          - src/hummingbird/icon-naming-utils
+          - src/hummingbird/libxml++30
+          - src/hummingbird/mingw-gettext
+          - src/hummingbird/mingw-libpng
+          - src/hummingbird/mingw-libpsl
+          - src/hummingbird/mingw-sqlite
+          - src/hummingbird/opusfile
+          - src/hummingbird/parted
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier cosmic-08 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-cosmic-08-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-cosmic-08:
+    needs: build-cosmic-08
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-cosmic-08-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-cosmic-09:
+    needs: consolidate-cosmic-08
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/mingw-glib2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier cosmic-09 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-cosmic-09-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-cosmic-09:
+    needs: build-cosmic-09
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-cosmic-09-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-cosmic-10:
+    needs: consolidate-cosmic-09
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/ImageMagick
+          - src/hummingbird/asciidoc
+          - src/hummingbird/babel
+          - src/hummingbird/dbus-python
+          - src/hummingbird/docbook-utils
+          - src/hummingbird/emacs
+          - src/hummingbird/firewalld
+          - src/hummingbird/ghostscript
+          - src/deps/gi-docgen
+          - src/hummingbird/gtk-doc
+          - src/hummingbird/gtk2
+          - src/hummingbird/jack-audio-connection-kit
+          - src/hummingbird/libao
+          - src/hummingbird/libappstream-glib
+          - src/hummingbird/libcamera
+          - src/hummingbird/libdbi
+          - src/hummingbird/libffado
+          - src/hummingbird/libraqm
+          - src/hummingbird/libwmf
+          - src/hummingbird/lirc
+          - src/hummingbird/lttng-ust
+          - src/hummingbird/lv2
+          - src/hummingbird/mesa-libGLU
+          - src/hummingbird/mingw-lcms2
+          - src/hummingbird/mingw-libjpeg-turbo
+          - src/hummingbird/mingw-libtiff
+          - src/hummingbird/nasm
+          - src/hummingbird/newt
+          - src/hummingbird/openjade
+          - src/hummingbird/opensp
+          - src/hummingbird/portaudio
+          - src/deps/python-dbusmock
+          - src/deps/python-smartypants
+          - src/hummingbird/python-sphinx
+          - src/hummingbird/python-sphinx_rtd_theme
+          - src/deps/python-typogrify
+          - src/hummingbird/redhat-fonts
+          - src/hummingbird/roc-toolkit
+          - src/hummingbird/rrdtool
+          - src/hummingbird/sox
+          - src/hummingbird/systemtap
+          - src/hummingbird/texlive-base
+          - src/hummingbird/texlive-collection-basic
+          - src/hummingbird/texlive-collection-fontsrecommended
+          - src/hummingbird/texlive-collection-latex
+          - src/hummingbird/texlive-collection-latexextra
+          - src/hummingbird/texlive-collection-latexrecommended
+          - src/deps/umockdev
+          - src/hummingbird/urw-base35-fonts
+          - src/hummingbird/vala
+          - src/hummingbird/weston
+          - src/hummingbird/xpdf
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier cosmic-10 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-cosmic-10-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-cosmic-10:
+    needs: build-cosmic-10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-cosmic-10-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-cosmic-11:
+    needs: consolidate-cosmic-10
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/cosmic-app-library
+          - src/hummingbird/cosmic-applets
+          - src/hummingbird/cosmic-comp
+          - src/hummingbird/cosmic-files
+          - src/hummingbird/cosmic-greeter
+          - src/hummingbird/cosmic-launcher
+          - src/hummingbird/cosmic-osd
+          - src/hummingbird/cosmic-screenshot
+          - src/hummingbird/cosmic-session
+          - src/hummingbird/cosmic-settings
+          - src/hummingbird/cosmic-settings-daemon
+          - src/hummingbird/cosmic-term
+          - src/hummingbird/cosmic-workspaces
+          - src/hummingbird/ethtool
+          - src/hummingbird/gnome-icon-theme
+          - src/hummingbird/libdbusmenu
+          - src/deps/libglib-testing
+          - src/hummingbird/pop-launcher
+          - src/hummingbird/pyparsing
+          - src/hummingbird/satyr
+          - src/hummingbird/texlive-collection-langgerman
+          - src/hummingbird/tuned
+          - src/hummingbird/w3m
+          - src/hummingbird/xdg-desktop-portal-cosmic
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier cosmic-11 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-cosmic-11-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-cosmic-11:
+    needs: build-cosmic-11
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-cosmic-11-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-cosmic-12:
+    needs: consolidate-cosmic-11
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/deps/flatpak
+          - src/hummingbird/libappindicator
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier cosmic-12 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-cosmic-12-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-cosmic-12:
+    needs: build-cosmic-12
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-cosmic-12-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-cosmic-13:
+    needs: consolidate-cosmic-12
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/cosmic-initial-setup
+          - src/hummingbird/network-manager-applet
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier cosmic-13 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-cosmic-13-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-cosmic-13:
+    needs: build-cosmic-13
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-cosmic-13-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-niri-00:
+    needs: consolidate-cosmic-13
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/AMF
+          - src/hummingbird/CharLS
+          - src/hummingbird/Cython
+          - src/hummingbird/asl
+          - src/hummingbird/blosc
+          - src/hummingbird/brightnessctl
+          - src/hummingbird/catch
+          - src/hummingbird/cfitsio
+          - src/hummingbird/cliquer
+          - src/hummingbird/cmocka
+          - src/hummingbird/decklink
+          - src/hummingbird/enca
+          - src/hummingbird/faad2
+          - src/hummingbird/fdupes
+          - src/hummingbird/flexiblas
+          - src/hummingbird/fluid-soundfont
+          - src/hummingbird/ghc-pandoc
+          - src/hummingbird/iniparser
+          - src/hummingbird/kde-qdoc-common
+          - src/hummingbird/langtable
+          - src/hummingbird/laszip
+          - src/hummingbird/libaec
+          - src/hummingbird/libdca
+          - src/hummingbird/libgdither
+          - src/hummingbird/libgta
+          - src/hummingbird/libharu
+          - src/hummingbird/libklvanc
+          - src/hummingbird/libmicrodns
+          - src/hummingbird/libmpcdec
+          - src/hummingbird/libmpdclient
+          - src/hummingbird/libsass
+          - src/hummingbird/luajit
+          - src/hummingbird/mm-common
+          - src/hummingbird/muParser
+          - src/hummingbird/nettle3.10
+          - src/hummingbird/nv-codec-headers
+          - src/hummingbird/opencl-headers
+          - src/hummingbird/pps-tools
+          - src/hummingbird/pyserial
+          - src/hummingbird/python-aiodns
+          - src/hummingbird/python-click
+          - src/hummingbird/python-configobj
+          - src/hummingbird/python-decorator
+          - src/hummingbird/python-pyproject-hooks
+          - src/hummingbird/python-setproctitle
+          - src/hummingbird/python-six
+          - src/hummingbird/python-trove-classifiers
+          - src/hummingbird/pytz
+          - src/hummingbird/qt5-qtdeclarative
+          - src/hummingbird/qt5-qtserialport
+          - src/hummingbird/qt5-qtx11extras
+          - src/hummingbird/qt6-doc
+          - src/hummingbird/qt6-qtlanguageserver
+          - src/hummingbird/rpcsvc-proto
+          - src/hummingbird/rtmpdump
+          - src/hummingbird/rust-askalono-cli
+          - src/hummingbird/rust-matugen
+          - src/hummingbird/scons
+          - src/hummingbird/soundtouch
+          - src/hummingbird/stb
+          - src/hummingbird/teckit
+          - src/hummingbird/tllist
+          - src/hummingbird/userspace-rcu
+          - src/hummingbird/utf8cpp
+          - src/hummingbird/wildmidi
+          - src/hummingbird/yajl
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier niri-00 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-niri-00-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-niri-00:
+    needs: build-niri-00
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-niri-00-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-niri-01:
+    needs: consolidate-niri-00
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/arpack
+          - src/hummingbird/bdftopcf
+          - src/hummingbird/cli11
+          - src/hummingbird/earcut-hpp
+          - src/hummingbird/gavl
+          - src/hummingbird/libXScrnSaver
+          - src/hummingbird/libavc1394
+          - src/hummingbird/libavtp
+          - src/hummingbird/libmng
+          - src/hummingbird/openvr
+          - src/hummingbird/pandoc-cli
+          - src/hummingbird/python-click-log
+          - src/hummingbird/python-click-threading
+          - src/hummingbird/python-gssapi
+          - src/hummingbird/python-hatchling
+          - src/hummingbird/python-regex
+          - src/hummingbird/qhull
+          - src/hummingbird/qt5-qtsensors
+          - src/hummingbird/qt5-qtwebsockets
+          - src/hummingbird/qt5-qtxmlpatterns
+          - src/hummingbird/quota
+          - src/hummingbird/sassc
+          - src/hummingbird/suitesparse
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier niri-01 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-niri-01-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-niri-01:
+    needs: build-niri-01
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-niri-01-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-niri-02:
+    needs: consolidate-niri-01
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/armadillo
+          - src/hummingbird/glpk
+          - src/hummingbird/libdc1394
+          - src/hummingbird/python-dns
+          - src/hummingbird/python-expandvars
+          - src/hummingbird/python-re-assert
+          - src/hummingbird/python-requests-gssapi
+          - src/hummingbird/python-wcwidth
+          - src/hummingbird/qt5-qtwebchannel
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier niri-02 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-niri-02-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-niri-02:
+    needs: build-niri-02
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-niri-02-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-niri-03:
+    needs: consolidate-niri-02
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/coin-or-CoinUtils
+          - src/hummingbird/python-frozenlist
+          - src/hummingbird/sombok
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier niri-03 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-niri-03-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-niri-03:
+    needs: build-niri-03
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-niri-03-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-niri-04:
+    needs: consolidate-niri-03
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/coin-or-Osi
+          - src/hummingbird/perl-ExtUtils-Install
+          - src/hummingbird/perl-ExtUtils-Manifest
+          - src/hummingbird/perl-ExtUtils-ParseXS
+          - src/hummingbird/perl-MIME-Charset
+          - src/hummingbird/perl-Unicode-LineBreak
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier niri-04 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-niri-04-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-niri-04:
+    needs: build-niri-04
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-niri-04-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-niri-05:
+    needs: consolidate-niri-04
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/latexmk
+          - src/hummingbird/perl-Algorithm-Diff
+          - src/hummingbird/perl-Business-ISBN-Data
+          - src/hummingbird/perl-Business-ISSN
+          - src/hummingbird/perl-Class-Accessor
+          - src/hummingbird/perl-Class-Data-Inheritable
+          - src/hummingbird/perl-Class-Method-Modifiers
+          - src/hummingbird/perl-Class-Singleton
+          - src/hummingbird/perl-Clone-PP
+          - src/hummingbird/perl-Compress-Raw-Lzma
+          - src/hummingbird/perl-Convert-ASN1
+          - src/hummingbird/perl-Crypt-URandom
+          - src/hummingbird/perl-Data-Uniqid
+          - src/hummingbird/perl-Date-ISO8601
+          - src/hummingbird/perl-Date-Manip
+          - src/hummingbird/perl-Devel-StackTrace
+          - src/hummingbird/perl-DynaLoader-Functions
+          - src/hummingbird/perl-Email-Date-Format
+          - src/hummingbird/perl-File-Slurper
+          - src/hummingbird/perl-GSSAPI
+          - src/hummingbird/perl-Getopt-Tabular
+          - src/hummingbird/perl-IO-String
+          - src/hummingbird/perl-IPC-Run3
+          - src/hummingbird/perl-IPC-SysV
+          - src/hummingbird/perl-JSON
+          - src/hummingbird/perl-Lingua-Translit
+          - src/hummingbird/perl-List-UtilsBy
+          - src/hummingbird/perl-MRO-Compat
+          - src/hummingbird/perl-Module-Runtime
+          - src/hummingbird/perl-Mozilla-CA
+          - src/hummingbird/perl-Net-SMTP-SSL
+          - src/hummingbird/perl-Number-Compare
+          - src/hummingbird/perl-PadWalker
+          - src/hummingbird/perl-Params-Util
+          - src/hummingbird/perl-Parse-Yapp
+          - src/hummingbird/perl-Ref-Util-XS
+          - src/hummingbird/perl-Regexp-Common
+          - src/hummingbird/perl-Sort-Key
+          - src/hummingbird/perl-Sub-Install
+          - src/hummingbird/perl-Sys-Hostname-Long
+          - src/hummingbird/perl-Sys-Syslog
+          - src/hummingbird/perl-Text-Balanced
+          - src/hummingbird/perl-Text-CSV
+          - src/hummingbird/perl-Text-Glob
+          - src/hummingbird/perl-Text-Roman
+          - src/hummingbird/perl-Text-Soundex
+          - src/hummingbird/perl-Tie-Cycle
+          - src/hummingbird/perl-Tie-RefHash
+          - src/hummingbird/perl-Variable-Magic
+          - src/hummingbird/perl-XString
+          - src/hummingbird/perl-autovivification
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier niri-05 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-niri-05-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-niri-05:
+    needs: build-niri-05
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-niri-05-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-niri-06:
+    needs: consolidate-niri-05
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/metis
+          - src/hummingbird/nauty
+          - src/hummingbird/perl-Business-ISBN
+          - src/hummingbird/perl-Business-ISMN
+          - src/hummingbird/perl-Data-OptList
+          - src/hummingbird/perl-Devel-CallChecker
+          - src/hummingbird/perl-Devel-Caller
+          - src/hummingbird/perl-Dist-CheckConflicts
+          - src/hummingbird/perl-Exception-Class
+          - src/hummingbird/perl-File-Find-Rule
+          - src/hummingbird/perl-MIME-Lite
+          - src/hummingbird/perl-Mail-Sender
+          - src/hummingbird/perl-Mail-Sendmail
+          - src/hummingbird/perl-MailTools
+          - src/hummingbird/perl-Module-Implementation
+          - src/hummingbird/perl-Package-Generator
+          - src/hummingbird/perl-Package-Stash-XS
+          - src/hummingbird/perl-Parse-RecDescent
+          - src/hummingbird/perl-Ref-Util
+          - src/hummingbird/perl-Role-Tiny
+          - src/hummingbird/perl-Text-BibTeX
+          - src/hummingbird/perl-Text-Diff
+          - src/hummingbird/perl-Unicode-Collate
+          - src/hummingbird/perl-XML-Writer
+          - src/hummingbird/perl-autodie
+          - src/hummingbird/rapidjson
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier niri-06 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-niri-06-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-niri-06:
+    needs: build-niri-06
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-niri-06-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-niri-07:
+    needs: consolidate-niri-06
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/hdf
+          - src/hummingbird/libpq
+          - src/hummingbird/perl-Authen-SASL
+          - src/hummingbird/perl-Data-Compare
+          - src/hummingbird/perl-Devel-LexAlias
+          - src/hummingbird/perl-IO-Compress-Lzma
+          - src/hummingbird/perl-IO-Zlib
+          - src/hummingbird/perl-List-SomeUtils
+          - src/hummingbird/perl-Package-Stash
+          - src/hummingbird/perl-Params-Classify
+          - src/hummingbird/perl-Params-Validate
+          - src/hummingbird/perl-Sub-Exporter
+          - src/hummingbird/qt5-qtlocation
+          - src/hummingbird/scotch
+          - src/hummingbird/unixODBC
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier niri-07 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-niri-07-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-niri-07:
+    needs: build-niri-07
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-niri-07-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-niri-08:
+    needs: consolidate-niri-07
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/MUMPS
+          - src/hummingbird/netcdf
+          - src/hummingbird/perl-Archive-Tar
+          - src/hummingbird/perl-DateTime-TimeZone-SystemV
+          - src/hummingbird/perl-List-AllUtils
+          - src/hummingbird/perl-Sub-Exporter-Progressive
+          - src/hummingbird/perl-XML-LibXML
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier niri-08 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-niri-08-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-niri-08:
+    needs: build-niri-08
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-niri-08-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-niri-09:
+    needs: consolidate-niri-08
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/bc
+          - src/hummingbird/coin-or-Cbc
+          - src/hummingbird/coin-or-Cgl
+          - src/hummingbird/coin-or-Clp
+          - src/hummingbird/perl-B-Hooks-EndOfScope
+          - src/hummingbird/perl-DateTime-TimeZone-Tzfile
+          - src/hummingbird/perl-Devel-GlobalDestruction
+          - src/hummingbird/perl-XML-LibXML-Simple
+          - src/hummingbird/perl-XML-LibXSLT
+          - src/hummingbird/perltidy
+          - src/hummingbird/pyxdg
+          - src/hummingbird/xwayland-satellite
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier niri-09 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-niri-09-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-niri-09:
+    needs: build-niri-09
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-niri-09-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-niri-10:
+    needs: consolidate-niri-09
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/perl-Eval-Closure
+          - src/hummingbird/perl-LDAP
+          - src/hummingbird/perl-LWP-Protocol-https
+          - src/hummingbird/perl-namespace-clean
+          - src/hummingbird/swayidle
+          - src/hummingbird/wl-clipboard
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier niri-10 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-niri-10-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-niri-10:
+    needs: build-niri-10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-niri-10-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-niri-11:
+    needs: consolidate-niri-10
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/geos
+          - src/hummingbird/jxrlib
+          - src/hummingbird/mingw-bzip2
+          - src/hummingbird/mingw-gmp
+          - src/hummingbird/mingw-xz
+          - src/hummingbird/perl-namespace-autoclean
+          - src/hummingbird/xerces-c
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier niri-11 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-niri-11-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-niri-11:
+    needs: build-niri-11
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-niri-11-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-niri-12:
+    needs: consolidate-niri-11
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/freexl
+          - src/hummingbird/libkml
+          - src/hummingbird/librttopo
+          - src/hummingbird/mingw-nettle
+          - src/hummingbird/perl-Specio
+          - src/hummingbird/qt6-qtnetworkauth
+          - src/hummingbird/qt6-qtserialbus
+          - src/hummingbird/xfsprogs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier niri-12 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-niri-12-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-niri-12:
+    needs: build-niri-12
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-niri-12-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-niri-13:
+    needs: consolidate-niri-12
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/mingw-libxml2
+          - src/hummingbird/perl-Params-ValidationCompiler
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier niri-13 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-niri-13-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-niri-13:
+    needs: build-niri-13
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-niri-13-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-niri-14:
+    needs: consolidate-niri-13
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/mingw-json-glib
+          - src/hummingbird/mingw-libarchive
+          - src/hummingbird/mingw-libxslt
+          - src/hummingbird/perl-DateTime-Locale
+          - src/hummingbird/perl-DateTime-TimeZone
+          - src/hummingbird/perl-Log-Dispatch
+          - src/hummingbird/qt6-qtcharts
+          - src/hummingbird/qt6-qtdatavis3d
+          - src/hummingbird/qt6-qtremoteobjects
+          - src/hummingbird/qt6-qtscxml
+          - src/hummingbird/qt6-qtsensors
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier niri-14 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-niri-14-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-niri-14:
+    needs: build-niri-14
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-niri-14-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-niri-15:
+    needs: consolidate-niri-14
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/PDAL
+          - src/hummingbird/alembic
+          - src/hummingbird/bullet
+          - src/hummingbird/cepces
+          - src/hummingbird/cgnslib
+          - src/hummingbird/dblatex
+          - src/hummingbird/dbus-c++
+          - src/hummingbird/efl
+          - src/hummingbird/fish
+          - src/hummingbird/fluidsynth
+          - src/hummingbird/freeglut
+          - src/hummingbird/frei0r-plugins
+          - src/hummingbird/gdal
+          - src/hummingbird/gdcm
+          - src/hummingbird/jasper
+          - src/hummingbird/ladspa
+          - src/hummingbird/libcaca
+          - src/hummingbird/libdicom
+          - src/hummingbird/libgeotiff
+          - src/hummingbird/liblas
+          - src/hummingbird/liblrdf
+          - src/hummingbird/libspatialite
+          - src/hummingbird/libspectre
+          - src/hummingbird/libsrtp
+          - src/hummingbird/mjpegtools
+          - src/hummingbird/netpbm
+          - src/hummingbird/ocl-icd
+          - src/hummingbird/openal-soft
+          - src/hummingbird/opencascade
+          - src/hummingbird/opencv
+          - src/hummingbird/openslide
+          - src/hummingbird/perl-DateTime
+          - src/hummingbird/perl-Log-Dispatch-FileRotate
+          - src/hummingbird/proj
+          - src/hummingbird/python-accessible-pygments
+          - src/hummingbird/python-beautifulsoup4
+          - src/hummingbird/python-breathe
+          - src/hummingbird/python-build
+          - src/hummingbird/python-cssselect
+          - src/hummingbird/python-dateutil
+          - src/hummingbird/python-execnet
+          - src/hummingbird/python-freezegun
+          - src/hummingbird/python-furo
+          - src/hummingbird/python-hatch-fancy-pypi-readme
+          - src/hummingbird/python-hatch-vcs
+          - src/hummingbird/python-html5lib
+          - src/hummingbird/python-hypothesis
+          - src/hummingbird/python-lxml-html-clean
+          - src/hummingbird/python-poetry-core
+          - src/hummingbird/python-psutil
+          - src/hummingbird/python-pyasn1
+          - src/hummingbird/python-pytest-asyncio
+          - src/hummingbird/python-pytest-mock
+          - src/hummingbird/python-pytest-xdist
+          - src/hummingbird/python-qt5
+          - src/hummingbird/python-soupsieve
+          - src/hummingbird/python-sphinx-basic-ng
+          - src/hummingbird/python-sphinx-copybutton
+          - src/hummingbird/python-webencodings
+          - src/hummingbird/python-wheel
+          - src/hummingbird/qt5-qtconnectivity
+          - src/hummingbird/qt5-qtmultimedia
+          - src/hummingbird/qt5-qttools
+          - src/hummingbird/qt6-qthttpserver
+          - src/hummingbird/raptor2
+          - src/hummingbird/sdl12-compat
+          - src/hummingbird/texlive-collection-fontsextra
+          - src/hummingbird/texlive-collection-formatsextra
+          - src/hummingbird/texlive-collection-luatex
+          - src/hummingbird/texlive-collection-mathscience
+          - src/hummingbird/texlive-collection-pictures
+          - src/hummingbird/texlive-collection-xetex
+          - src/hummingbird/transfig
+          - src/hummingbird/vapoursynth
+          - src/hummingbird/vtk
+          - src/hummingbird/zbar
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier niri-15 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-niri-15-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-niri-15:
+    needs: build-niri-15
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-niri-15-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-niri-16:
+    needs: consolidate-niri-15
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/atkmm
+          - src/hummingbird/blueprint-compiler
+          - src/hummingbird/cairomm
+          - src/hummingbird/cava
+          - src/hummingbird/certmonger
+          - src/hummingbird/extra-cmake-modules
+          - src/hummingbird/fcft
+          - src/hummingbird/glfw
+          - src/xfce-wayland/gtk-layer-shell
+          - src/hummingbird/gtk4-layer-shell
+          - src/hummingbird/libgee
+          - src/hummingbird/mako
+          - src/hummingbird/marshalparser
+          - src/hummingbird/niri
+          - src/hummingbird/perl-DateTime-Calendar-Julian
+          - src/hummingbird/perl-DateTime-Format-Strptime
+          - src/hummingbird/perl-Log-Log4perl
+          - src/hummingbird/playerctl
+          - src/hummingbird/protobuf3
+          - src/hummingbird/python-aiohappyeyeballs
+          - src/hummingbird/python-aiosignal
+          - src/hummingbird/python-blinker
+          - src/hummingbird/python-boolean.py
+          - src/hummingbird/python-cloudpickle
+          - src/hummingbird/python-greenlet
+          - src/hummingbird/python-gunicorn
+          - src/hummingbird/python-icalendar
+          - src/hummingbird/python-itsdangerous
+          - src/hummingbird/python-multidict
+          - src/hummingbird/python-pkgconfig
+          - src/hummingbird/python-propcache
+          - src/hummingbird/python-sphinxext-opengraph
+          - src/hummingbird/python-tzlocal
+          - src/hummingbird/python-urwid
+          - src/hummingbird/python-werkzeug
+          - src/hummingbird/python-zlib-ng
+          - src/hummingbird/qt
+          - src/hummingbird/qt6-qtconnectivity
+          - src/hummingbird/qt6-qtimageformats
+          - src/hummingbird/quickshell
+          - src/hummingbird/swaybg
+          - src/hummingbird/swaylock
+          - src/hummingbird/texlive-collection-bibtexextra
+          - src/hummingbird/texlive-collection-humanities
+          - src/hummingbird/texlive-collection-langarabic
+          - src/hummingbird/texlive-collection-langchinese
+          - src/hummingbird/texlive-collection-langcjk
+          - src/hummingbird/texlive-collection-langcyrillic
+          - src/hummingbird/texlive-collection-langenglish
+          - src/hummingbird/texlive-collection-langjapanese
+          - src/hummingbird/texlive-collection-langkorean
+          - src/hummingbird/texlive-collection-langother
+          - src/hummingbird/texlive-collection-plaingeneric
+          - src/hummingbird/texlive-collection-pstricks
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier niri-16 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-niri-16-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-niri-16:
+    needs: build-niri-16
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-niri-16-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-niri-17:
+    needs: consolidate-niri-16
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/SwayNotificationCenter
+          - src/hummingbird/blueman
+          - src/hummingbird/emacs-auctex
+          - src/hummingbird/khal
+          - src/hummingbird/liborc
+          - src/hummingbird/nanosvg
+          - src/hummingbird/pangomm
+          - src/hummingbird/perl-DateTime-Format-Builder
+          - src/hummingbird/plasma-wayland-protocols
+          - src/hummingbird/python-aiohttp
+          - src/hummingbird/python-flask
+          - src/hummingbird/python-license-expression
+          - src/hummingbird/python-oauthlib
+          - src/hummingbird/python-pytest-httpserver
+          - src/hummingbird/python-pytest-localserver
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier niri-17 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-niri-17-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-niri-17:
+    needs: build-niri-17
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-niri-17-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-niri-18:
+    needs: consolidate-niri-17
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/biber
+          - src/hummingbird/fuzzel
+          - src/hummingbird/go-vendor-tools
+          - src/hummingbird/gtkmm3.0
+          - src/hummingbird/libarrow
+          - src/hummingbird/python-aiohttp-oauthlib
+          - src/hummingbird/python-httpbin
+          - src/hummingbird/qt6-qt3d
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier niri-18 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-niri-18-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-niri-18:
+    needs: build-niri-18
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-niri-18-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-niri-19:
+    needs: consolidate-niri-18
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/DankMaterialShell
+          - src/hummingbird/cliphist
+          - src/hummingbird/danksearch
+          - src/hummingbird/dgop
+          - src/hummingbird/pavucontrol
+          - src/hummingbird/python-pytest-httpbin
+          - src/hummingbird/qt6-qtgraphs
+          - src/hummingbird/vdirsyncer
+          - src/hummingbird/waybar
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier niri-19 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-niri-19-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-niri-19:
+    needs: build-niri-19
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-niri-19-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-niri-21:
+    needs: consolidate-niri-19
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/python-pyside6
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier niri-21 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-niri-21-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-niri-21:
+    needs: build-niri-21
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-niri-21-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-niri-26:
+    needs: consolidate-niri-21
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/qt6ct
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier niri-26 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-niri-26-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-niri-26:
+    needs: build-niri-26
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-niri-26-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-xfce-01:
+    needs: consolidate-niri-26
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/iceauth
+          - src/hummingbird/libXpresent
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier xfce-01 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-xfce-01-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-xfce-01:
+    needs: build-xfce-01
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-xfce-01-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-xfce-04:
+    needs: consolidate-xfce-01
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/xset
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier xfce-04 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-xfce-04-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-xfce-04:
+    needs: build-xfce-04
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-xfce-04-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-xfce-05:
+    needs: consolidate-xfce-04
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/gspell
+          - src/hummingbird/gtksourceview4
+          - src/hummingbird/libwnck3
+          - src/xfce-wayland/libxfce4util
+          - src/hummingbird/libxklavier
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier xfce-05 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-xfce-05-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-xfce-05:
+    needs: build-xfce-05
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-xfce-05-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-xfce-06:
+    needs: consolidate-xfce-05
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/xfce-wayland/libxfce4windowing
+          - src/xfce-wayland/tumbler
+          - src/xfce-wayland/xfconf
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier xfce-06 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-xfce-06-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-xfce-06:
+    needs: build-xfce-06
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-xfce-06-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-xfce-07:
+    needs: consolidate-xfce-06
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/xfce-wayland/libxfce4ui
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier xfce-07 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-xfce-07-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-xfce-07:
+    needs: build-xfce-07
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-xfce-07-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-xfce-08:
+    needs: consolidate-xfce-07
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/xfce-wayland/exo
+          - src/xfce-wayland/garcon
+          - src/hummingbird/mousepad
+          - src/hummingbird/xfce-polkit
+          - src/xfce-wayland/xfce4-session
+          - src/xfce-wayland/xfce4-terminal
+          - src/hummingbird/xfwm4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier xfce-08 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-xfce-08-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-xfce-08:
+    needs: build-xfce-08
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-xfce-08-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-xfce-09:
+    needs: consolidate-xfce-08
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/ristretto
+          - src/xfce-wayland/xfce4-panel
+          - src/xfce-wayland/xfce4-settings
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier xfce-09 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-xfce-09-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-xfce-09:
+    needs: build-xfce-09
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-xfce-09-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-xfce-10:
+    needs: consolidate-xfce-09
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/hummingbird/Thunar
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier xfce-10 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-xfce-10-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-xfce-10:
+    needs: build-xfce-10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-xfce-10-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  build-xfce-11:
+    needs: consolidate-xfce-10
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - src/xfce-wayland/xfdesktop
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install host dependencies
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm
+      - name: Cache CentOS Stream 10 image
+        uses: actions/cache@v6
+        with:
+          path: /tmp/cs10-image.tar
+          key: cs10-image-${{ hashFiles('mock/hummingbird-ci.cfg') }}
+      - name: Load or pull image
+        run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
+      - name: Seed local repo from R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/ || true
+
+          createrepo_c local-repo
+
+          '
+      - name: Cache mock chroot (dnf downloads)
+        uses: actions/cache@v6
+        with:
+          path: .mock-cache
+          key: mock-cache-${{ matrix.package }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ github.run_id }}
+          restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
+
+            mock-cache-${{ matrix.package }}-'
+      - name: Build package
+        env:
+          MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
+        run: "touch .build-marker\nARGS=(--backend podman --tier xfce-11 --package ${{ matrix.package }} --manifest build-order-hummingbird-desktops.yml --mock-config hummingbird-ci)\nif [[ \"${{ github.event.inputs.force }}\" == \"true\" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh \"${ARGS[@]}\"\n"
+      - name: Find new RPMs
+        id: find-rpms
+        run: 'mkdir -p new-rpms
+
+          find local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \;
+
+          count=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)
+
+          echo "count=$count" >> $GITHUB_OUTPUT
+
+          '
+      - name: Upload RPMs
+        if: steps.find-rpms.outputs.count > '0'
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpms-xfce-11-${{ strategy.job-index }}
+          path: new-rpms/*.rpm
+          retention-days: 1
+  consolidate-xfce-11:
+    needs: build-xfce-11
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install createrepo_c
+        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Download new RPMs
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: rpms-xfce-11-*
+          path: local-repo
+          merge-multiple: true
+      - name: Publish this tier to R2
+        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          rclone copy local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          '
+  publish:
+    needs: consolidate-xfce-11
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install dependencies
+        run: 'sudo apt-get update -q && sudo apt-get install -y -q rpm createrepo-c gpg gpgconf
+
+          curl -fsSL https://rclone.org/install.sh | sudo bash
+
+          '
+      - name: Seed final repo from R2
+        run: 'mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          mkdir -p local-repo
+
+          rclone copy "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/" local-repo/
+
+          '
+      - name: Import GPG key
+        id: import-gpg
+        uses: crazy-max/ghaction-import-gpg@v7
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_committer_name: RPM Builder
+          git_committer_email: rpm-signing@tunaos.org
+      - name: Configure RPM macros
+        run: 'echo "%_signature gpg" > ~/.rpmmacros
+
+          echo "%_gpg_name ${{ steps.import-gpg.outputs.keyid }}" >> ~/.rpmmacros
+
+          echo "%__gpg_sign_cmd %{__gpg} gpg --batch --no-verbose --no-armor --use-agent --no-secmem-warning -u \"%{_gpg_name}\" -sbo %{__signature_filename} %{__plaintext_filename}" >> ~/.rpmmacros
+
+          '
+      - name: Sign RPMs
+        run: 'find local-repo -name "*.rpm" -exec rpmsign --addsign {} \;
+
+          createrepo_c --update local-repo
+
+          '
+      - name: Configure rclone
+        run: 'mkdir -p ~/.config/rclone
+
+          cat > ~/.config/rclone/rclone.conf << EOF
+
+          [r2]
+
+          type = s3
+
+          provider = Cloudflare
+
+          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+
+          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+
+          endpoint = ${{ secrets.R2_ENDPOINT }}
+
+          EOF
+
+          '
+      - name: Upload to R2
+        run: 'echo "Uploading to 20251124-x86_64..."
+
+          rclone sync local-repo/ "r2:${R2_BUCKET}/hummingbird/20251124-x86_64/"
+
+          rclone copyto public.gpg "r2:${R2_BUCKET}/public.gpg"
+
+          rclone copyto contrib/install.sh "r2:${R2_BUCKET}/install.sh"
+
+          '

--- a/scripts/generate-distributed-workflow.py
+++ b/scripts/generate-distributed-workflow.py
@@ -3,6 +3,25 @@ import yaml
 import sys
 import os
 
+def _rclone_conf(r2_state):
+    """One rclone endpoint for the whole workflow.
+
+    The seed and publish jobs built theirs from CLOUDFLARE_ACCOUNT_ID while
+    the per-tier jobs use R2_ENDPOINT. Two secrets for one endpoint means
+    whichever is unset fails at runtime, two minutes in, in a job that looks
+    unrelated to the change that introduced it. --r2-state makes every job
+    use R2_ENDPOINT, which is the secret the existing Hummingbird workflow
+    has been publishing with.
+    """
+    endpoint = ('${{ secrets.R2_ENDPOINT }}' if r2_state
+                else 'https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com')
+    return ('mkdir -p ~/.config/rclone\ncat > ~/.config/rclone/rclone.conf << EOF\n'
+            '[r2]\ntype = s3\nprovider = Cloudflare\n'
+            'access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}\n'
+            'secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}\n'
+            f'endpoint = {endpoint}\nEOF\n')
+
+
 def generate_workflow(manifest_path, output_path, workflow_name='Distributed Build and Publish RPMs',
                       r2_path='repo/10-stream-x86_64', secondary_r2_path='repo/10-x86_64',
                       install_script='contrib/install.sh', install_r2_dest='install.sh',
@@ -47,7 +66,7 @@ def generate_workflow(manifest_path, output_path, workflow_name='Distributed Bui
         'steps': [
             {'name': 'Checkout', 'uses': 'actions/checkout@v7'},
             {'name': 'Install dependencies', 'run': 'sudo apt-get update -q && sudo apt-get install -y -q createrepo-c'},
-            {'name': 'Configure rclone', 'run': 'curl -fsSL https://rclone.org/install.sh | sudo bash\nmkdir -p ~/.config/rclone\ncat > ~/.config/rclone/rclone.conf << EOF\n[r2]\ntype = s3\nprovider = Cloudflare\naccess_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}\nsecret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}\nendpoint = https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com\nEOF\n'},
+            {'name': 'Configure rclone', 'run': 'curl -fsSL https://rclone.org/install.sh | sudo bash\n' + _rclone_conf(r2_state)},
             {'name': 'Seed local repo from R2', 'run': f'mkdir -p local-repo\necho "Downloading existing repo from R2..."\nrclone sync "r2:${{R2_BUCKET}}/{r2_path}/" "local-repo/" --exclude "repodata/**" || true\ncreaterepo_c local-repo\n'},
             # With R2 as the shared state this job exists to guarantee the
             # repository has valid metadata before any runner seeds from it;
@@ -161,7 +180,7 @@ def generate_workflow(manifest_path, output_path, workflow_name='Distributed Bui
             {'name': 'Import GPG key', 'id': 'import-gpg', 'uses': 'crazy-max/ghaction-import-gpg@v7', 'with': {'gpg_private_key': '${{ secrets.GPG_PRIVATE_KEY }}', 'passphrase': '${{ secrets.GPG_PASSPHRASE }}', 'git_committer_name': 'RPM Builder', 'git_committer_email': 'rpm-signing@tunaos.org'}},
             {'name': 'Configure RPM macros', 'run': 'echo "%_signature gpg" > ~/.rpmmacros\necho "%_gpg_name ${{ steps.import-gpg.outputs.keyid }}" >> ~/.rpmmacros\necho "%__gpg_sign_cmd %{__gpg} gpg --batch --no-verbose --no-armor --use-agent --no-secmem-warning -u \\"%{_gpg_name}\\" -sbo %{__signature_filename} %{__plaintext_filename}" >> ~/.rpmmacros\n'},
             {'name': 'Sign RPMs', 'run': 'find local-repo -name "*.rpm" -exec rpmsign --addsign {} \\;\ncreaterepo_c --update local-repo\n'},
-            {'name': 'Configure rclone', 'run': 'mkdir -p ~/.config/rclone\ncat > ~/.config/rclone/rclone.conf << EOF\n[r2]\ntype = s3\nprovider = Cloudflare\naccess_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}\nsecret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}\nendpoint = https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com\nEOF\n'},
+            {'name': 'Configure rclone', 'run': _rclone_conf(r2_state)},
             {'name': 'Upload to R2', 'run': _build_upload_run(r2_path, secondary_r2_path, install_script, install_r2_dest)}
         ]
     }

--- a/scripts/generate-distributed-workflow.py
+++ b/scripts/generate-distributed-workflow.py
@@ -6,7 +6,7 @@ import os
 def generate_workflow(manifest_path, output_path, workflow_name='Distributed Build and Publish RPMs',
                       r2_path='repo/10-stream-x86_64', secondary_r2_path='repo/10-x86_64',
                       install_script='contrib/install.sh', install_r2_dest='install.sh',
-                      submodules=True, mock_config=None):
+                      submodules=True, mock_config=None, r2_state=False):
     with open(manifest_path, 'r') as f:
         manifest = yaml.safe_load(f)
 
@@ -49,7 +49,12 @@ def generate_workflow(manifest_path, output_path, workflow_name='Distributed Bui
             {'name': 'Install dependencies', 'run': 'sudo apt-get update -q && sudo apt-get install -y -q createrepo-c'},
             {'name': 'Configure rclone', 'run': 'curl -fsSL https://rclone.org/install.sh | sudo bash\nmkdir -p ~/.config/rclone\ncat > ~/.config/rclone/rclone.conf << EOF\n[r2]\ntype = s3\nprovider = Cloudflare\naccess_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}\nsecret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}\nendpoint = https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com\nEOF\n'},
             {'name': 'Seed local repo from R2', 'run': f'mkdir -p local-repo\necho "Downloading existing repo from R2..."\nrclone sync "r2:${{R2_BUCKET}}/{r2_path}/" "local-repo/" --exclude "repodata/**" || true\ncreaterepo_c local-repo\n'},
-            {'name': 'Upload initial repo', 'uses': 'actions/upload-artifact@v7', 'with': {'name': 'repo-0', 'path': 'local-repo', 'retention-days': 1}}
+            # With R2 as the shared state this job exists to guarantee the
+            # repository has valid metadata before any runner seeds from it;
+            # there is nothing to hand on as an artifact.
+            *([] if r2_state else [
+                {'name': 'Upload initial repo', 'uses': 'actions/upload-artifact@v7', 'with': {'name': 'repo-0', 'path': 'local-repo', 'retention-days': 1}},
+            ])
         ]
     }
     
@@ -89,7 +94,25 @@ def generate_workflow(manifest_path, output_path, workflow_name='Distributed Bui
                 {'name': 'Install host dependencies', 'run': 'sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm'},
                 {'name': 'Cache CentOS Stream 10 image', 'uses': 'actions/cache@v6', 'with': {'path': '/tmp/cs10-image.tar', 'key': f"cs10-image-${{{{ hashFiles('{mock_cfg_file}') }}}}"}},
                 {'name': 'Load or pull image', 'run': 'if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n'},
-                {'name': 'Download previous repo', 'uses': 'actions/download-artifact@v8', 'with': {'name': prev_tier_repo, 'path': 'local-repo'}},
+                *([
+                    # Seed each runner straight from R2 rather than passing the
+                    # whole repository between tiers as an artifact.
+                    #
+                    # The artifact route is O(repo x packages-in-tier): every
+                    # runner downloads the entire repo. Hummingbird's repo is
+                    # over a gigabyte and gnome-00 alone is 116 packages, so a
+                    # single tier would move on the order of a hundred gigabytes
+                    # of artifact traffic to distribute a few hundred megabytes
+                    # of RPMs. Seeding is O(1) per runner and takes about two
+                    # minutes, which the sequential workflow already pays once.
+                    #
+                    # Correctness is unchanged because the barrier is unchanged:
+                    # a tier's runners start only after the previous tier's
+                    # consolidate job has published to R2.
+                    {'name': 'Seed local repo from R2', 'run': 'curl -fsSL https://rclone.org/install.sh | sudo bash\nmkdir -p ~/.config/rclone\ncat > ~/.config/rclone/rclone.conf << EOF\n[r2]\ntype = s3\nprovider = Cloudflare\naccess_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}\nsecret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}\nendpoint = ${{ secrets.R2_ENDPOINT }}\nEOF\nmkdir -p local-repo\nrclone copy "r2:${R2_BUCKET}/%s/" local-repo/ || true\ncreaterepo_c local-repo\n' % r2_path},
+                ] if r2_state else [
+                    {'name': 'Download previous repo', 'uses': 'actions/download-artifact@v8', 'with': {'name': prev_tier_repo, 'path': 'local-repo'}},
+                ]),
                 {'name': 'Cache mock chroot (dnf downloads)', 'uses': 'actions/cache@v6', 'with': {'path': '.mock-cache', 'key': f"mock-cache-${{{{ matrix.package }}}}-${{{{ hashFiles('{mock_cfg_file}') }}}}-${{{{ github.run_id }}}}", 'restore-keys': f"mock-cache-${{{{ matrix.package }}}}-${{{{ hashFiles('{mock_cfg_file}') }}}}-\nmock-cache-${{{{ matrix.package }}}}-"}},
                 {'name': 'Build package', 'env': {'MOCK_CACHE_DIR': '${{ github.workspace }}/.mock-cache'}, 'run': f'touch .build-marker\nARGS=(--backend podman --tier {tier_name} --package ${{{{ matrix.package }}}}{manifest_flag}{mock_flag})\nif [[ "${{{{ github.event.inputs.force }}}}" == "true" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh "${{ARGS[@]}}"\n'},
                 {'name': 'Find new RPMs', 'id': 'find-rpms', 'run': 'mkdir -p new-rpms\nfind local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \\;\ncount=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)\necho "count=$count" >> $GITHUB_OUTPUT\n'},
@@ -103,10 +126,20 @@ def generate_workflow(manifest_path, output_path, workflow_name='Distributed Bui
             'runs-on': 'ubuntu-latest',
             'steps': [
                 {'name': 'Install createrepo_c', 'run': 'sudo apt-get update -q && sudo apt-get install -y -q createrepo-c'},
-                {'name': 'Download previous repo', 'uses': 'actions/download-artifact@v8', 'with': {'name': prev_tier_repo, 'path': 'local-repo'}},
+                *([] if r2_state else [
+                    {'name': 'Download previous repo', 'uses': 'actions/download-artifact@v8', 'with': {'name': prev_tier_repo, 'path': 'local-repo'}},
+                ]),
+                # Only this tier's NEW rpms travel as artifacts -- megabytes,
+                # not the whole repository.
                 {'name': 'Download new RPMs', 'uses': 'actions/download-artifact@v8', 'continue-on-error': True, 'with': {'pattern': f'rpms-{tier_name}-*', 'path': 'local-repo', 'merge-multiple': True}},
-                {'name': 'Update repo', 'run': 'createrepo_c --update local-repo'},
-                {'name': 'Upload updated repo', 'uses': 'actions/upload-artifact@v7', 'with': {'name': repo_artifact_name, 'path': 'local-repo', 'retention-days': 1}}
+                *([
+                    # copy, not sync: this tier adds to what earlier tiers
+                    # published and must never delete it.
+                    {'name': 'Publish this tier to R2', 'run': 'curl -fsSL https://rclone.org/install.sh | sudo bash\nmkdir -p ~/.config/rclone\ncat > ~/.config/rclone/rclone.conf << EOF\n[r2]\ntype = s3\nprovider = Cloudflare\naccess_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}\nsecret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}\nendpoint = ${{ secrets.R2_ENDPOINT }}\nEOF\nrclone copy local-repo/ "r2:${R2_BUCKET}/%s/"\n' % r2_path},
+                ] if r2_state else [
+                    {'name': 'Update repo', 'run': 'createrepo_c --update local-repo'},
+                    {'name': 'Upload updated repo', 'uses': 'actions/upload-artifact@v7', 'with': {'name': repo_artifact_name, 'path': 'local-repo', 'retention-days': 1}},
+                ])
             ]
         }
         
@@ -120,7 +153,11 @@ def generate_workflow(manifest_path, output_path, workflow_name='Distributed Bui
         'steps': [
             {'name': 'Checkout', 'uses': 'actions/checkout@v7'},
             {'name': 'Install dependencies', 'run': 'sudo apt-get update -q && sudo apt-get install -y -q rpm createrepo-c gpg gpgconf\ncurl -fsSL https://rclone.org/install.sh | sudo bash\n'},
-            {'name': 'Download final repo', 'uses': 'actions/download-artifact@v8', 'with': {'name': prev_tier_repo, 'path': 'local-repo'}},
+            *([
+                {'name': 'Seed final repo from R2', 'run': 'mkdir -p ~/.config/rclone\ncat > ~/.config/rclone/rclone.conf << EOF\n[r2]\ntype = s3\nprovider = Cloudflare\naccess_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}\nsecret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}\nendpoint = ${{ secrets.R2_ENDPOINT }}\nEOF\nmkdir -p local-repo\nrclone copy "r2:${R2_BUCKET}/%s/" local-repo/\n' % r2_path},
+            ] if r2_state else [
+                {'name': 'Download final repo', 'uses': 'actions/download-artifact@v8', 'with': {'name': prev_tier_repo, 'path': 'local-repo'}},
+            ]),
             {'name': 'Import GPG key', 'id': 'import-gpg', 'uses': 'crazy-max/ghaction-import-gpg@v7', 'with': {'gpg_private_key': '${{ secrets.GPG_PRIVATE_KEY }}', 'passphrase': '${{ secrets.GPG_PASSPHRASE }}', 'git_committer_name': 'RPM Builder', 'git_committer_email': 'rpm-signing@tunaos.org'}},
             {'name': 'Configure RPM macros', 'run': 'echo "%_signature gpg" > ~/.rpmmacros\necho "%_gpg_name ${{ steps.import-gpg.outputs.keyid }}" >> ~/.rpmmacros\necho "%__gpg_sign_cmd %{__gpg} gpg --batch --no-verbose --no-armor --use-agent --no-secmem-warning -u \\"%{_gpg_name}\\" -sbo %{__signature_filename} %{__plaintext_filename}" >> ~/.rpmmacros\n'},
             {'name': 'Sign RPMs', 'run': 'find local-repo -name "*.rpm" -exec rpmsign --addsign {} \\;\ncreaterepo_c --update local-repo\n'},
@@ -175,6 +212,13 @@ if __name__ == '__main__':
                         help='Skip submodules: recursive in checkout steps')
     parser.add_argument('--mock-config', default=None,
                         help='Mock config name passed to build-chain.sh (e.g. centos-stream-10-ci-gnome50); also keys the image/chroot caches on that config file')
+    parser.add_argument('--r2-state', action='store_true',
+                        help='Carry the repository between tiers in R2 rather than as a GitHub '
+                             'artifact. Each build runner seeds itself and each tier publishes '
+                             'its own rpms. Required at Hummingbird scale: the artifact route '
+                             'makes every runner download the whole repository, which is over a '
+                             'gigabyte, so one 116-package tier would move ~116 GB to distribute '
+                             'a few hundred megabytes.')
     args = parser.parse_args()
     secondary = args.secondary_r2_path if args.secondary_r2_path else None
     generate_workflow(args.manifest, args.output,
@@ -184,5 +228,6 @@ if __name__ == '__main__':
                       install_script=args.install_script,
                       install_r2_dest=args.install_r2_dest,
                       submodules=not args.no_submodules,
-                      mock_config=args.mock_config)
+                      mock_config=args.mock_config,
+                      r2_state=args.r2_state)
     print(f"Generated {args.output}")

--- a/tests/test_distributed_workflow_r2_state.py
+++ b/tests/test_distributed_workflow_r2_state.py
@@ -115,3 +115,28 @@ def test_tiers_publish_with_copy_not_sync(tmp_path):
                    if s.get("name") == "Publish this tier to R2")
     assert "rclone copy" in publish["run"]
     assert "rclone sync" not in publish["run"]
+
+
+def test_one_r2_endpoint_secret_across_the_whole_workflow(tmp_path):
+    """Two secrets for one endpoint means whichever is unset fails at runtime.
+
+    The seed and publish jobs built their endpoint from CLOUDFLARE_ACCOUNT_ID
+    while every per-tier job used R2_ENDPOINT. In a 158-job workflow that
+    surfaces as two unrelated-looking jobs dying two minutes in, long after the
+    change that caused it.
+
+    R2_ENDPOINT is the one the existing Hummingbird workflow publishes with.
+    """
+    wf = generate(tmp_path, "--r2-state")
+    text = yaml.safe_dump(wf)
+    assert "CLOUDFLARE_ACCOUNT_ID" not in text, (
+        "some job still builds its R2 endpoint from CLOUDFLARE_ACCOUNT_ID; "
+        "under --r2-state every job must use R2_ENDPOINT"
+    )
+    assert "secrets.R2_ENDPOINT" in text
+
+
+def test_the_default_still_uses_the_account_id_form(tmp_path):
+    """The other caller's secrets are not ours to change."""
+    wf = generate(tmp_path)
+    assert "CLOUDFLARE_ACCOUNT_ID" in yaml.safe_dump(wf)

--- a/tests/test_distributed_workflow_r2_state.py
+++ b/tests/test_distributed_workflow_r2_state.py
@@ -1,0 +1,117 @@
+"""At Hummingbird scale the repository cannot travel as a GitHub artifact.
+
+The generator's original model hands the whole repository from tier to tier as
+an artifact: every build runner downloads it. That is O(repo x packages-in-tier)
+and it was fine at the scale it was written for.
+
+Hummingbird's repository is over a gigabyte and gnome-00 is 108 packages, so a
+single tier would move on the order of a hundred gigabytes of artifact traffic
+in order to distribute a few hundred megabytes of RPMs.
+
+--r2-state seeds each runner from R2 instead, which is O(1) per runner and
+about two minutes -- a cost the sequential workflow already pays once. The
+barrier is unchanged, so correctness is unchanged: a tier's runners start only
+after the previous tier's consolidate job has published.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+GENERATOR = REPO / "scripts" / "generate-distributed-workflow.py"
+MANIFEST = REPO / "build-order-hummingbird-desktops.yml"
+
+
+def generate(tmp_path, *extra):
+    order = yaml.safe_load(MANIFEST.read_text())
+    slice_ = [t for t in order["tiers"] if t["name"].startswith(("bootstrap", "gnome"))]
+    src = tmp_path / "order.yml"
+    src.write_text(yaml.safe_dump({"r2_path": order["r2_path"], "tiers": slice_}, sort_keys=False))
+    out = tmp_path / "wf.yml"
+    subprocess.run(
+        [sys.executable, str(GENERATOR), str(src), str(out),
+         "--mock-config", "hummingbird-ci",
+         "--r2-path", order["r2_path"], "--secondary-r2-path", "",
+         "--no-submodules", *extra],
+        check=True, capture_output=True, cwd=REPO,
+    )
+    return yaml.safe_load(out.read_text())
+
+
+def step_names(job):
+    return [s.get("name") or s.get("uses") for s in job["steps"]]
+
+
+def test_r2_state_never_moves_the_repository_as_an_artifact(tmp_path):
+    wf = generate(tmp_path, "--r2-state")
+    for name, job in wf["jobs"].items():
+        for step in job["steps"]:
+            if str(step.get("uses", "")).startswith("actions/download-artifact"):
+                pattern = str(step.get("with", {}).get("pattern", ""))
+                artifact = str(step.get("with", {}).get("name", ""))
+                assert pattern.startswith("rpms-") or artifact.startswith("rpms-"), (
+                    f"{name} downloads {artifact or pattern!r}; under --r2-state only a "
+                    "tier's new rpms may travel as artifacts, never the repository"
+                )
+
+
+def test_without_the_flag_the_original_artifact_model_is_untouched(tmp_path):
+    """The generator has another caller; this must be opt-in."""
+    wf = generate(tmp_path)
+    assert "Download previous repo" in step_names(wf["jobs"]["build-gnome-00"])
+
+
+def test_every_build_runner_seeds_itself(tmp_path):
+    wf = generate(tmp_path, "--r2-state")
+    for name, job in wf["jobs"].items():
+        if name.startswith("build-"):
+            assert "Seed local repo from R2" in step_names(job), f"{name} has no repository"
+
+
+def test_the_barrier_between_tiers_survives(tmp_path):
+    """Correctness rests on this: tier N must wait for tier N-1 to publish."""
+    wf = generate(tmp_path, "--r2-state")
+    tiers = [t["name"] for t in yaml.safe_load(MANIFEST.read_text())["tiers"]
+             if t["name"].startswith(("bootstrap", "gnome"))]
+    for previous, current in zip(tiers, tiers[1:]):
+        assert wf["jobs"][f"build-{current}"]["needs"] == f"consolidate-{previous}", (
+            f"build-{current} does not wait for consolidate-{previous}; its packages "
+            "would build against a repository missing the tier they depend on"
+        )
+
+
+def test_the_matrix_covers_every_package_in_the_tier(tmp_path):
+    """A silently short matrix looks exactly like a complete one."""
+    wf = generate(tmp_path, "--r2-state")
+    order = yaml.safe_load(MANIFEST.read_text())
+    for tier in order["tiers"]:
+        if not tier["name"].startswith(("bootstrap", "gnome")):
+            continue
+        matrix = wf["jobs"][f"build-{tier['name']}"]["strategy"]["matrix"]["package"]
+        assert len(matrix) == len(tier["packages"]), (
+            f"{tier['name']}: matrix has {len(matrix)} cells for "
+            f"{len(tier['packages'])} packages"
+        )
+
+
+def test_a_failing_package_does_not_cancel_its_tier(tmp_path):
+    wf = generate(tmp_path, "--r2-state")
+    for name, job in wf["jobs"].items():
+        if name.startswith("build-"):
+            assert job["strategy"]["fail-fast"] is False, (
+                f"{name} is fail-fast; one package failing would cancel every "
+                "other package in the tier mid-build"
+            )
+
+
+def test_tiers_publish_with_copy_not_sync(tmp_path):
+    """sync would delete what earlier tiers published."""
+    wf = generate(tmp_path, "--r2-state")
+    publish = next(s for s in wf["jobs"]["consolidate-gnome-00"]["steps"]
+                   if s.get("name") == "Publish this tier to R2")
+    assert "rclone copy" in publish["run"]
+    assert "rclone sync" not in publish["run"]


### PR DESCRIPTION
The second half of making the desktop builds part of Tideforge (#297 was the first).

Tideforge fans out because its packages are **leaves**. Hummingbird's are a DAG — but the tiers already encode it: packages within a tier are independent *by construction*, which is what a tier is. So the fan-out was always available and simply never taken. Today a tier runs `--jobs 4` on one runner.

## What was already there, and what wasn't

`scripts/generate-distributed-workflow.py` already emitted the right shape — one job per tier, matrix over packages, `fail-fast: false`, a consolidate job per tier.

What it could not do at this scale is carry the **repository** between tiers as a GitHub artifact, because every build runner downloads the whole thing:

| | cost |
|---|---|
| artifact model | O(repo × packages-in-tier) |
| Hummingbird repo | >1 GB |
| `gnome-00` | 108 packages |
| **one tier** | **~100 GB of artifact traffic to distribute a few hundred MB of RPMs** |

`--r2-state` seeds each runner from R2 instead: O(1) per runner, ~2 minutes — a cost the sequential workflow already pays once per run. Only a tier's **new** RPMs travel as artifacts.

**The barrier is untouched.** Tier N's runners still `needs:` tier N-1's consolidate job, so correctness is unchanged, and there is a test walking that chain link by link.

## Deliberate choices

- **Opt-in.** The generator has another caller and the artifact model is right at its scale; a test pins that the default output is what it was.
- **`copy`, never `sync`.** A tier adds to what earlier tiers published and must not delete it. Tested, because `sync` is the natural thing to reach for and would silently empty the repository.

## Testing

7 tests, mutation-verified three ways: dropping the build job's seed step, letting the flag strip the artifact model when off, and swapping `copy` for `sync`.

Two of those mutations **initially reported a false pass** — there are two `Seed local repo from R2` steps (the seed job's and the build job's) and I mutated the wrong one. Re-verified against the correct occurrence. Worth stating because a mutation that silently no-ops looks exactly like a passing one.

## Not yet run

The structure is checked — 30 jobs for GNOME's 14 tiers, a 108-cell matrix for `gnome-00`, no repository artifact anywhere, every tier waiting on its predecessor. But **no dispatch has exercised it**, and the generated workflows are deliberately not committed until one has.

## Correction

I had been quoting `gnome-00` as 116 packages. It is **108**. The 116 came from adding "built 108" and "failed 8" in an early run, but #273's tier retry re-runs failures, so those 8 were counted in both — a subset, not an addition. `gnome-00` is complete at 108/108.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->