### PR TITLE
fix(buildroot): the python pin does not cover its own build macros

### DIFF
--- a/mock/hummingbird-ci.cfg
+++ b/mock/hummingbird-ci.cfg
@@ -37,6 +37,33 @@
 #     installed package python3-pip-26.2-0.1.hum1.noarch requires
 #     python(abi) = 3.14
 #
+# That glob was too narrow, and layer-02 found the hole.  python-expandvars:
+#
+#     cannot install both python3-3.15.0~rc1-1.fc45.x86_64 from fedora
+#                    and python3-3.14.6-2.2.hum1.x86_64 from hummingbird
+#      - package python3-click-1:8.4.2-1.fc45.noarch from fedora requires
+#        python(abi) = 3.15, but none of the providers can be installed
+#      - package tomcli-0.10.1-6.fc45.noarch from fedora requires
+#        python3.15dist(click), but none of the providers can be installed
+#
+# tomcli is what pyproject-rpm-macros uses to read pyproject.toml, so every
+# %pyproject_buildrequires package drags it in.  None of the Python build
+# toolchain outside the python3- prefix matched the glob:
+#
+#     tomcli                  MISSED     python3-rpm-macros   matched
+#     pyproject-rpm-macros    MISSED
+#     pyproject-srpm-macros   MISSED
+#     python-rpm-macros       MISSED
+#     python-srpm-macros      MISSED
+#
+# They came from Rawhide instead, hard-bound to 3.15, and conflicted with
+# Hummingbird's 3.14 interpreter.  F44 carries all of them built against 3.14
+# (tomcli 0.10.1-4.fc44, pyproject-rpm-macros 1.23.2-1.fc44).  93 of the 1248
+# packages in the build order are python-*.
+#
+# `python3` itself stays out of the glob: it is not `python3-*`, and
+# Hummingbird's interpreter at priority 10 is the one that must win.
+#
 # Perl is the same story, one release further along, and it was NOT mitigated
 # until run 31294475023 hit it:
 #
@@ -156,7 +183,7 @@ metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-44&arch=$basearc
 gpgcheck=0
 enabled=1
 priority=50
-includepkgs=python3-*,flit
+includepkgs=python3-*,flit,pyproject-rpm-macros,pyproject-srpm-macros,python-rpm-macros,python-srpm-macros,tomcli
 
 [fedora-44-python-updates]
 name=Fedora 44 updates - Python 3.14 build inputs only
@@ -164,7 +191,7 @@ metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f44&ar
 gpgcheck=0
 enabled=1
 priority=50
-includepkgs=python3-*,flit
+includepkgs=python3-*,flit,pyproject-rpm-macros,pyproject-srpm-macros,python-rpm-macros,python-srpm-macros,tomcli
 
 [fedora-44-perl]
 name=Fedora 44 - perl 5.42 build inputs only

--- a/tests/test_hummingbird_python_abi_pin.py
+++ b/tests/test_hummingbird_python_abi_pin.py
@@ -140,3 +140,68 @@ def test_the_pin_records_why_it_exists_and_when_to_drop_it() -> None:
         "— it must go when Hummingbird's own python3 reaches 3.15, or it will "
         "silently build 3.14 modules for a 3.15 target"
     )
