### PR TITLE
ci(hummingbird): validate relevant main changes

### DIFF
--- a/.github/workflows/build-hummingbird-desktops.yml
+++ b/.github/workflows/build-hummingbird-desktops.yml
@@ -73,10 +73,10 @@ env:
   R2_BUCKET: bluefin
   # workflow_dispatch inputs are absent on push. These resolved values preserve
   # manual behavior while making a main-branch run mean a full published matrix.
-  IN_DESKTOP: ${{ inputs.desktop || 'all' }}
-  IN_TIERS: ${{ inputs.tiers || '' }}
-  IN_EXCLUDE_TIERS: ${{ inputs.exclude_tiers || '' }}
-  IN_FORCE: ${{ inputs.force || false }}
+  TRIGGER_DESKTOP: ${{ inputs.desktop || 'all' }}
+  TRIGGER_TIERS: ${{ inputs.tiers || '' }}
+  TRIGGER_EXCLUDE_TIERS: ${{ inputs.exclude_tiers || '' }}
+  TRIGGER_FORCE: ${{ inputs.force || false }}
   MANIFEST: build-order-hummingbird-desktops.yml
   # Fedora + mock toolchain (mock/Containerfile). The tag names the chroot the
   # image was first built for, not the chroot it can build; mock pulls the
@@ -101,8 +101,8 @@ jobs:
         run: |
           python3 scripts/plan_hummingbird_matrix.py \
             --gap-report docs/hummingbird-desktop-gap.json \
-            --desktop "${IN_DESKTOP}" \
-            --tiers "${IN_TIERS}" >> "$GITHUB_OUTPUT"
+            --desktop "${TRIGGER_DESKTOP}" \
+            --tiers "${TRIGGER_TIERS}" >> "$GITHUB_OUTPUT"
 
   build:
     needs: plan
@@ -182,9 +182,9 @@ jobs:
           # job per desktop (see the plan job), and each job resolves only its
           # own share. Reading the input here would make all five jobs select
           # the same tiers and build the identical work five times.
-          SELECT_DESKTOP: ${{ matrix.desktop }}
-          SELECT_TIERS: ${{ env.IN_TIERS }}
-          SELECT_EXCLUDE: ${{ env.IN_EXCLUDE_TIERS }}
+          IN_DESKTOP: ${{ matrix.desktop }}
+          IN_TIERS: ${{ env.TRIGGER_TIERS }}
+          IN_EXCLUDE: ${{ env.TRIGGER_EXCLUDE_TIERS }}
         run: |
           # Not a name-prefix match. The manifest deduplicates packages across
           # desktops, so a tier named gnome-* holds packages XFCE needs too and
@@ -196,9 +196,9 @@ jobs:
           list=$(python3 scripts/select-desktop-tiers.py \
             --manifest "${MANIFEST}" \
             --gap-report docs/hummingbird-desktop-gap.json \
-            --desktop "${SELECT_DESKTOP}" \
-            --tiers "${SELECT_TIERS}" \
-            --exclude-tiers "${SELECT_EXCLUDE}")
+            --desktop "${IN_DESKTOP}" \
+            --tiers "${IN_TIERS}" \
+            --exclude-tiers "${IN_EXCLUDE}")
           echo "selected $(tr ',' '\n' <<< "$list" | wc -l) tiers: $list"
           echo "list=$list" >> "$GITHUB_OUTPUT"
 
@@ -322,7 +322,7 @@ jobs:
           # real ceiling.
           ARGS=(--manifest "${MANIFEST}" --mock-config "${{ matrix.target }}-ci"
                 --local-repo "$PWD/local-repo-hummingbird" --jobs "$(nproc)")
-          if [[ "${IN_FORCE}" == "true" ]]; then ARGS+=(--force); fi
+          if [[ "${TRIGGER_FORCE}" == "true" ]]; then ARGS+=(--force); fi
           # Keep going after a tier that had failures, and fail the step at
           # the end instead.
           #

--- a/.github/workflows/build-hummingbird-desktops.yml
+++ b/.github/workflows/build-hummingbird-desktops.yml
@@ -15,6 +15,24 @@ name: Build Hummingbird desktops
 # packages earlier runs published.
 
 on:
