### PR TITLE
fix(buildroot): perl has the same ABI split as python, and no pin

### DIFF
--- a/mock/hummingbird-ci.cfg
+++ b/mock/hummingbird-ci.cfg
@@ -37,6 +37,38 @@
 #     installed package python3-pip-26.2-0.1.hum1.noarch requires
 #     python(abi) = 3.14
 #
+# Perl is the same story, one release further along, and it was NOT mitigated
+# until run 31294475023 hit it:
+#
+#     perl      hummingbird 5.42.2        rawhide 5.44.0-527.fc45
+#
+# Read out of that run's layer-04, which failed thirteen perl packages at once:
+#
+#     Failed to resolve the transaction:
+#     Problem 1: cannot install both perl-libs-4:5.44.0-527.fc45.x86_64 from
+#       fedora and perl-libs-4:5.42.2-525.hum1.x86_64 from hummingbird
+#      - package perl-Unicode-LineBreak-...fc45 from fedora requires
+#        libperl.so.5.44()(64bit), but none of the providers can be installed
+#      - package perl-version-9:0.99.33-522.fc44.x86_64 from fedora-44-python
+#        is filtered out by exclude filtering
+#
+# That last line is the whole fix: F44 already carries the perl module the
+# buildroot needs, and includepkgs=python3-*,flit was excluding it.
+#
+# F44's perl is 5.42.1, so its modules want libperl.so.5.42 and
+# perl(:MODULE_COMPAT_5.42.1).  Hummingbird's perl-libs 5.42.2 provides
+# libperl.so.5.42 and MODULE_COMPAT for 5.42.0, 5.42.1 AND 5.42.2 -- a range,
+# not a point -- so an F44 module resolves against Hummingbird's interpreter.
+# Rawhide's want libperl.so.5.44 and MODULE_COMPAT_5.44.0, which Hummingbird
+# does not provide at all, so every Rawhide perl module is uninstallable here.
+# 166 of the 1248 packages in the build order are perl-*.
+#
+# `perl` and `perl-libs` are deliberately NOT in includepkgs: Hummingbird ships
+# both and sits at priority 10, so it wins those names and stays the
+# interpreter.  F44 supplies only the modules around it.
+#
+# Remove this pin when Hummingbird's own perl reaches Rawhide's.
+#
 # Fedora 44 is the release whose interpreter is python3-3.14.6 — the same
 # upstream version Hummingbird ships — with a complete Python 3.14 module set
 # behind it.  It is pinned here for the Python namespace ONLY.  `includepkgs`
@@ -56,6 +88,7 @@
 #   1  local-build      RPMs produced by earlier tiers of this same run
 #   10 hummingbird      the target's own signed RPMs — the ABI we must match
 #   50 fedora-44-python Python 3.14 modules, buildroot only, includepkgs-confined
+#   50 fedora-44-perl   perl 5.42 modules, buildroot only, includepkgs-confined
 #   99 rawhide          (inherited) BuildRequires: fallback only
 #
 # Hummingbird stays at 10 so its own python3, setuptools, pip, packaging and
@@ -132,6 +165,22 @@ gpgcheck=0
 enabled=1
 priority=50
 includepkgs=python3-*,flit
