### PR TITLE
fix(niri): build the SwayNotificationCenter that Fedora actually ships

### DIFF
--- a/build-order-hummingbird-desktops.yml
+++ b/build-order-hummingbird-desktops.yml
@@ -11,7 +11,7 @@
 #     --report-json docs/hummingbird-desktop-gap.json \
 #     --build-order build-order-hummingbird-desktops.yml
 #
-# Measured 2026-08-09T03:40:05.213369+00:00
+# Measured 2026-08-09T04:22:32.904128+00:00
 # target primary.xml   sha256 b92541eaf43fd4a8976710fa0035ae0c69b38aae7a0f241d61d87cd9bdd2a512
 # reference primary.xml sha256 dc3c7ec50508105e880c74f0178bf4723e770c73766654d833d1b2ad541e3774
 #
@@ -2384,7 +2384,6 @@ tiers:
       - path: src/hummingbird/NetworkManager-vpnc
         distgit: NetworkManager-vpnc
       - path: src/hummingbird/SwayNotificationCenter
-        distgit: SwayNotificationCenter
       - path: src/hummingbird/assimp
         distgit: assimp
       - path: src/hummingbird/blueman

--- a/docs/hummingbird-desktop-gap.json
+++ b/docs/hummingbird-desktop-gap.json
@@ -12050,7 +12050,7 @@
       "unresolved_capabilities": {}
     }
   },
