### PR TITLE
fix(fanout): import the package before trying to build it

### DIFF
--- a/.github/workflows/build-hummingbird-distributed.yml
+++ b/.github/workflows/build-hummingbird-distributed.yml
@@ -108,6 +108,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -226,6 +228,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -341,6 +345,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -457,6 +463,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -679,6 +687,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -823,6 +833,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -948,6 +960,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -1068,6 +1082,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -1248,6 +1264,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -1404,6 +1422,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -1535,6 +1555,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -1660,6 +1682,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -1780,6 +1804,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -1895,6 +1921,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -2058,6 +2086,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -2194,6 +2224,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -2313,6 +2345,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -2433,6 +2467,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -2558,6 +2594,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -2699,6 +2737,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -2843,6 +2883,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -2975,6 +3017,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -3097,6 +3141,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -3219,6 +3265,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -3336,6 +3384,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -3453,6 +3503,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -3578,6 +3630,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -3700,6 +3754,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -3825,6 +3881,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -3946,6 +4004,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -4061,6 +4121,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -4176,6 +4238,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -4294,6 +4358,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -4486,6 +4552,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -4643,6 +4711,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -4770,6 +4840,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -4895,6 +4967,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -5016,6 +5090,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -5137,6 +5213,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -5255,6 +5333,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -5387,6 +5467,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -5513,6 +5595,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -5628,6 +5712,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -5794,6 +5880,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -5932,6 +6020,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -6048,6 +6138,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -6164,6 +6256,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -6344,6 +6438,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -6481,6 +6577,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -6604,6 +6702,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -6721,6 +6821,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -6841,6 +6943,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -7006,6 +7110,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -7146,6 +7252,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -7275,6 +7383,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -7396,6 +7506,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -7522,6 +7634,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -7642,6 +7756,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -7763,6 +7879,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -7885,6 +8003,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -8001,6 +8121,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -8126,6 +8248,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -8316,6 +8440,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -8484,6 +8610,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -8613,6 +8741,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -8735,6 +8865,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -8858,6 +8990,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -8973,6 +9107,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -9088,6 +9224,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -9204,6 +9342,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -9319,6 +9459,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -9438,6 +9580,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -9555,6 +9699,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -9670,6 +9816,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -9791,6 +9939,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -9908,6 +10058,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -10023,6 +10175,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache
@@ -10138,6 +10292,8 @@ jobs:
           restore-keys: 'mock-cache-${{ matrix.package }}-${{ hashFiles(''mock/hummingbird-ci.cfg'') }}-
 
             mock-cache-${{ matrix.package }}-'
+      - name: Import this package's dist-git packaging
+        run: "set -euo pipefail\npkg_path=\"${{ matrix.package }}\"\nif [ -d \"$pkg_path\" ]; then\n  echo \"$pkg_path is maintained in-tree; nothing to import\"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package \"$(basename \"$pkg_path\")\" \\\n    --dest \"$(dirname \"$pkg_path\")\" \\\n    --branch rawhide --release-bump\nfi\n"
       - name: Build package
         env:
           MOCK_CACHE_DIR: ${{ github.workspace }}/.mock-cache

--- a/scripts/generate-distributed-workflow.py
+++ b/scripts/generate-distributed-workflow.py
@@ -133,6 +133,22 @@ def generate_workflow(manifest_path, output_path, workflow_name='Distributed Bui
                     {'name': 'Download previous repo', 'uses': 'actions/download-artifact@v8', 'with': {'name': prev_tier_repo, 'path': 'local-repo'}},
                 ]),
                 {'name': 'Cache mock chroot (dnf downloads)', 'uses': 'actions/cache@v6', 'with': {'path': '.mock-cache', 'key': f"mock-cache-${{{{ matrix.package }}}}-${{{{ hashFiles('{mock_cfg_file}') }}}}-${{{{ github.run_id }}}}", 'restore-keys': f"mock-cache-${{{{ matrix.package }}}}-${{{{ hashFiles('{mock_cfg_file}') }}}}-\nmock-cache-${{{{ matrix.package }}}}-"}},
+                # Import this package's dist-git packaging before building it.
+                #
+                # The sequential workflow imports a whole tier in one step; a
+                # fan-out job needs exactly one package, which is also far
+                # gentler on src.fedoraproject.org than bulk parallel clones --
+                # one clone per runner rather than four at a time over hundreds.
+                #
+                # Without this the runner has no spec at all and build-chain
+                # dies in find_spec with "package: <none in scope>", which is
+                # what happened on the first dispatch (run 31287886482): all
+                # three bootstrap-00 jobs failed in under three seconds.
+                #
+                # Packages under src/deps are maintained in this repository and
+                # carry no distgit key, so their spec is already checked out.
+                # The existence test is what tells the two apart.
+                {'name': "Import this package's dist-git packaging", 'run': 'set -euo pipefail\npkg_path="${{ matrix.package }}"\nif [ -d "$pkg_path" ]; then\n  echo "$pkg_path is maintained in-tree; nothing to import"\nelse\n  python3 scripts/import-fedora-distgit.py \\\n    --package "$(basename "$pkg_path")" \\\n    --dest "$(dirname "$pkg_path")" \\\n    --branch rawhide --release-bump\nfi\n'},
                 {'name': 'Build package', 'env': {'MOCK_CACHE_DIR': '${{ github.workspace }}/.mock-cache'}, 'run': f'touch .build-marker\nARGS=(--backend podman --tier {tier_name} --package ${{{{ matrix.package }}}}{manifest_flag}{mock_flag})\nif [[ "${{{{ github.event.inputs.force }}}}" == "true" ]]; then\n  ARGS+=(--force)\nfi\n./scripts/build-chain.sh "${{ARGS[@]}}"\n'},
                 {'name': 'Find new RPMs', 'id': 'find-rpms', 'run': 'mkdir -p new-rpms\nfind local-repo -name "*.rpm" -newer .build-marker -exec cp {} new-rpms/ \\;\ncount=$(ls -1 new-rpms/*.rpm 2>/dev/null | wc -l)\necho "count=$count" >> $GITHUB_OUTPUT\n'},
                 {'name': 'Upload RPMs', 'if': "steps.find-rpms.outputs.count > '0'", 'uses': 'actions/upload-artifact@v7', 'with': {'name': f'rpms-{tier_name}-${{{{ strategy.job-index }}}}', 'path': 'new-rpms/*.rpm', 'retention-days': 1}}

