### PR TITLE
feat: report which packages cannot build before dispatching the run

### DIFF
--- a/scripts/preflight-buildrequires.py
+++ b/scripts/preflight-buildrequires.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Find the packages that cannot build before spending four hours proving it.
+
+A tier's job only discovers an unsatisfiable BuildRequires when it gets there.
+On the 40-layer order that can be hours in, and the answer was knowable before
+the run started: for every source package in the build order, is every one of
+its BuildRequires provided by something -- the target, the reference, or another
+package in the build set?
+
+Run against the current manifest this reports one package out of 1245:
+
+    SwayNotificationCenter  needs pkgconfig(granite-7)
+
+Rawhide carries exactly one granite source package and it provides
+pkgconfig(granite) and libgranite.so.6. Three Rawhide packages BuildRequire
+granite-7 -- SwayNotificationCenter, minder, warble -- so this is a Fedora-wide
+FTBFS rather than anything specific to Hummingbird, and SwayNotificationCenter
+is a declared niri root.
+
+Usage:
+
+    scripts/preflight-buildrequires.py --manifest build-order-hummingbird-desktops.yml
+
+Exits non-zero when anything is unsatisfiable, so it can gate a dispatch.
+"""
+
+import argparse
+import collections
+import importlib.util
+import pathlib
+import sys
+
+import yaml
+
+HERE = pathlib.Path(__file__).resolve().parent
+
+
+def load_gap():
+    spec = importlib.util.spec_from_file_location(
+        "gap", HERE / "measure-hummingbird-gap.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def unsatisfiable(sources, source_index, provides, have, rich_prefix="("):
+    """Which BuildRequires of these sources nothing can supply.
+
+    A requirement is fine if the target already ships it, if rpm resolves it at
+    install time (a rich dependency), or if anything in the reference provides
+    it -- the reference is the buildroot, and the build set is a subset of it,
+    so "not in the reference" means not available from any source at all.
+    """
+    blocked = collections.defaultdict(list)
+    for name in sources:
+        for requirement in source_index.get(name, ()):
+            if requirement in have or requirement.startswith(rich_prefix):
+                continue
+            if requirement not in provides:
+                blocked[name].append(requirement)
+    return dict(blocked)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=pathlib.Path,
+                        default=pathlib.Path("build-order-hummingbird-desktops.yml"))
+    parser.add_argument("--catalog", type=pathlib.Path,
+                        default=pathlib.Path("manifests/hummingbird-desktops.yaml"))
+    parser.add_argument("--cache", type=pathlib.Path,
+                        default=pathlib.Path(".cache/hummingbird-gap"))
+    parser.add_argument("--arch", default="x86_64")
+    args = parser.parse_args()
+
+    gap = load_gap()
+    catalog = yaml.safe_load(args.catalog.read_text())
+    target = catalog["target"]
+    baseurl = target["baseurl"].replace("$arch", args.arch).replace("$basearch", args.arch)
+
+    target_index = gap.parse_primary(gap.primary_of(baseurl, args.cache)[0])
+    reference = gap.parse_primary(gap.primary_of(gap.DEFAULT_REFERENCE, args.cache)[0])
+    source_index = gap.parse_source_primary(
+        gap.primary_of(gap.DEFAULT_SOURCE_REFERENCE, args.cache)[0])
+    have = set(target_index["provides"]) | set(target_index["packages"])
+
+    order = yaml.safe_load(args.manifest.read_text())
+    sources = sorted({
+        pkg.get("distgit") or pkg["path"].rsplit("/", 1)[-1]
+        for tier in order["tiers"] for pkg in tier["packages"]
+    })
+
+    blocked = unsatisfiable(sources, source_index, reference["provides"], have,
+                            gap.RICH_DEP_PREFIX)
+
+    print(f"source packages in the build order : {len(sources)}")
+    print(f"packages that cannot build         : {len(blocked)}")
+    if not blocked:
+        print("\nevery BuildRequires in the build order is satisfiable")
+        return 0
+
+    blocked_by = collections.Counter(
+        cap for caps in blocked.values() for cap in caps)
+    print()
+    for cap, count in blocked_by.most_common():
+        users = sorted(n for n, caps in blocked.items() if cap in caps)
+        print(f"  {cap}  blocks {count}: {', '.join(users)}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_preflight_buildrequires.py
+++ b/tests/test_preflight_buildrequires.py
@@ -1,0 +1,69 @@
+"""Knowing which packages cannot build should not require building them.
+
+A tier's job discovers an unsatisfiable BuildRequires only when it reaches it,
+which on the 40-layer order can be hours into a run. The answer is knowable
+before dispatch: every source package's BuildRequires are in the Rawhide source
+index, and every capability anything provides is in the reference index.
+
+Against the current manifest this finds one package in 1248 --
+SwayNotificationCenter needs pkgconfig(granite-7), and Rawhide's only granite
+provides pkgconfig(granite) and libgranite.so.6.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture(scope="module")
+def preflight():
+    spec = importlib.util.spec_from_file_location(
+        "preflight", REPO / "scripts" / "preflight-buildrequires.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+PROVIDES = {"pkgconfig(gtk4)", "pkgconfig(granite)", "meson", "vala"}
+HAVE = {"glibc", "pkgconfig(glib-2.0)"}
+SOURCE_INDEX = {
+    "good": ["pkgconfig(gtk4)", "meson", "pkgconfig(glib-2.0)"],
+    "blocked": ["pkgconfig(gtk4)", "pkgconfig(granite-7)"],
+    "very-blocked": ["pkgconfig(granite-7)", "pkgconfig(nonesuch)"],
+}
+
+
+def run(preflight, sources):
+    return preflight.unsatisfiable(sources, SOURCE_INDEX, PROVIDES, HAVE)
+
+
+def test_a_package_whose_buildrequires_all_resolve_is_not_reported(preflight):
+    assert run(preflight, ["good"]) == {}
+
+
+def test_a_capability_nothing_provides_is_reported_against_its_package(preflight):
+    assert run(preflight, ["blocked"]) == {"blocked": ["pkgconfig(granite-7)"]}
+
+
+def test_every_missing_capability_is_listed_not_just_the_first(preflight):
+    assert run(preflight, ["very-blocked"]) == {
+        "very-blocked": ["pkgconfig(granite-7)", "pkgconfig(nonesuch)"]}
+
+
+def test_what_the_target_already_ships_is_not_a_blocker(preflight):
+    """pkgconfig(glib-2.0) is in `have` and in no provides set."""
+    assert "good" not in run(preflight, ["good", "blocked"])
+
+
+def test_rich_dependencies_are_not_blockers(preflight):
+    """rpm resolves `(a or b)` at install time; no provides entry exists."""
+    index = {"rich": ["(gtk4 or gtk3)"]}
+    assert preflight.unsatisfiable(["rich"], index, PROVIDES, HAVE) == {}
+
+
+def test_a_package_absent_from_the_source_index_is_not_a_blocker(preflight):
+    """No BuildRequires known is not the same as unsatisfiable ones."""
+    assert preflight.unsatisfiable(["unknown"], SOURCE_INDEX, PROVIDES, HAVE) == {}


### PR DESCRIPTION
A tier's job discovers an unsatisfiable `BuildRequires` only when it reaches it, which on the layered order can be hours into a run. The answer is knowable before dispatch: every source package's BuildRequires are in Rawhide's source index, and every capability anything provides is in the reference index. Comparing the two takes seconds.

```
$ scripts/preflight-buildrequires.py
source packages in the build order : 1248
packages that cannot build         : 1

  pkgconfig(granite-7)  blocks 1: SwayNotificationCenter
```

**1247 of 1248 are clean.** The one that is not:

Rawhide carries exactly one `granite` source package, and it provides `pkgconfig(granite)` and `libgranite.so.6`. Three Rawhide packages BuildRequire `granite-7` — `SwayNotificationCenter`, `minder`, `warble` — so this is a **Fedora-wide FTBFS**, not anything specific to Hummingbird.

I verified that against a **freshly fetched** index (`primary.xml` sha `f0af4333`, 66644 packages) rather than the repo's pinned cache, because `fetch()` never expires an entry and `repomd.xml` has a fixed URL — a stale answer here would be worse than none.

## Why it matters

`SwayNotificationCenter` is a declared **niri root** (`manifests/hummingbird-desktops.yaml`), so niri ships without a notification daemon until either Granite 7 is packaged or the root changes. That is a decision, not a fix — and this script is what surfaces it before four hours of building rather than after.

The script exits non-zero when anything is unsatisfiable, so it can gate a dispatch.

## Tests

6 tests against the extracted `unsatisfiable()` core, each mutation-verified: dropping the `have` check, treating rich dependencies as blockers, and reporting only the first missing capability each fail exactly the test that covers them and nothing else.

`483 passed` for the rest of the suite. Independent of #302 and #303 — this adds two new files and changes nothing existing, so it can merge in any order.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->