+
+[fedora-44-perl]
+name=Fedora 44 - perl 5.42 build inputs only
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-44&arch=$basearch
+gpgcheck=0
+enabled=1
+priority=50
+includepkgs=perl-*
+
+[fedora-44-perl-updates]
+name=Fedora 44 updates - perl 5.42 build inputs only
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f44&arch=$basearch
+gpgcheck=0
+enabled=1
+priority=50
+includepkgs=perl-*
 """
 config_opts['plugin_conf']['bind_mount_enable'] = True
 config_opts['plugin_conf']['bind_mount_opts']['dirs'].append(('/local-repo', '/local-repo'))

--- a/tests/test_hummingbird_perl_abi_pin.py
+++ b/tests/test_hummingbird_perl_abi_pin.py
@@ -1,0 +1,128 @@
+"""Hummingbird is on perl 5.42.2; Rawhide is on 5.44.0.  Guard the bridge.
+
+This is the python(abi) split again, one interpreter over, and it went
+unmitigated until run 31294475023 reached layer-04 and failed thirteen perl
+packages at once.  The chain, read out of that run's log rather than guessed:
+
+    Failed to resolve the transaction:
+    Problem 1: cannot install both perl-libs-4:5.44.0-527.fc45.x86_64 from
+      fedora and perl-libs-4:5.42.2-525.hum1.x86_64 from hummingbird
+     - package perl-Unicode-LineBreak-2019.001-28.fc45.x86_64 from fedora
+       requires libperl.so.5.44()(64bit), but none of the providers can be
+       installed
+     - package perl-version-9:0.99.33-522.fc44.x86_64 from fedora-44-python
+       is filtered out by exclude filtering
+
+The last line names the fix.  F44 already carries the module the buildroot
+wants; `includepkgs=python3-*,flit` was excluding it.
+
+Why F44's modules resolve and Rawhide's cannot, measured against each
+repository's own metadata:
+
+    hummingbird perl-libs 5.42.2  provides  libperl.so.5.42
+                                            perl(:MODULE_COMPAT_5.42.0)
+                                            perl(:MODULE_COMPAT_5.42.1)
+                                            perl(:MODULE_COMPAT_5.42.2)
+    fedora 44   perl      5.42.1  modules want libperl.so.5.42 / COMPAT_5.42.1  -> OK
+    rawhide     perl      5.44.0  modules want libperl.so.5.44 / COMPAT_5.44.0  -> no provider
+
+MODULE_COMPAT is a range here, not a point, which is the property the whole
+pin rests on.  166 of the 1248 packages in the build order are perl-*.
+"""
+
+from __future__ import annotations
+
+import configparser
+import io
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+CFG = ROOT / "mock" / "hummingbird-ci.cfg"
+PERL_REPOS = ("fedora-44-perl", "fedora-44-perl-updates")
+RAWHIDE_PRIORITY = 99
+
+
+@pytest.fixture(scope="module")
+def conf() -> configparser.ConfigParser:
+    text = CFG.read_text()
+    blocks = re.findall(r'config_opts\[.dnf\.conf.\]\s*\+=\s*"""(.*?)"""', text, re.S)
+    assert blocks, "hummingbird-ci.cfg appends no dnf.conf repositories"
+    parser = configparser.ConfigParser(strict=False)
+    parser.read_file(io.StringIO("\n".join(blocks)))
+    return parser
+
+
+def test_a_perl_542_repository_is_pinned(conf) -> None:
+    for repo in PERL_REPOS:
+        assert conf.has_section(repo), (
+            f"{repo} is gone, so Rawhide's perl 5.44 modules are the only ones "
+            "on offer and every perl-* package fails buildroot install"
+        )
+        assert conf.get(repo, "enabled") == "1", f"{repo} is disabled"
+
+
+def test_the_pin_is_confined_to_the_perl_namespace(conf) -> None:
+    """includepkgs is the whole safety argument for adding an older Fedora."""
+    for repo in PERL_REPOS:
+        globs = [g.strip() for g in conf.get(repo, "includepkgs", fallback="").split(",")]
+        globs = [g for g in globs if g]
+        assert globs, (
+            f"{repo} has no includepkgs, so an entire Fedora 44 -- two releases "
+            "of C libraries -- can enter the chroot"
+        )
+        assert "*" not in globs, f"{repo} includepkgs is unrestricted"
+        for glob in globs:
+            assert glob.startswith("perl"), (
+                f"{repo} includepkgs carries {glob!r}, which is outside the perl "
+                "namespace this pin exists for"
+            )
+
+
+def test_the_interpreter_is_left_to_hummingbird(conf) -> None:
+    """Pulling `perl` or `perl-libs` from F44 would swap the interpreter.
+
+    Hummingbird ships both at priority 10 and would win the name anyway, but
+    listing them states the intent -- and a later priority change must not
+    silently turn F44 into the interpreter.
+    """
+    for repo in PERL_REPOS:
+        globs = [g.strip() for g in conf.get(repo, "includepkgs").split(",")]
+        for exact in ("perl", "perl-libs"):
+            assert exact not in globs, (
+                f"{repo} includes {exact!r} by name; the interpreter must come "
+                "from Hummingbird, not Fedora 44"
+            )
+
+
+def test_the_pin_outranks_rawhide_but_never_hummingbird(conf) -> None:
+    hummingbird = conf.getint("hummingbird", "priority")
+    local = conf.getint("local-build", "priority")
+    for repo in PERL_REPOS:
+        pinned = conf.getint(repo, "priority")
+        assert pinned > hummingbird, (
+            f"{repo} priority {pinned} is at least as good as hummingbird's "
+            f"{hummingbird}, so F44 could shadow the target's own perl"
+        )
+        assert pinned < RAWHIDE_PRIORITY, (
+            f"{repo} priority {pinned} does not beat Rawhide's "
+            f"{RAWHIDE_PRIORITY}, so Rawhide's 5.44 modules still win"
+        )
+        assert local < pinned, "packages this run built must outrank Fedora 44"
+
+
+def test_the_reason_travels_with_the_config() -> None:
+    """A pin with no stated expiry outlives the problem it was added for."""
+    text = CFG.read_text()
+    assert "5.44" in text and "5.42" in text, (
+        "the config does not record the perl versions the pin bridges"
+    )
+    assert "MODULE_COMPAT" in text, (
+        "the config does not record WHY an F44 module resolves against "
+        "Hummingbird's interpreter, which is the load-bearing fact"
+    )
+    assert "Remove this pin when Hummingbird's own perl" in text, (
+        "no removal condition, so this outlives the split"
+    )


### PR DESCRIPTION
Run [31294475023](https://github.com/tuna-os/tunaos-packages/actions/runs/31294475023) reached `layer-04` and failed **fifteen perl packages at once** — `Term-Table`, `Math-BigInt`, `Unicode-LineBreak`, `MIME-Charset`, `ExtUtils-Install`, `ExtUtils-MakeMaker`, `ExtUtils-ParseXS`, `ExtUtils-Manifest`, `Test-Simple`, `Test-Harness`, `JSON-PP`, `Module-Metadata`, `version`, `generators`, `Fedora-VSP`.

Its log says why, and its own last line names the fix:

```
Failed to resolve the transaction:
Problem 1: cannot install both perl-libs-4:5.44.0-527.fc45.x86_64 from fedora
                           and perl-libs-4:5.42.2-525.hum1.x86_64 from hummingbird
 - package perl-Unicode-LineBreak-2019.001-28.fc45.x86_64 from fedora requires
   libperl.so.5.44()(64bit), but none of the providers can be installed
 - package perl-version-9:0.99.33-522.fc44.x86_64 from fedora-44-python
   is filtered out by exclude filtering
```

This is the `python(abi)` 3.14/3.15 split `mock/hummingbird-ci.cfg` already documents, one interpreter over — except **perl had no mitigation at all.** The config mentioned perl zero times. **166 of the 1248** packages in the build order are `perl-*`.

## The fix is the last line of the error

Fedora 44 already carries the module the buildroot wants. `includepkgs=python3-*,flit` was excluding it. So this adds `fedora-44-perl` and `-updates` with `includepkgs=perl-*` at priority 50, mirroring the python pin exactly.

## Why F44's modules resolve and Rawhide's cannot

Measured against each repository's own `primary.xml`, not assumed:

| | provides / wants |
|---|---|
| hummingbird `perl-libs` 5.42.2 | `libperl.so.5.42`, `MODULE_COMPAT_5.42.0`, `_5.42.1`, `_5.42.2` |
| fedora 44 perl 5.42.1 → modules want | `libperl.so.5.42`, `MODULE_COMPAT_5.42.1` — **satisfied** |
| rawhide perl 5.44.0 → modules want | `libperl.so.5.44`, `MODULE_COMPAT_5.44.0` — **no provider** |

`MODULE_COMPAT` being a **range and not a point** is the property the whole pin rests on. Without it no Fedora release would work, because none ships 5.42.2 exactly — F44 is 5.42.1, F43 is 5.42.3.

`perl` and `perl-libs` are deliberately **absent** from `includepkgs`. Hummingbird ships both at priority 10 and wins those names regardless, but stating it means a later priority change can't quietly swap the interpreter, and a test pins that.

## On how this was arrived at

I nearly shipped it on the version gap alone — Hummingbird 5.42.2 vs Rawhide 5.44.0, no perl in the config, 166 packages exposed. That is the same shortcut that produced three wrong diagnoses for `qt6-qtserialport` earlier in this run (a NEVR theory, a Python-ABI theory, and a repo-shadowing theory, all measured and all wrong).

So I read a failing job's log first and wrote the change second. That is also how the `fedora-44-python is filtered out by exclude filtering` line turned up — and that line, not my hypothesis, is the actual fix.

## Tests

5 tests, mutation-verified six ways: removing the repos, letting the pin pull `perl`/`perl-libs`, widening `includepkgs` past the perl namespace, giving F44 a better priority than Hummingbird, dropping the `MODULE_COMPAT` rationale, and dropping the removal condition each fail exactly the tests that cover them.

`551 passed`. The three files that fail to collect need Python 3.12+ for `scripts/tideforge.py` and do so unchanged on `main`.

Based on #310, at the tip of the stack.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->