+
+
+# --- the glob was too narrow; layer-02 found the hole -------------------------
+
+PYTHON_BUILD_TOOLCHAIN = (
+    "tomcli",
+    "pyproject-rpm-macros",
+    "pyproject-srpm-macros",
+    "python-rpm-macros",
+    "python-srpm-macros",
+)
+
+
+def test_the_pin_covers_its_own_build_toolchain(conf) -> None:
+    """`python3-*` does not match the macros that drive a pyproject build.
+
+    python-expandvars died in layer-02 on
+
+        cannot install both python3-3.15.0~rc1-1.fc45.x86_64 from fedora
+                       and python3-3.14.6-2.2.hum1.x86_64 from hummingbird
+         - tomcli-0.10.1-6.fc45.noarch from fedora requires
+           python3.15dist(click), but none of the providers can be installed
+
+    tomcli is what pyproject-rpm-macros uses to read pyproject.toml, so every
+    %pyproject_buildrequires package pulls it in.  None of these names starts
+    with `python3-`, so all of them came from Rawhide at 3.15 and conflicted
+    with Hummingbird's 3.14 interpreter.  93 of the 1248 packages in the build
+    order are python-*.
+    """
+    for repo in PINNED:
+        globs = {g.strip() for g in conf.get(repo, "includepkgs").split(",")}
+        missing = [n for n in PYTHON_BUILD_TOOLCHAIN if n not in globs]
+        assert not missing, (
+            f"{repo} does not carry {missing}; `python3-*` does not match them, "
+            "so they resolve from Rawhide against python 3.15 and conflict with "
+            "Hummingbird's 3.14"
+        )
+
+
+def test_the_interpreter_still_comes_from_hummingbird(conf) -> None:
+    """Widening the glob must not start shipping Fedora 44's python3.
+
+    `python3` is not `python3-*`, so it was never matched; adding names by hand
+    is exactly how it would get matched by accident.
+    """
+    for repo in PINNED:
+        globs = {g.strip() for g in conf.get(repo, "includepkgs").split(",")}
+        assert "python3" not in globs, (
+            f"{repo} includes python3 by name; the interpreter must come from "
+            "Hummingbird, not Fedora 44"
+        )
+
+
+def test_the_toolchain_widening_records_what_forced_it() -> None:
+    """Five names added by hand read as arbitrary without the failure behind them.
+
+    The next person to tidy this glob needs to see that tomcli is not
+    decoration: it is what pyproject-rpm-macros shells out to, and Rawhide's
+    build of it is bound to python3.15dist(click).
+    """
+    text = CONFIG.read_text()
+    assert "tomcli" in text and "python3.15dist(click)" in text, (
+        "the config no longer records the layer-02 chain that forced the "
+        "toolchain names into includepkgs"
+    )


### PR DESCRIPTION
`layer-02` found the hole. `python-expandvars`, from [job 93216654527](https://github.com/tuna-os/tunaos-packages/actions/runs/31294475023/job/93216654527):

```
cannot install both python3-3.15.0~rc1-1.fc45.x86_64 from fedora
               and python3-3.14.6-2.2.hum1.x86_64 from hummingbird
 - package python3-click-1:8.4.2-1.fc45.noarch from fedora requires
   python(abi) = 3.15, but none of the providers can be installed
 - package tomcli-0.10.1-6.fc45.noarch from fedora requires
   python3.15dist(click), but none of the providers can be installed
```

This **is** the `python(abi)` split — the one `mock/hummingbird-ci.cfg` already documents — reaching a build through a path the pin didn't cover.

Worth saying plainly, because I spent much of tonight retracting a **wrong** attribution of `qt6-qtserialport`'s failure to this same split. Both things are true: qt6 is not python, and `python-expandvars` is. The difference is that this one was read out of a log rather than inferred from a version gap.

## `python3-*` doesn't match the macros that drive a pyproject build

`tomcli` is what `pyproject-rpm-macros` shells out to for `pyproject.toml`, so every `%pyproject_buildrequires` package drags it in. None of the toolchain outside the `python3-` prefix matched the glob:

| name | matched `python3-*`? |
|---|---|
| `tomcli` | **no** |
| `pyproject-rpm-macros` | **no** |
| `pyproject-srpm-macros` | **no** |
| `python-rpm-macros` | **no** |
| `python-srpm-macros` | **no** |
| `python3-rpm-macros` | yes |

So they resolved from Rawhide, hard-bound to 3.15, and conflicted with Hummingbird's 3.14 interpreter — while **F44 carries every one of them built against 3.14** (`tomcli 0.10.1-4.fc44`, `pyproject-rpm-macros 1.23.2-1.fc44`). **93 of the 1248** packages in the build order are `python-*`.

`python3` stays out of the glob. It never matched `python3-*` to begin with, and adding names by hand is exactly how it would get matched by accident — so a test pins that the interpreter still comes from Hummingbird.

## Two guards earned their keep

The string `includepkgs=python3-*,flit` occurs **three** times, not two — the third is prose inside #311's comment. An applied-count assertion stopped a replacement that would have silently rewritten a comment into config.

And the first mutation run reported a **false pass** on *"drop the layer-02 evidence"*. That was correct: no test pinned it. That test now exists.

## Tests

3 tests added, mutation-verified five ways — reverting to the narrow glob, dropping `tomcli` alone, dropping the srpm macros alone, letting F44 supply the interpreter, and dropping the recorded evidence each fail exactly the tests that cover them.

`554 passed`. The three files that fail to collect need Python 3.12+ for `scripts/tideforge.py` and do so unchanged on `main`.

Based on #311, at the tip of the stack.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->