--- a/tests/test_distributed_workflow_r2_state.py
+++ b/tests/test_distributed_workflow_r2_state.py
@@ -140,3 +140,52 @@ def test_the_default_still_uses_the_account_id_form(tmp_path):
     """The other caller's secrets are not ours to change."""
     wf = generate(tmp_path)
     assert "CLOUDFLARE_ACCOUNT_ID" in yaml.safe_dump(wf)
+
+
+def test_every_build_job_imports_its_package_before_building(tmp_path):
+    """A fan-out runner has no spec until it imports one.
+
+    The sequential workflow imports a whole tier in one step. The generator
+    predates the dist-git model -- it was written for a manifest whose packages
+    are vendored in-tree -- so its build jobs went straight to build-chain with
+    nothing on disk.
+
+    On the first dispatch (run 31287886482) all three bootstrap-00 jobs failed
+    in under three seconds, and #273's ERR trap named it exactly:
+
+        command     : spec="$(find_spec "$pkg_dir" "$spec_override")"
+        package     : <none in scope>
+    """
+    wf = generate(tmp_path, "--r2-state")
+    for name, job in wf["jobs"].items():
+        if not name.startswith("build-"):
+            continue
+        names = step_names(job)
+        assert "Import this package's dist-git packaging" in names, (
+            f"{name} builds without importing a spec"
+        )
+        assert names.index("Import this package's dist-git packaging") < names.index("Build package"), (
+            f"{name} imports after building, which is no import at all"
+        )
+
+
+def test_the_import_takes_one_package_not_the_whole_tier(tmp_path):
+    """One clone per runner. --tier here would be 108 clones x 108 runners."""
+    wf = generate(tmp_path, "--r2-state")
+    step = next(s for s in wf["jobs"]["build-gnome-00"]["steps"]
+                if s.get("name") == "Import this package's dist-git packaging")
+    assert "--package" in step["run"]
+    assert "--tier" not in step["run"], (
+        "the import is tier-scoped, so every runner in a 108-package tier would "
+        "clone all 108 -- 11664 clones against src.fedoraproject.org for one tier"
+    )
+
+
+def test_in_tree_packages_are_not_imported(tmp_path):
+    """src/deps/* are maintained here and have no distgit to import."""
+    step = next(s for s in generate(tmp_path, "--r2-state")["jobs"]["build-gnome-00"]["steps"]
+                if s.get("name") == "Import this package's dist-git packaging")
+    assert 'if [ -d "$pkg_path" ]' in step["run"], (
+        "no check for an in-tree package; the import would try to clone a "
+        "dist-git repo that does not exist for it"
+    )


### PR DESCRIPTION
## What the first dispatch showed

[Run 31287886482](https://github.com/tuna-os/tunaos-packages/actions/runs/31287886482) fanned out **correctly** — 160 jobs materialised, `bootstrap-00` split into one job per package, each on its own runner seeding from R2 in ~2 minutes. The structure works.

Then all three failed in under three seconds, and #273's ERR trap said exactly why:

```
command     : spec="$(find_spec "$pkg_dir" "$spec_override")"
package     : <none in scope>
ERROR: Failed: src/hummingbird/python-flit-core
```

**There was no spec.** The sequential workflow imports a whole tier's dist-git packaging in its own step. The generator predates that model — it was written for a manifest whose packages are vendored in-tree — so its build jobs went straight to `build-chain.sh` with an empty directory.

## The fix

Each build job imports exactly its own package. That is also the right shape for a fan-out:

| | clones against src.fedoraproject.org |
|---|---|
| tier-scoped import, per runner | 108 |
| × 108 runners in `gnome-00` | **11,664** |
| per-package import | **1 per runner** |

Which matters tonight in particular — that host has been shedding load and returning 503s for hours (#281, #285).

Packages under `src/deps/` are maintained in this repository and carry no `distgit` key, so their spec is already checked out. The directory-existence test is what distinguishes them from an import.

## Testing

3 tests, mutation-verified two ways: removing the import step (3 fail) and making it tier-scoped (1 fail).

Suite 474 → 477.

## Note

This is the failure #298 said to expect — it shipped explicitly marked *"not yet run"*, and the first run found a real gap in under three minutes. The diagnostic that named it is the ERR trap from #273, which was written this evening for exactly this purpose.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->