### PR TITLE
fix(buildroot): Hummingbird ships five packages that cannot install

### DIFF
--- a/mock/hummingbird-ci.cfg
+++ b/mock/hummingbird-ci.cfg
@@ -86,6 +86,36 @@ baseurl=https://packages.redhat.com/api/pulp-content/public-hummingbird/$basearc
 gpgcheck=0
 enabled=1
 priority=10
+# Five packages Hummingbird ships that cannot install anywhere, including in
+# Hummingbird itself.  Its protobuf and re2 were linked against abseil-cpp
+# soname 2601 and Hummingbird never shipped that abseil; Rawhide's is
+# 20260526.0, a different soname.  Measured 2026-08-09 over Hummingbird's own
+# primary.xml: 21 libabsl_* capabilities that neither repository provides.
+#
+# At priority 10 Hummingbird wins the name, so the buildroot took the broken
+# copy and every build that reached it died -- that is what failed
+# libphonenumber in run 31281499563:
+#
+#     package re2-2:20251105-19.hum1.x86_64 from hummingbird requires
+#       libabsl_hash.so.2601.0.0()(64bit), but none of the providers can be
+#       installed
+#
+# Excluding them hands protobuf/re2 to Rawhide, which is self-consistent.
+# Safe by construction: a package that cannot install was in no successful
+# resolution, so nothing that works today can change.
+#
+# protobuf-devel is in the list because the set has to be closed, not because
+# it is broken as shipped -- it requires libprotobuf.so.35.1.0 from
+# Hummingbird's protobuf-cpp, so dropping protobuf-cpp orphans it.  Simulated
+# before committing: excluding the other four left exactly one new casualty,
+# and adding it converges with zero soname-broken packages left.
+#
+# The 23 that remain are all `python3.14dist(...)` +extras metapackages
+# (python3-sentry-sdk+flask and friends).  They are inert until something asks
+# for one, and excluding them would hide the gap rather than close it.
+#
+# scripts/target-abi-gaps.py --check recomputes this and fails if it drifts.
+excludepkgs=protobuf-compiler,protobuf-cpp,protobuf-devel,protobuf-lite,re2
 
 [fedora-44-python]
 name=Fedora 44 - Python 3.14 build inputs only

