### PR TITLE
fix(fanout): a 403 from a repo we never use must not kill a build job

### DIFF
--- a/.github/workflows/build-hummingbird-distributed.yml
+++ b/.github/workflows/build-hummingbird-distributed.yml
@@ -17,7 +17,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Configure rclone
         run: 'mkdir -p ~/.config/rclone
 
@@ -62,7 +64,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -132,7 +136,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -178,7 +184,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -248,7 +256,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -291,7 +301,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -361,7 +373,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -405,7 +419,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -475,7 +491,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -724,7 +742,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -794,7 +814,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -915,7 +937,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -985,7 +1009,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -1050,7 +1076,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -1120,7 +1148,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -1170,7 +1200,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -1240,7 +1272,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -1299,7 +1333,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -1369,7 +1405,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -1493,7 +1531,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -1563,7 +1603,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -1643,7 +1685,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -1713,7 +1757,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -1784,7 +1830,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -1854,7 +1902,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -1916,7 +1966,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -1986,7 +2038,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -2052,7 +2106,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -2122,7 +2178,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -2177,7 +2235,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -2247,7 +2307,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -2327,7 +2389,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -2397,7 +2461,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -2469,7 +2535,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -2539,7 +2607,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -2585,7 +2655,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -2655,7 +2727,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -2712,7 +2786,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -2782,7 +2858,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -3074,7 +3152,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -3151,7 +3231,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -3223,7 +3305,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -3407,7 +3491,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -3477,7 +3563,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -3593,7 +3681,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -3663,7 +3753,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -3734,7 +3826,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -3804,7 +3898,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -3872,7 +3968,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -3942,7 +4040,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -3990,7 +4090,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -4060,7 +4162,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -4104,7 +4208,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -4174,7 +4280,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -4223,7 +4331,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -4293,7 +4403,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -4348,7 +4460,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -4418,7 +4532,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -4466,7 +4582,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -4536,7 +4654,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -4583,7 +4703,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -4653,7 +4775,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -4701,7 +4825,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -4771,7 +4897,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -4814,7 +4942,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -4884,7 +5014,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -4927,7 +5059,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -4997,7 +5131,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -5051,7 +5187,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -5121,7 +5259,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -5173,7 +5313,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -5243,7 +5385,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -5295,7 +5439,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -5365,7 +5511,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -5411,7 +5559,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -5481,7 +5631,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -5524,7 +5676,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -5594,7 +5748,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -5637,7 +5793,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -5707,7 +5865,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -5753,7 +5913,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install host dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q podman createrepo-c rpm rclone'
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6
         with:
@@ -5823,7 +5985,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install createrepo_c
-        run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q createrepo-c rclone'
       - name: Download new RPMs
         uses: actions/download-artifact@v8
         continue-on-error: true
@@ -5861,7 +6025,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Install dependencies
-        run: sudo apt-get update -q && sudo apt-get install -y -q rpm createrepo-c gpg gpgconf rclone
+        run: 'sudo apt-get update -q || sudo apt-get update -q || true
+
+          sudo apt-get install -y -q rpm createrepo-c gpg gpgconf rclone'
       - name: Seed final repo from R2
         run: 'mkdir -p ~/.config/rclone
 

