### PR TITLE
ci(arch): gate the DMS greeter package (#131)

### DIFF
--- a/.github/workflows/build-tideforge-arch.yml
+++ b/.github/workflows/build-tideforge-arch.yml
@@ -63,6 +63,10 @@ jobs:
         # under-declared `depends`.
         include:
           - package: niri
+          # DMS's greeter payload is the user-visible Arch gap: keep it in the
+          # clean-install gate so a recipe can be green without ever being
+          # exercised by the Arch package pipeline (#131).
+          - package: dms-greeter
           # uupd and greetd are green on every other declared target with the
           # byte-identical contract; arch was the last declared-but-never-
           # exercised pair for both (#139 defect class).

--- a/tests/test_tideforge.py
+++ b/tests/test_tideforge.py
@@ -276,6 +276,14 @@ def test_real_recipes_keep_declared_runtime_metadata(
         assert dependency in metadata
 
 
+def test_dms_greeter_is_an_arch_recipe_with_runtime_closure() -> None:
+    recipe = tideforge.load_yaml(ROOT / "packages" / "dms-greeter" / "package.yaml")
+    tideforge.validate(recipe, "arch")
+    pkgbuild = tideforge.render(recipe, "arch")["PKGBUILD"]
+    assert "depends=('greetd' 'quickshell')" in pkgbuild
+    assert "usr/bin/dms-greeter" in pkgbuild
+
+
 def test_rpm_changelog_uses_a_valid_rpm_date(recipe: dict) -> None:
     spec = tideforge.render(recipe, "el10")["hello-tuna.spec"]
     assert "* Sat Jul 25 2026 TunaOS Package Factory" in spec


### PR DESCRIPTION
## Summary

- add `dms-greeter` to the Arch Tideforge clean-install matrix
- assert its generated PKGBUILD retains the `greetd` and `quickshell` runtime closure

The recipe and renderer already support the Arch target; this connects the package to the real Arch build/install gate so it cannot remain an untested data package.

## Validation

- `git diff --check`
- `bash -n scripts/arch-clean-install.sh scripts/assert-arch-runtime-closure.sh`
- Python tests require the repository's Python 3.12+ runtime; this environment only provides Python 3.11.

Refs tuna-os/tunaos-packages#131

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->