### PR TITLE
fix(build-chain): report long-running worker progress

### DIFF
--- a/scripts/build-chain.sh
+++ b/scripts/build-chain.sh
@@ -1050,10 +1050,10 @@ build_tier() {
                     return
                 fi
 
-                if (( now - last_heartbeat[$i] >= heartbeat_interval )); then
-                    local elapsed=$(( now - started_at[$i] ))
+                if (( now - last_heartbeat[i] >= heartbeat_interval )); then
+                    local elapsed=$(( now - started_at[i] ))
                     log "  Still building ${path} (pid ${pid}, elapsed ${elapsed}s)"
-                    last_heartbeat[$i]=$now
+                    last_heartbeat[i]=$now
                 fi
             done
             sleep 0.5

--- a/scripts/build-chain.sh
+++ b/scripts/build-chain.sh
@@ -1012,31 +1012,52 @@ build_tier() {
 
     local pids=()
     local pkg_paths=()
+    # Worker output stays in a per-package file until the package exits, so
+    # parallel builds do not interleave. That made a single long build look
+    # indistinguishable from a hung one in Actions: after "Queued", nothing at
+    # all reached the live log until mock and rpmbuild both finished. Keep the
+    # clean final log, but let the parent scheduler prove every live worker is
+    # still alive once a minute.
+    local started_at=()
+    local last_heartbeat=()
+    local heartbeat_interval=60
     local active=0
     local _tier_start_rpms
     _tier_start_rpms="$(_repo_rpm_count)"
 
     wait_one() {
-        for i in "${!pids[@]}"; do
-            local pid="${pids[$i]}"
-            local path="${pkg_paths[$i]}"
-            if ! kill -0 "$pid" 2>/dev/null; then
-                local logfile
-                logfile="${logdir}/$(basename "$path").log"
-                cat "$logfile"
-                if wait "$pid"; then
-                    : # success
-                else
-                    err "Failed: ${path}"
-                    _tier_failed+=("${path}")
+        # This used to recurse every 0.5 seconds while all workers were alive.
+        # A TeX package can run for hours, so use a loop: progress reporting
+        # must not grow the shell call stack just because a build is slow.
+        while true; do
+            local now
+            now=$(date +%s)
+            for i in "${!pids[@]}"; do
+                local pid="${pids[$i]}"
+                local path="${pkg_paths[$i]}"
+                if ! kill -0 "$pid" 2>/dev/null; then
+                    local logfile
+                    logfile="${logdir}/$(basename "$path").log"
+                    cat "$logfile"
+                    if wait "$pid"; then
+                        : # success
+                    else
+                        err "Failed: ${path}"
+                        _tier_failed+=("${path}")
+                    fi
+                    unset 'pids[$i]' 'pkg_paths[$i]' 'started_at[$i]' 'last_heartbeat[$i]'
+                    active=$(( active - 1 ))
+                    return
                 fi
-                unset 'pids[$i]' 'pkg_paths[$i]'
-                active=$(( active - 1 ))
-                return
-            fi
+
+                if (( now - last_heartbeat[$i] >= heartbeat_interval )); then
+                    local elapsed=$(( now - started_at[$i] ))
+                    log "  Still building ${path} (pid ${pid}, elapsed ${elapsed}s)"
+                    last_heartbeat[$i]=$now
+                fi
+            done
+            sleep 0.5
         done
-        sleep 0.5
-        wait_one
     }
 
     while IFS=$'\t' read -r pkg_path spec_override; do
@@ -1058,10 +1079,15 @@ build_tier() {
         local logfile
         logfile="${logdir}/$(basename "$pkg_path").log"
         build_package "$pkg_path" "$spec_override" > "$logfile" 2>&1 &
-        pids+=($!)
+        local pid=$!
+        local now
+        now=$(date +%s)
+        pids+=("$pid")
         pkg_paths+=("$pkg_path")
+        started_at+=("$now")
+        last_heartbeat+=("$now")
         active=$(( active + 1 ))
-        log "  Queued ${pkg_path} (pid $!)"
+        log "  Queued ${pkg_path} (pid ${pid})"
 
     done < <(python3 "${SCRIPT_DIR}/parse-build-order.py" "$MANIFEST" --tier "$tier_name")
 


### PR DESCRIPTION
## What changed

The tier scheduler now prints a heartbeat every 60 seconds for each live worker, including its package path, PID, and elapsed time.

## Why

Package output is deliberately redirected to a per-package log and emitted only after that worker exits, so a one-package dispatch showed only `Queued …` for the entire Mock/RPM build. Long TeX builds consequently looked hung even when healthy.

The heartbeat is emitted by the parent scheduler, leaving worker logs intact and avoiding interleaved package output. The polling implementation is iterative rather than recursive, so a long-running package cannot grow the shell call stack.

## Validation

- Verified the updated `build_tier` implementation on the branch.
- Ran `bash -n` against the heartbeat scheduler block.

Repository CI remains the end-to-end validation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->