--- a/scripts/generate-distributed-workflow.py
+++ b/scripts/generate-distributed-workflow.py
@@ -87,7 +87,7 @@ def generate_workflow(manifest_path, output_path, workflow_name='Distributed Bui
         'runs-on': 'ubuntu-latest',
         'steps': [
             {'name': 'Checkout', 'uses': 'actions/checkout@v7'},
-            {'name': 'Install dependencies', 'run': 'sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone'},
+            {'name': 'Install dependencies', 'run': 'sudo apt-get update -q || sudo apt-get update -q || true\nsudo apt-get install -y -q createrepo-c rclone'},
             {'name': 'Configure rclone', 'run': _rclone_conf(r2_state)},
             {'name': 'Seed local repo from R2', 'run': f'mkdir -p local-repo\necho "Downloading existing repo from R2..."\nrclone sync "r2:${{R2_BUCKET}}/{r2_path}/" "local-repo/" --exclude "repodata/**" {RCLONE_FLAGS} || true\ncreaterepo_c local-repo\n'},
             # With R2 as the shared state this job exists to guarantee the
@@ -144,7 +144,7 @@ def generate_workflow(manifest_path, output_path, workflow_name='Distributed Bui
                 },
                 'steps': [
                     {'name': 'Checkout', 'uses': 'actions/checkout@v7', **({'with': {'submodules': 'recursive'}} if submodules else {})},
-                    {'name': 'Install host dependencies', 'run': 'sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone'},
+                    {'name': 'Install host dependencies', 'run': 'sudo apt-get update -q || sudo apt-get update -q || true\nsudo apt-get install -y -q podman createrepo-c rpm rclone'},
                     {'name': 'Cache CentOS Stream 10 image', 'uses': 'actions/cache@v6', 'with': {'path': '/tmp/cs10-image.tar', 'key': f"cs10-image-${{{{ hashFiles('{mock_cfg_file}') }}}}"}},
                     {'name': 'Load or pull image', 'run': 'if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n'},
                     *([
@@ -232,7 +232,7 @@ def generate_workflow(manifest_path, output_path, workflow_name='Distributed Bui
             'if': '${{ !cancelled() }}',
             'runs-on': 'ubuntu-latest',
             'steps': [
-                {'name': 'Install createrepo_c', 'run': 'sudo apt-get update -q && sudo apt-get install -y -q createrepo-c rclone'},
+                {'name': 'Install createrepo_c', 'run': 'sudo apt-get update -q || sudo apt-get update -q || true\nsudo apt-get install -y -q createrepo-c rclone'},
                 *([] if r2_state else [
                     {'name': 'Download previous repo', 'uses': 'actions/download-artifact@v8', 'with': {'name': prev_tier_repo, 'path': 'local-repo'}},
                 ]),
@@ -261,7 +261,7 @@ def generate_workflow(manifest_path, output_path, workflow_name='Distributed Bui
         'runs-on': 'ubuntu-latest',
         'steps': [
             {'name': 'Checkout', 'uses': 'actions/checkout@v7'},
-            {'name': 'Install dependencies', 'run': 'sudo apt-get update -q && sudo apt-get install -y -q rpm createrepo-c gpg gpgconf rclone'},
+            {'name': 'Install dependencies', 'run': 'sudo apt-get update -q || sudo apt-get update -q || true\nsudo apt-get install -y -q rpm createrepo-c gpg gpgconf rclone'},
             *([
                 {'name': 'Seed final repo from R2', 'run': ('mkdir -p ~/.config/rclone\ncat > ~/.config/rclone/rclone.conf << EOF\n[r2]\ntype = s3\nprovider = Cloudflare\naccess_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}\nsecret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}\nendpoint = ${{ secrets.R2_ENDPOINT }}\nEOF\nmkdir -p local-repo\nrclone copy "r2:${R2_BUCKET}/%s/" local-repo/ ' + RCLONE_FLAGS + '\n') % r2_path},
             ] if r2_state else [

--- a/tests/test_apt_update_survives_a_broken_third_party_repo.py
+++ b/tests/test_apt_update_survives_a_broken_third_party_repo.py
@@ -1,0 +1,86 @@
+"""A 403 from a repo we never use must not fail a build job.
+
+GitHub's Ubuntu runner image ships apt sources for packages.microsoft.com --
+azure-cli and the Microsoft prod repo -- that this project does not use. When
+one of them returns 403, `apt-get update` exits 100, and because the step is
+
+    sudo apt-get update -q && sudo apt-get install -y -q ...
+
+under `bash -e`, the whole job dies before it builds anything. Observed on run
+31294475023, job 93199440461:
+
+    E: Failed to fetch https://packages.microsoft.com/repos/azure-cli/...
+       403  Forbidden [IP: 13.107.246.41 443]
+    E: The repository '...' is no longer signed.
+    ##[error]Process completed with exit code 100.
+
+The package there was libid3tag, which never got as far as being built. At
+1248 jobs a transient 403 on somebody else's mirror would take out a random
+subset of the run every time.
+
+`update` may now fail; `install` may not. If the packages genuinely cannot be
+resolved, apt-get install still exits non-zero and the job still fails -- which
+is the distinction that matters, because swallowing that would turn a broken
+runner into a silently incomplete build.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO / ".github" / "workflows" / "build-hummingbird-distributed.yml"
+
+
+@pytest.fixture(scope="module")
+def apt_steps():
+    wf = yaml.safe_load(WORKFLOW.read_text())
+    found = []
+    for job_name, job in wf["jobs"].items():
+        for step in job.get("steps", []):
+            if "apt-get" in str(step.get("run", "")):
+                found.append((job_name, step["run"]))
+    return found
+
+
+def test_there_are_apt_steps_to_check(apt_steps):
+    assert apt_steps, "no apt-get steps found; the fixture is wrong"
+
+
+def test_no_step_chains_update_into_install(apt_steps):
+    for job_name, run in apt_steps:
+        assert "apt-get update -q && sudo apt-get install" not in run, (
+            f"{job_name} still fails the whole job when any configured apt "
+            "repository returns an error, including ones the runner image "
+            "ships and this project never uses"
+        )
+
+
+def test_update_is_allowed_to_fail(apt_steps):
+    for job_name, run in apt_steps:
+        update = [l for l in run.split("\n") if "apt-get update" in l]
+        assert update, f"{job_name} installs without updating"
+        assert any("|| true" in l for l in update), (
+            f"{job_name} lets a third-party repo failure kill the job: {update}"
+        )
+
+
+def test_install_is_not_allowed_to_fail(apt_steps):
+    """Swallowing this would turn a broken runner into a silent partial build."""
+    for job_name, run in apt_steps:
+        install = [l for l in run.split("\n") if "apt-get install" in l]
+        assert install, f"{job_name} updates but never installs"
+        for line in install:
+            assert "|| true" not in line and "|| :" not in line, (
+                f"{job_name} ignores a failed install: {line}"
+            )
+
+
+def test_update_is_retried_before_giving_up(apt_steps):
+    """The 403 was transient; one retry costs seconds and usually clears it."""
+    for job_name, run in apt_steps:
+        update = [l for l in run.split("\n") if "apt-get update" in l][0]
+        assert update.count("apt-get update") >= 2, (
+            f"{job_name} gives up on the first failure: {update}"
+        )


### PR DESCRIPTION
First real failure of run [31294475023](https://github.com/tuna-os/tunaos-packages/actions/runs/31294475023), job `93199440461`, nominally **`build-layer-00 (src/hummingbird/libid3tag)`**:

```
E: Failed to fetch https://packages.microsoft.com/repos/azure-cli/dists/noble/InRelease
   403  Forbidden [IP: 13.107.246.41 443]
E: The repository 'https://packages.microsoft.com/ubuntu/24.04/prod noble InRelease' is no longer signed.
##[error]Process completed with exit code 100.
```

**`libid3tag` never got as far as being built.** GitHub's Ubuntu runner image ships apt sources for `packages.microsoft.com` — azure-cli and the Microsoft prod repo — which this project does not use and cannot control. `apt-get update` exits 100 if *any* configured repository fails, and the step was:

```yaml
sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm rclone
```

under `bash -e`. So somebody else's mirror having a bad minute takes out an entire build job.

At 1248 jobs that removes a **random subset of every run** — and the failure gets attributed to whichever package happened to be on that runner, which is exactly how this nearly got triaged as a `libid3tag` problem.

## The fix

```yaml
sudo apt-get update -q || sudo apt-get update -q || true
sudo apt-get install -y -q podman createrepo-c rpm rclone
```

`update` may fail, and is retried once first because the 403 is transient. **`install` may not fail** — if the packages genuinely can't be resolved, the job still dies.

That distinction is the entire point. Swallowing a failed *install* would turn a broken runner into a silently incomplete build, which is a worse bug than the one being fixed. There's a test pinning it in both directions.

## Tests

5 tests, mutation-verified three ways — restoring the chained form, swallowing a failed install, and dropping the retry each fail exactly the test that covers them. `524 passed` overall.

Applies to all four apt steps (seed, build, consolidate, publish). Based on #306, at the tip of the stack.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->