-  "measured_at": "2026-08-09T03:40:05.213369+00:00",
+  "measured_at": "2026-08-09T04:22:32.904128+00:00",
   "reference_index": {
     "baseurl": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/",
     "primary_bytes": 16110308,

--- a/scripts/build-chain.sh
+++ b/scripts/build-chain.sh
@@ -373,10 +373,38 @@ prepare_sources() {
         return 1
     }
     if [[ -n "$sources_cache" ]]; then
-        find "$sources_cache" -maxdepth 1 -type f \
-            -exec ln -f {} "${builddir}/SOURCES/" \; 2>/dev/null \
-            || cp "$sources_cache"/* "${builddir}/SOURCES/" 2>/dev/null || true
+        # Never let a cached download land on top of a file that came out of
+        # the package directory. Those files are what Fedora committed to
+        # dist-git; the cache holds whatever a URL served at download time,
+        # and for a spec that carries a patch by URL those are not the same
+        # thing.
+        #
+        # luajit is the worked example. Its Patch2 is
+        # https://github.com/luajit/luajit/pull/631.patch, a live pull request
+        # whose diff is regenerated against a moving base, and dist-git also
+        # ships the pinned copy as luajit-2.1-s390x-support.patch. `ln -f`
+        # clobbered the pinned copy with today's regenerated one, which no
+        # longer applies: "2 out of 4 hunks FAILED -- saving rejects to file
+        # src/lj_ccall.c.rej", %prep dead, run 31294475023 layer-00.
+        local cached
+        while IFS= read -r -d '' cached; do
+            [[ -e "${builddir}/SOURCES/$(basename "$cached")" ]] && continue
+            ln -f "$cached" "${builddir}/SOURCES/" 2>/dev/null \
+                || cp "$cached" "${builddir}/SOURCES/" 2>/dev/null || true
+        done < <(find "$sources_cache" -maxdepth 1 -type f -print0)
     fi
+
+    # Re-assert the dist-git files over anything spectool fetched. When
+    # $RPM_SOURCES_CACHE is unset spectool downloads straight into SOURCES,
+    # so the guard above never sees those writes; this makes "dist-git wins"
+    # true on both paths rather than only on the cached one.
+    find "$abs_pkg_dir" -maxdepth 1 -type f \
+        ! -name "*.spec" \
+        ! -name "sources" \
+        ! -name "changelog" \
+        ! -name "rpminspect.yaml" \
+        ! -name "*.md" \
+        -exec cp -f {} "${builddir}/SOURCES/" \;
 
     # Fetch dist-git lookaside sources. A package imported from Fedora dist-git
     # can list artifacts in its `sources` file that have no URL in the spec at
@@ -418,7 +446,32 @@ prepare_sources() {
             else
                 continue
             fi
-            [[ -f "${builddir}/SOURCES/${entry_name}" ]] && continue
+            # Present is not the same as correct. A `sources` entry pins an
+            # exact artifact, but plenty of Rawhide specs point Source0 at a
+            # moving ref -- luajit's is
+            # https://github.com/LuaJIT/LuaJIT/archive/refs/heads/v2.1/...,
+            # the branch head. Fedora builds from the lookaside copy the
+            # checksum names; spectool downloads whatever that branch is
+            # today. The two drifted, so the patches (cut against the pinned
+            # snapshot) stopped applying and luajit failed %prep in
+            # run 31294475023 while Fedora's own build of the same commit is
+            # fine.
+            #
+            # So verify what is staged against the recorded hash, and treat a
+            # mismatch exactly like a missing file: discard it and take the
+            # lookaside copy, which is by definition the artifact the rest of
+            # the packaging was written against.
+            if [[ -f "${builddir}/SOURCES/${entry_name}" ]]; then
+                if echo "${entry_hash}  ${builddir}/SOURCES/${entry_name}" \
+                    | "${entry_algo}sum" --check --status -; then
+                    continue
+                fi
+                echo "==> [${pkg_name}] ${entry_name} does not match the ${entry_algo} in dist-git sources; refetching"
+                # rm rather than overwrite: with $RPM_SOURCES_CACHE this file
+                # is a hard link to the cached copy, and writing through it
+                # would edit the cache behind its own checksum check.
+                rm -f "${builddir}/SOURCES/${entry_name}"
+            fi
             echo "==> [${pkg_name}] Fetching ${entry_name} from the Fedora lookaside cache (${entry_algo})..."
             # The lookaside path carries the algorithm, so the legacy entries
             # live under .../md5/<hash>/... and not under sha512.

--- a/src/hummingbird/SwayNotificationCenter/SwayNotificationCenter.spec
+++ b/src/hummingbird/SwayNotificationCenter/SwayNotificationCenter.spec
@@ -1,0 +1,141 @@
+%global alt_pkg_name swaync
+
+Name:       SwayNotificationCenter
+Version:    0.10.1
+Release:    5%{?dist}
+Summary:    Simple notification daemon with GTK GUI for SwayWM
+License:    GPL-3.0-only
+URL:        https://github.com/ErikReider/SwayNotificationCenter
+Source:     %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+
+BuildRequires:  meson >= 0.51.0
+BuildRequires:  vala >= 0.56
+BuildRequires:  scdoc
+BuildRequires:  pkgconfig(gtk+-3.0) >= 3.22
+BuildRequires:  pkgconfig(gtk-layer-shell-0) >= 0.1
+BuildRequires:  pkgconfig(json-glib-1.0) >= 1.0
+BuildRequires:  pkgconfig(libhandy-1) >= 1.4.0
+BuildRequires:  pkgconfig(glib-2.0) >= 2.50
+BuildRequires:  pkgconfig(gobject-introspection-1.0) >= 1.68
+BuildRequires:  pkgconfig(gee-0.8) >= 0.20
+BuildRequires:  pkgconfig(bash-completion)
+BuildRequires:  pkgconfig(fish)
+BuildRequires:  pkgconfig(libpulse)
+BuildRequires:  pkgconfig(granite)
+BuildRequires:  systemd-devel
+BuildRequires:  systemd
+BuildRequires:  sassc
+BuildRequires:  granite-devel
+
+Requires:       gvfs
+Requires:       libnotify
+Requires:       dbus
+Requires:       dbus-common
+
+Provides:   desktop-notification-daemon
+Provides:   sway-notification-center = %{version}-%{release}
+Provides:   %{alt_pkg_name} = %{version}-%{release}
+
+%description
+%{summary}.
+
+%package bash-completion
+BuildArch:      noarch
+Summary:        Bash completion files for %{name}
+Provides:       %{alt_pkg_name}-bash-completion = %{version}-%{release}
+Supplements:    (%{name} and bash-completion)
+
+Requires:       bash-completion
+Requires:       %{name} = %{version}-%{release}
+
+%description bash-completion
+This package installs Bash completion files for %{name}
+
+%package zsh-completion
+BuildArch:      noarch
+Summary:        Zsh completion files for %{name}
+Provides:       %{alt_pkg_name}-zsh-completion = %{version}-%{release}
+Supplements:    (%{name} and zsh)
+
+Requires:       zsh
+Requires:       %{name} = %{version}-%{release}
+
+%description zsh-completion
+This package installs Zsh completion files for %{name}
+
+%package fish-completion
+BuildArch:      noarch
+Summary:        Fish completion files for %{name}
+Provides:       %{alt_pkg_name}-fish-completion = %{version}-%{release}
+Supplements:    (%{name} and fish)
+
+Requires:       fish
+Requires:       %{name} = %{version}-%{release}
+
+%description fish-completion
+This package installs Fish completion files for %{name}
+
+%prep
+%autosetup
+
+
+%build
+%meson
+%meson_build
+
+
+%install
+%meson_install
+
+
+%post
+%systemd_user_post swaync.service
+
+%preun
+%systemd_user_preun swaync.service
+
+
+%files
+%doc README.md
+%{_bindir}/swaync-client
+%{_bindir}/swaync
+%license COPYING
+%dir %{_sysconfdir}/xdg/swaync
+%config(noreplace) %{_sysconfdir}/xdg/swaync/configSchema.json
+%config(noreplace) %{_sysconfdir}/xdg/swaync/config.json
+%config(noreplace) %{_sysconfdir}/xdg/swaync/style.css
+%{_userunitdir}/swaync.service
+%{_datadir}/dbus-1/services/org.erikreider.swaync.service
+%{_datadir}/glib-2.0/schemas/org.erikreider.swaync.gschema.xml
+%{_mandir}/man1/swaync-client.1*
+%{_mandir}/man1/swaync.1*
+%{_mandir}/man5/swaync.5*
+
+%files bash-completion
+%{_datadir}/bash-completion/completions/swaync
+%{_datadir}/bash-completion/completions/swaync-client
+
+%files zsh-completion
+%{_datadir}/zsh/site-functions/_swaync
+%{_datadir}/zsh/site-functions/_swaync-client
+
+%files fish-completion
+%{_datadir}/fish/vendor_completions.d/swaync-client.fish
+%{_datadir}/fish/vendor_completions.d/swaync.fish
+
+%changelog
+* Fri Jan 16 2026 Fedora Release Engineering <releng@fedoraproject.org> - 0.10.1-5
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_44_Mass_Rebuild
+
+* Fri Jan 16 2026 Fedora Release Engineering <releng@fedoraproject.org> - 0.10.1-4
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_44_Mass_Rebuild
+
+* Wed Jul 23 2025 Fedora Release Engineering <releng@fedoraproject.org> - 0.10.1-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_43_Mass_Rebuild
+
+* Thu Jan 16 2025 Fedora Release Engineering <releng@fedoraproject.org> - 0.10.1-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_42_Mass_Rebuild
+
+* Tue Sep 03 2024 Neal Gompa <ngompa@fedoraproject.org> - 0.10.1-1
+- Initial package
+

--- a/src/hummingbird/SwayNotificationCenter/sources
+++ b/src/hummingbird/SwayNotificationCenter/sources
@@ -1,0 +1,1 @@
+SHA512 (SwayNotificationCenter-0.10.1.tar.gz) = fa753ee60ab180186d852f69c0ecf22d64b8c3aba280dce7c53f86c04a694abdb9570546fab46d4a32cade3a6eed5599ae2794afc56d5b141d4ea5fde976b49a

--- a/tests/test_hummingbird_uses_tideforge_caching.py
+++ b/tests/test_hummingbird_uses_tideforge_caching.py
@@ -83,8 +83,13 @@ def test_lookaside_downloads_are_persisted_only_after_verification():
     text = BUILD_CHAIN.read_text()
     start = text.index("Fetch dist-git lookaside sources")
     block = text[start:text.index('done < "$sources_file"', start)]
-    check = block.index("--check --quiet")
-    persist = block.index("RPM_SOURCES_CACHE")
+    # Comments in this block discuss the cache by name, and prose is not an
+    # order of operations -- index the code only.
+    code = "\n".join(
+        line for line in block.splitlines() if not line.lstrip().startswith("#")
+    )
+    check = code.index("--check --quiet")
+    persist = code.index("RPM_SOURCES_CACHE")
     assert check < persist, (
         "a lookaside archive is copied into the shared cache before its "
         "checksum is verified; a corrupt download would be served to every "

--- a/tests/test_swaync_builds_the_version_fedora_ships.py
+++ b/tests/test_swaync_builds_the_version_fedora_ships.py
@@ -1,0 +1,91 @@
+"""niri's notification daemon could not build, and Fedora's cannot either.
+
+SwayNotificationCenter is a declared niri root. Importing it from Rawhide
+dist-git gets a spec at 0.12.6 whose src/meson.build carries
+
+    dependency('granite-7', version: '>= 7.5.0')
+
+and Rawhide ships Granite 6 -- one `granite` source package providing
+pkgconfig(granite) and libgranite.so.6, nothing newer. That is not a
+Hummingbird problem: Fedora's own changelog stops at 0.10.1-5 and the binary
+in Rawhide today is 0.10.1, so the 0.12.6 bump has never built there. Three
+Rawhide packages want granite-7 (SwayNotificationCenter, minder, warble).
+
+Packaging Granite 7 is the better long-term answer -- 0.12.6 is the GTK4 and
+libadwaita version, and the rest of niri's stack is GTK4. It is not the answer
+available right now: it needs an upstream tarball and its checksum, and the
+elementary/granite archive is not reachable from the build environment.
+
+So this pins the version Fedora actually ships. 0.10.1 needs granite 6,
+gtk+-3.0, libhandy-1 and gtk-layer-shell-0, all of which Rawhide provides --
+all 18 of its BuildRequires resolve. niri gets the same notification daemon a
+Fedora user gets today, instead of none.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+VENDORED = REPO / "src" / "hummingbird" / "SwayNotificationCenter"
+SPEC = VENDORED / "SwayNotificationCenter.spec"
+MANIFEST = REPO / "build-order-hummingbird-desktops.yml"
+
+
+@pytest.fixture(scope="module")
+def spec_text():
+    return SPEC.read_text()
+
+
+def test_the_packaging_is_vendored_not_imported():
+    """An imported spec is whatever Rawhide has today, which is the broken one."""
+    assert SPEC.is_file(), f"{SPEC} is missing"
+    assert (VENDORED / "sources").is_file(), "no sources file; the tarball cannot be fetched"
+
+
+def test_the_manifest_builds_it_from_the_vendored_spec():
+    order = yaml.safe_load(MANIFEST.read_text())
+    entries = [p for tier in order["tiers"] for p in tier["packages"]
+               if p["path"].endswith("/SwayNotificationCenter")]
+    assert len(entries) == 1, f"expected exactly one entry, got {entries}"
+    assert "distgit" not in entries[0], (
+        "the manifest still imports SwayNotificationCenter from dist-git, which "
+        "fetches 0.12.6 and its unsatisfiable granite-7 BuildRequires"
+    )
+
+
+def test_it_pins_the_version_fedora_actually_ships(spec_text):
+    version = re.search(r"^Version:\s*(\S+)", spec_text, re.M).group(1)
+    assert version == "0.10.1", (
+        f"pinned to {version}; 0.12.6 needs granite-7 >= 7.5.0 and Rawhide has "
+        "only Granite 6. If Granite 7 gets packaged, this pin can be lifted."
+    )
+
+
+def test_it_does_not_buildrequire_granite_7(spec_text):
+    """The single capability nothing in Rawhide provides."""
+    assert "granite-7" not in spec_text, (
+        "the vendored spec still wants granite-7, which is the thing that "
+        "could not be satisfied in the first place"
+    )
+
+
+def test_every_buildrequires_names_something(spec_text):
+    """A typo here fails hours into a run, in a layer near the end."""
+    brs = re.findall(r"^BuildRequires:\s*(\S+)", spec_text, re.M)
+    assert len(brs) >= 15, f"only {len(brs)} BuildRequires; the spec looks truncated"
+    for b in brs:
+        assert not b.startswith("%"), f"unexpanded macro in BuildRequires: {b}"
+
+
+def test_the_sources_entry_is_a_usable_sha512():
+    """build-chain resolves the tarball through Fedora's lookaside cache using
+    this line; a malformed one fails the download rather than the checksum."""
+    text = (VENDORED / "sources").read_text().strip()
+    match = re.match(r"^SHA512 \((.+)\) = ([0-9a-f]{128})$", text)
+    assert match, f"sources is not a lookaside SHA512 entry: {text!r}"
+    assert "0.10.1" in match.group(1), (
+        f"sources names {match.group(1)}, which is not the pinned version"
+    )


### PR DESCRIPTION
`SwayNotificationCenter` is a declared **niri root** and it could not build — the last package in the whole 1248-package set with an unsatisfiable `BuildRequires`.

## Why it fails

Importing it from Rawhide dist-git gets a spec at **0.12.6**, whose upstream `src/meson.build:91` carries:

```meson
dependency('granite-7', version: '>= 7.5.0'),
```

Rawhide has exactly one `granite` source package, providing `pkgconfig(granite)` and `libgranite.so.6`. Nothing newer.

**This is not a Hummingbird problem.** Fedora's own changelog for this package stops at `0.10.1-5`, and the binary in Rawhide today *is* 0.10.1 — the 0.12.6 bump has never built there. Three Rawhide packages want `granite-7`: `SwayNotificationCenter`, `minder`, `warble`.

## Why not just package Granite 7

That is the better long-term answer, and I'd still recommend it: 0.12.6 is the GTK4/libadwaita version, and the rest of niri's stack is GTK4, where 0.10.1 is GTK3 with libhandy and gtk-layer-shell.

It is not the answer available right now. It needs the upstream tarball and its checksum, and the `elementary/granite` archive is not reachable from this build environment — so the spec could be neither completed nor verified. Shipping an unbuildable guess would be worse than shipping the version that works.

## What this does

Vendors the packaging Fedora shipped last, at **0.10.1**. All **18** of its BuildRequires resolve against Rawhide — `granite` 6, `gtk+-3.0`, `libhandy-1`, `gtk-layer-shell-0` and the rest — checked against a **freshly fetched** index rather than the pinned cache:

```
vendored 0.10.1 spec BuildRequires (18):  all OK
unsatisfiable: 0
```

niri gets the same notification daemon a Fedora user gets today instead of none, and the pin lifts the moment Granite 7 exists.

Vendoring is also what makes it stick: the manifest entry now carries no `distgit:` key, so the build uses this spec rather than re-importing the broken one every run. Same mechanism `src/gnome-50/gtk4` already uses.

## Limitation worth naming

`scripts/preflight-buildrequires.py` (#304) still reads BuildRequires from Fedora's *source index*, so it will keep reporting `granite-7` for this package even though the vendored spec doesn't want it. The check should prefer a vendored spec when one exists; until it does, its one finding here is a **false positive**.

## Tests

6 tests, mutation-verified three ways — restoring 0.12.6, reintroducing the `granite-7` BuildRequires, and putting the `distgit:` key back each fail exactly the test that covers them and nothing else. `514 passed` overall.

Based on #303 rather than `main`, since it needs that branch's emitter to regenerate the manifest.

## Also here: CI source staging (`scripts/build-chain.sh`)

CI on this branch failed in `layer-00` on an unrelated package, `luajit`, with `2 out of 4 hunks FAILED -- saving rejects to file src/lj_ccall.c.rej`. It is a build-chain bug, not a luajit one, so the fix rides along.

Two of luajit's artifacts are fetched live on every build and had both drifted out from under packaging Fedora still builds fine: `Source0` is a branch head (`.../archive/refs/heads/v2.1/...`) rather than a snapshot, and `Patch2` is `https://github.com/luajit/luajit/pull/631.patch`, whose diff GitHub regenerates against a moving base. dist-git pins both, and `prepare_sources` was throwing away both pins: the lookaside fetch skipped the tarball because a file of that name already existed, and the cache hard-link step overwrote the committed patch with the live download.

Verifying presence is not enough, so a `sources` entry is now checked against its recorded hash, and a mismatch is handled like a missing file:

```bash
if [[ -f "${builddir}/SOURCES/${entry_name}" ]]; then
    if echo "${entry_hash}  ${builddir}/SOURCES/${entry_name}" \
        | "${entry_algo}sum" --check --status -; then
        continue
    fi
    echo "==> [${pkg_name}] ${entry_name} does not match the ${entry_algo} in dist-git sources; refetching"
    rm -f "${builddir}/SOURCES/${entry_name}"
fi
```

A cached download also no longer lands on a filename the package directory already provides. Reproduced outside CI: the pinned tarball plus either live artifact gives that exact reject, and the pinned tarball plus both dist-git copies applies clean; a harness driving the real `prepare_sources` with a spectool stub passes on both the cached and uncached paths.

A rolling `Source0` is ordinary in Rawhide and 1248 packages import from dist-git the same way, so this was never specific to luajit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->