--- a/scripts/target-abi-gaps.py
+++ b/scripts/target-abi-gaps.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Which of the target's OWN packages cannot install in the buildroot.
+
+Hummingbird is the highest-priority repository in mock/hummingbird-ci.cfg, so
+its packages win the buildroot whenever a name matches.  That is the point --
+we must build against the ABI the target actually ships.  It only works while
+the target is self-consistent, and it is not:
+
+    package re2-2:20251105-19.hum1.x86_64 from hummingbird requires
+      libabsl_hash.so.2601.0.0()(64bit), but none of the providers can be
+      installed
+
+Hummingbird's protobuf and re2 were linked against abseil-cpp soname 2601 and
+Hummingbird never shipped that abseil.  Rawhide's is 20260526.0, a different
+soname.  Those packages are dead on arrival, and so is every buildroot that
+pulls one in -- which is what failed libphonenumber in run 31281499563.
+
+Excluding them lets dnf fall back to Rawhide's protobuf/re2, which are
+self-consistent.  Excluding a package that cannot install is safe by
+construction: no successful resolution could have used it.  The catch is that
+the set has to be closed -- dropping protobuf-cpp orphans protobuf-devel,
+which requires it by soname -- so this iterates to a fixed point.
+
+    scripts/target-abi-gaps.py --check      # exit 1 if the config is stale
+    scripts/target-abi-gaps.py              # print the report
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+MOCK_CONFIG = REPO / "mock" / "hummingbird-ci.cfg"
+
+
+def _load_gap_module():
+    spec = importlib.util.spec_from_file_location(
+        "measure_hummingbird_gap", REPO / "scripts" / "measure-hummingbird-gap.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def is_soname(capability: str) -> bool:
+    """A shared-library dependency, as opposed to a name or a python dist tag.
+
+    Only these cascade.  A missing `python3.14dist(flask)` means an optional
+    `+extras` metapackage cannot install, which costs nothing until something
+    asks for it; excluding those would hide the gap rather than close it.
+    """
+    return capability.startswith("lib") and ".so." in capability
+
+
+def unsatisfiable(target, reference, excluded=frozenset()):
+    """Target packages requiring capabilities the buildroot cannot provide."""
+    provides: dict[str, set] = collections.defaultdict(set)
+    for capability, names in target["provides"].items():
+        kept = set(names) - excluded
+        if kept:
+            provides[capability] |= kept
+    for name in target["packages"]:
+        if name not in excluded:
+            provides[name].add(name)
+    have = set(provides) | set(reference["provides"]) | set(reference["packages"])
+
+    broken = {}
+    for name, info in target["packages"].items():
+        if name in excluded:
+            continue
+        missing = [
+            requirement
+            for requirement in info["requires"]
+            if not requirement.startswith("(") and requirement not in have
+        ]
+        if missing:
+            broken[name] = missing
+    return broken
+
+
+def exclude_closure(target, reference, limit=16):
+    """Smallest exclude set leaving no soname-broken target package behind.
+
+    Iterated rather than computed in one pass because excluding a package can
+    break another: protobuf-devel is fine until protobuf-cpp goes, and then it
+    is not.  Measured against the indexes of 2026-08-09 this converges in two
+    rounds on five packages.
+    """
+    excluded: set[str] = set()
+    for _ in range(limit):
+        broken = unsatisfiable(target, reference, excluded)
+        fresh = {
+            name
+            for name, missing in broken.items()
+            if any(is_soname(capability) for capability in missing)
+        } - excluded
+        if not fresh:
+            return excluded
+        excluded |= fresh
+    raise RuntimeError(
+        f"exclude set did not converge in {limit} rounds; the target's own "
+        "dependency graph is more broken than this tool assumes"
+    )
+
+
+def configured_excludes(text: str) -> set[str]:
+    """The excludepkgs the hummingbird repository carries in the mock config."""
+    block = re.search(r"\[hummingbird\]\n(.*?)(?=\n\[|\n\"\"\"|\Z)", text, re.S)
+    if not block:
+        return set()
+    found = re.search(r"^excludepkgs=(.*)$", block.group(1), re.M)
+    if not found:
+        return set()
+    return {name.strip() for name in found.group(1).split(",") if name.strip()}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true",
+                        help="exit non-zero if the mock config is out of date")
+    parser.add_argument("--cache", type=Path,
+                        default=Path.home() / ".cache" / "tunaos-gap")
+    parser.add_argument("--target", default="https://packages.redhat.com/api/"
+                        "pulp-content/public-hummingbird/x86_64/")
+    parser.add_argument("--reference", default="https://dl.fedoraproject.org/pub/"
+                        "fedora/linux/development/rawhide/Everything/x86_64/os/")
+    args = parser.parse_args()
+
+    gap = _load_gap_module()
+    target = gap.parse_primary(gap.primary_of(args.target, args.cache)[0])
+    reference = gap.parse_primary(gap.primary_of(args.reference, args.cache)[0])
+
+    broken = unsatisfiable(target, reference)
+    excluded = exclude_closure(target, reference)
+    remaining = unsatisfiable(target, reference, excluded)
+
+    print(f"target packages                 {len(target['packages'])}")
+    print(f"cannot install as shipped       {len(broken)}")
+    print(f"exclude closure                 {','.join(sorted(excluded))}")
+    print(f"still broken after the exclude  {len(remaining)}"
+          f" (all non-soname: "
+          f"{not any(is_soname(c) for m in remaining.values() for c in m)})")
+
+    if args.check:
+        configured = configured_excludes(MOCK_CONFIG.read_text())
+        if configured != excluded:
+            print(
+                f"\nmock/hummingbird-ci.cfg excludes {sorted(configured)}\n"
+                f"but the measured closure is       {sorted(excluded)}",
+                file=sys.stderr,
+            )
+            return 1
+        print("\nmock config matches the measured closure")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_target_abi_gaps.py
+++ b/tests/test_target_abi_gaps.py
@@ -1,0 +1,135 @@
+"""Hummingbird ships packages that cannot install, including in Hummingbird.
+
+Its protobuf and re2 were linked against abseil-cpp soname 2601, which
+Hummingbird never shipped; Rawhide's abseil is 20260526.0, a different soname.
+Hummingbird sits at priority 10 and wins the name, so the buildroot took the
+broken copy and every build reaching it died -- measured in run 31281499563:
+
+    package re2-2:20251105-19.hum1.x86_64 from hummingbird requires
+      libabsl_hash.so.2601.0.0()(64bit), but none of the providers can be
+      installed
+
+Excluding them hands protobuf/re2 to Rawhide. The subtlety these tests exist
+for is that the set must be CLOSED: protobuf-devel installs fine as shipped
+and breaks only once protobuf-cpp is excluded, so a single pass produces a
+config that is still wrong. Simulating the exclude before committing is what
+caught that.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SPEC = importlib.util.spec_from_file_location(
+    "target_abi_gaps", REPO / "scripts" / "target-abi-gaps.py"
+)
+gaps = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(gaps)
+
+ABSL = "libabsl_hash.so.2601.0.0()(64bit)"
+PROTOBUF_SO = "libprotobuf.so.35.1.0()(64bit)"
+
+
+def _indexes():
+    """Hummingbird's protobuf/re2 shape, reduced to its bones."""
+    target = {
+        "packages": {
+            "re2": {"srpm": "re2-1-1.hum1.src.rpm", "requires": [ABSL]},
+            "protobuf-cpp": {"srpm": "protobuf-1-1.hum1.src.rpm", "requires": [ABSL]},
+            "protobuf-devel": {
+                "srpm": "protobuf-1-1.hum1.src.rpm",
+                "requires": [PROTOBUF_SO],
+            },
+            "healthy": {"srpm": "healthy-1-1.hum1.src.rpm", "requires": ["libc.so.6"]},
+        },
+        "provides": {
+            "re2": {"re2"},
+            "protobuf-cpp": {"protobuf-cpp", "healthy"},
+            PROTOBUF_SO: {"protobuf-cpp"},
+            "protobuf-devel": {"protobuf-devel"},
+            "healthy": {"healthy"},
+            "libc.so.6": {"healthy"},
+        },
+    }
+    reference = {
+        "packages": {"re2": {"srpm": "re2-2-1.fc45.src.rpm", "requires": []}},
+        "provides": {"re2": {"re2"}, "protobuf-cpp": {"protobuf-cpp"}},
+    }
+    return target, reference
+
+
+def test_the_broken_packages_are_found() -> None:
+    target, reference = _indexes()
+    broken = gaps.unsatisfiable(target, reference)
+    assert set(broken) == {"re2", "protobuf-cpp"}, broken
+    assert ABSL in broken["re2"]
+
+
+def test_the_closure_includes_the_package_the_exclude_orphans() -> None:
+    """protobuf-devel is not broken as shipped -- excluding protobuf-cpp breaks it.
+
+    A single pass returns {re2, protobuf-cpp} and leaves a buildroot that still
+    cannot resolve protobuf-devel. This is the bug the simulation caught before
+    the config was written.
+    """
+    target, reference = _indexes()
+    closure = gaps.exclude_closure(target, reference)
+    assert closure == {"re2", "protobuf-cpp", "protobuf-devel"}, closure
+
+
+def test_nothing_soname_broken_survives_the_closure() -> None:
+    target, reference = _indexes()
+    closure = gaps.exclude_closure(target, reference)
+    left = gaps.unsatisfiable(target, reference, closure)
+    assert not [
+        c for missing in left.values() for c in missing if gaps.is_soname(c)
+    ], left
+
+
+def test_a_healthy_package_is_never_excluded() -> None:
+    """Over-excluding would silently swap the target's ABI for Rawhide's."""
+    target, reference = _indexes()
+    assert "healthy" not in gaps.exclude_closure(target, reference)
+
+
+def test_python_dist_gaps_do_not_cascade() -> None:
+    """`python3.14dist(...)` gaps are inert +extras metapackages, not ABI breaks.
+
+    Excluding them would hide the gap rather than close it, and would drop 23
+    Hummingbird packages from the buildroot for no benefit.
+    """
+    target, reference = _indexes()
+    target["packages"]["python3-sentry-sdk+flask"] = {
+        "srpm": "python-sentry-sdk-1-1.hum1.src.rpm",
+        "requires": ["python3.14dist(flask)"],
+    }
+    assert "python3-sentry-sdk+flask" in gaps.unsatisfiable(target, reference)
+    assert "python3-sentry-sdk+flask" not in gaps.exclude_closure(target, reference)
+
+
+def test_a_graph_that_never_converges_is_an_error_not_a_hang() -> None:
+    target, reference = _indexes()
+    with pytest.raises(RuntimeError, match="did not converge"):
+        gaps.exclude_closure(target, reference, limit=1)
+
+
+def test_the_mock_config_carries_the_measured_closure() -> None:
+    """The measurement is worthless if the buildroot does not apply it."""
+    configured = gaps.configured_excludes(gaps.MOCK_CONFIG.read_text())
+    assert configured == {
+        "protobuf-compiler",
+        "protobuf-cpp",
+        "protobuf-devel",
+        "protobuf-lite",
+        "re2",
+    }, f"mock/hummingbird-ci.cfg excludes {sorted(configured)}"
+
+
+def test_the_config_says_why_and_how_to_recheck() -> None:
+    text = gaps.MOCK_CONFIG.read_text()
+    assert "2601" in text, "the config does not name the soname that broke"
+    assert "target-abi-gaps.py" in text, "no pointer to the tool that recomputes it"


