### PR TITLE
test(tideforge): lock runtime metadata for real recipes (#117)

### DIFF
--- a/tests/test_tideforge.py
+++ b/tests/test_tideforge.py
@@ -257,6 +257,25 @@ def test_rpm_and_deb_preserve_runtime_dependencies(recipe: dict) -> None:
     assert "Depends: ${shlibs:Depends}, ${misc:Depends}, dbus, bluez" in deb
 
 
+@pytest.mark.parametrize(
+    ("recipe_name", "target", "expected"),
+    [
+        ("kairpods", "el10", ["Requires:       dbus", "Requires:       bluez"]),
+        ("dms-cli", "ubuntu", ["dms", "quickshell"]),
+    ],
+)
+def test_real_recipes_keep_declared_runtime_metadata(
+    recipe_name: str, target: str, expected: list[str]
+) -> None:
+    """Guard the concrete recipes that exposed the renderer regression (#117)."""
+    recipe = tideforge.load_yaml(ROOT / "packages" / recipe_name / "package.yaml")
+    tideforge.validate(recipe, target)
+    rendered = tideforge.render(recipe, target)
+    metadata = "\n".join(rendered.values())
+    for dependency in expected:
+        assert dependency in metadata
+
+
 def test_rpm_changelog_uses_a_valid_rpm_date(recipe: dict) -> None:
     spec = tideforge.render(recipe, "el10")["hello-tuna.spec"]
     assert "* Sat Jul 25 2026 TunaOS Package Factory" in spec


### PR DESCRIPTION
## Summary

- add regression coverage for the real `kairpods` RPM metadata
- add regression coverage for the real `dms-cli` Debian metadata
- keep the renderer fix from silently regressing back to build-only dependencies

The renderer implementation is already present on main; this makes the issue's concrete reproduction recipes part of the permanent test contract.

## Validation

- `git diff --check`
- Python execution is blocked in this environment because the checkout requires Python 3.12+ f-string syntax while only Python 3.11 is available.

Refs tuna-os/tunaos-packages#117

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->