+  # A green PR check is not enough for this workflow: the full desktop build
+  # is deliberately too large to run on every pull request. Exercise it after
+  # relevant changes reach main so the published repository converges and a
+  # regression produces an authoritative package log.
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/build-hummingbird-desktops.yml
+      - build-order-hummingbird-desktops.yml
+      - docs/hummingbird-desktop-gap.json
+      - manifests/package-factory.yaml
+      - mock/hummingbird-ci.cfg
+      - scripts/build-chain.sh
+      - scripts/import-fedora-distgit.py
+      - scripts/plan_hummingbird_matrix.py
+      - scripts/select-desktop-tiers.py
+      - src/hummingbird/**
+
   workflow_dispatch:
     inputs:
       desktop:
@@ -45,8 +63,20 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  # Publishing is copy-not-sync, but two full matrices still waste runners and
+  # can race while signing the same RPM set. Queue a later main push instead.
+  group: hummingbird-desktops-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   R2_BUCKET: bluefin
+  # workflow_dispatch inputs are absent on push. These resolved values preserve
+  # manual behavior while making a main-branch run mean a full published matrix.
+  IN_DESKTOP: ${{ inputs.desktop || 'all' }}
+  IN_TIERS: ${{ inputs.tiers || '' }}
+  IN_EXCLUDE_TIERS: ${{ inputs.exclude_tiers || '' }}
+  IN_FORCE: ${{ inputs.force || false }}
   MANIFEST: build-order-hummingbird-desktops.yml
   # Fedora + mock toolchain (mock/Containerfile). The tag names the chroot the
   # image was first built for, not the chroot it can build; mock pulls the
@@ -71,8 +101,8 @@ jobs:
         run: |
           python3 scripts/plan_hummingbird_matrix.py \
             --gap-report docs/hummingbird-desktop-gap.json \
-            --desktop "${{ inputs.desktop }}" \
-            --tiers "${{ inputs.tiers }}" >> "$GITHUB_OUTPUT"
+            --desktop "${IN_DESKTOP}" \
+            --tiers "${IN_TIERS}" >> "$GITHUB_OUTPUT"
 
   build:
     needs: plan
@@ -152,9 +182,9 @@ jobs:
           # job per desktop (see the plan job), and each job resolves only its
           # own share. Reading the input here would make all five jobs select
           # the same tiers and build the identical work five times.
-          IN_DESKTOP: ${{ matrix.desktop }}
-          IN_TIERS: ${{ inputs.tiers }}
-          IN_EXCLUDE: ${{ inputs.exclude_tiers }}
+          SELECT_DESKTOP: ${{ matrix.desktop }}
+          SELECT_TIERS: ${{ env.IN_TIERS }}
+          SELECT_EXCLUDE: ${{ env.IN_EXCLUDE_TIERS }}
         run: |
           # Not a name-prefix match. The manifest deduplicates packages across
           # desktops, so a tier named gnome-* holds packages XFCE needs too and
@@ -166,9 +196,9 @@ jobs:
           list=$(python3 scripts/select-desktop-tiers.py \
             --manifest "${MANIFEST}" \
             --gap-report docs/hummingbird-desktop-gap.json \
-            --desktop "${IN_DESKTOP}" \
-            --tiers "${IN_TIERS}" \
-            --exclude-tiers "${IN_EXCLUDE}")
+            --desktop "${SELECT_DESKTOP}" \
+            --tiers "${SELECT_TIERS}" \
+            --exclude-tiers "${SELECT_EXCLUDE}")
           echo "selected $(tr ',' '\n' <<< "$list" | wc -l) tiers: $list"
           echo "list=$list" >> "$GITHUB_OUTPUT"
 
@@ -292,7 +322,7 @@ jobs:
           # real ceiling.
           ARGS=(--manifest "${MANIFEST}" --mock-config "${{ matrix.target }}-ci"
                 --local-repo "$PWD/local-repo-hummingbird" --jobs "$(nproc)")
-          if [[ "${{ inputs.force }}" == "true" ]]; then ARGS+=(--force); fi
+          if [[ "${IN_FORCE}" == "true" ]]; then ARGS+=(--force); fi
           # Keep going after a tier that had failures, and fail the step at
           # the end instead.
           #
@@ -336,7 +366,7 @@ jobs:
       # run rebuild only what is missing. The job still fails on failed
       # packages — publishing is not success, it is not losing the work.
       - name: Sign RPMs and publish
-        if: ${{ !cancelled() && inputs.publish }}
+        if: ${{ !cancelled() && (github.event_name == 'push' || inputs.publish) }}
         uses: crazy-max/ghaction-import-gpg@v7
         id: import-gpg
         with:
@@ -344,7 +374,7 @@ jobs:
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Publish signed rpm-md repository
-        if: ${{ !cancelled() && inputs.publish }}
+        if: ${{ !cancelled() && (github.event_name == 'push' || inputs.publish) }}
         run: |
           echo "%_signature gpg" > ~/.rpmmacros
           echo "%_gpg_name ${{ steps.import-gpg.outputs.keyid }}" >> ~/.rpmmacros


### PR DESCRIPTION
## What changed

The full Hummingbird desktop workflow now runs after relevant changes reach `main`, limited by path filters to its workflow, build manifest, gap report, package-factory target, Mock configuration, Hummingbird build/import/planning scripts, and locally carried Hummingbird sources.

For a push-triggered run:

- `desktop` defaults to `all`, producing one matrix job per desktop.
- `tiers` and exclusions default empty, selecting each complete desktop closure.
- partial successful builds are signed and published, so R2 advances even when a package fails.
- a workflow-level concurrency group queues overlapping Hummingbird runs instead of racing them.

Manual dispatch remains available with its existing GNOME, tier, force, and publish inputs.

## Why

The Hummingbird workflow was manual-only. Pull requests could be completely green without the full desktop chain ever running, leaving no authoritative post-merge signal and requiring a person to start every convergence pass. Now the merge of this PR itself will launch the first full five-desktop matrix on `main`.

## Scope and cost control

This does not run on every repository push. The path filter is limited to files that can change Hummingbird selection, importing, buildroot resolution, package building, or workflow behavior.

## Validation

The existing lint and Hummingbird workflow tests are the initial validation. The first push-triggered full matrix after merge is the end-to-end proof; its partial-publish behavior preserves successful work and makes subsequent retries incremental.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->