### PR TITLE
fix(ci): use an absolute RPM path in GNOME 49 smoke tests

### DIFF
--- a/.github/workflows/build-gnome49-package.yml
+++ b/.github/workflows/build-gnome49-package.yml
@@ -193,7 +193,8 @@ jobs:
         run: |
           # Verify the built RPM can be installed cleanly against the base OS.
           # Catches: missing deps, file conflicts, broken %%post scriptlets.
-          RPM=$(find local-repo -name '*.rpm' ! -name '*-debuginfo-*' ! -name '*-debugsource-*' 2>/dev/null | head -1)
+          # Podman requires an absolute host path for a file bind mount.
+          RPM=$(find "$PWD/local-repo" -name '*.rpm' ! -name '*-debuginfo-*' ! -name '*-debugsource-*' 2>/dev/null | head -1)
           if [[ -z "${RPM}" ]]; then
             echo "No non-debug RPM found to test"
             exit 0


### PR DESCRIPTION
## Root cause

GNOME 49 builds completed successfully, but the install smoke test mounted a relative RPM path such as `local-repo/gnome49-el10-compat-…rpm`. Podman rejects relative file bind-mount paths before the installation command can run.

## Change

Resolve the RPM from `$PWD/local-repo`, mirroring the existing GNOME 50 workflow.

## Result

The smoke test now reaches `dnf install`, so it can validate package dependencies, file conflicts, and scriptlets as intended.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/316"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->