### PR DESCRIPTION
Run [31281499563](https://github.com/tuna-os/tunaos-packages/actions/runs/31281499563)'s log, in full — the first time this repo has read one of these chains rather than its tail:

```
Problem 3: package re2-devel-2:20251105-19.hum1.x86_64 from hummingbird
  requires re2(x86-64) = 2:20251105-19.hum1, but none of the providers can be installed
  package re2-2:20251105-19.hum1.x86_64 requires
    libabsl_hash.so.2601.0.0()(64bit) [and nine more absl sonames]
```

Hummingbird's `protobuf` and `re2` were linked against abseil-cpp soname **2601** and Hummingbird never shipped that abseil. Rawhide's is `20260526.0` — a different soname. Hummingbird sits at priority 10 and wins the name, so the buildroot took the broken copy and every build that reached it died.

## Measured, not inferred

Over Hummingbird's own `primary.xml`: **3384 packages, 27 of which require a capability neither Hummingbird nor Rawhide provides.**

| group | capabilities | packages |
|---|---|---|
| `libabsl_*.so.2601` | 21 | `protobuf-compiler`, `protobuf-cpp`, `protobuf-lite`, `re2` |
| `python3.14dist(...)` | 34 | 23 `+extras` metapackages |

Excluding the ABI group hands `protobuf`/`re2` to Rawhide, which is self-consistent. **Safe by construction:** a package that cannot install was in no successful resolution, so nothing that works today can change.

## The fifth name is why this needed simulating

`protobuf-devel` is not broken as shipped. It breaks *only once `protobuf-cpp` is excluded*, because it requires `libprotobuf.so.35.1.0` from it:

```
round 1:  24 unsatisfiable, 1 new to exclude ['protobuf-devel']
round 2:  23 unsatisfiable, 0 new to exclude []
```

A single pass would have shipped a buildroot that is still wrong. `exclude_closure()` iterates to a fixed point, and the test that pins this is the one that matters most in the file.

The 23 `python3.14dist` packages are deliberately **not** excluded — optional `+extras` metapackages, inert until something asks for one. Excluding them would hide the gap rather than close it.

## `scripts/target-abi-gaps.py`

Recomputes all of it; `--check` fails if the config drifts from the measurement. That matters because it is a claim about two repositories that both move.

```
target packages                 3384
cannot install as shipped       27
exclude closure                 protobuf-compiler,protobuf-cpp,protobuf-devel,protobuf-lite,re2
still broken after the exclude  23 (all non-soname: True)

mock config matches the measured closure
```

## Two things this is not — both of which I proposed and then measured

- **Not the `python(abi)` 3.14/3.15 split.** `qt6-qtserialport`'s failure has no python line in it at all.
- **Not a build-ordering problem.** I claimed `libabsl_*.so.2601` came from our own `abseil-cpp` build. It does not — we build abseil-cpp from Rawhide's spec, so it yields the `20260526.0` soname, and **zero** of the 1248 packages in the build order close any of the 55 gaps. The tiering change I wrote for that theory also made the order strictly worse (packages in BuildRequires cycles 277 → 502, largest unordered tier 255 → 501) and was reverted. Detail in #290.

## Tests

8 tests, mutation-verified six ways: collapsing the fixed point to one pass, cascading the python dist gaps, excluding healthy packages, dropping `protobuf-devel` from the config, removing the soname from the comment, and returning instead of raising on non-convergence each fail exactly the tests that cover them.

The comment mutation first reported a **false pass** — the soname appears twice and only one was replaced. The applied-count assertion caught it, for the second time tonight.

`546 passed`. The three files that fail to collect need Python 3.12+ for `scripts/tideforge.py` and do so unchanged on `main`.

Based on #309, at the tip of the stack.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->