### PR TITLE
ci: hard-fail incomplete GNOME desktop package sets (#132)

### DIFF
--- a/docs/gnome-desktop-contract.md
+++ b/docs/gnome-desktop-contract.md
@@ -1,0 +1,39 @@
+# GNOME desktop experience contract
+
+`gnome-shell` plus a session file is not a complete desktop. In particular,
+the session can start while file dialogs, screenshots, removable media,
+portals, and keyring-backed credentials remain unusable.
+
+The package repository now provides
+[`verify-gnome-desktop-experience.py`](../scripts/verify-gnome-desktop-experience.py),
+a package-manager-neutral hard-fail check. It requires the core session,
+file-manager, portal, and keyring packages:
+
+```text
+gdm
+gnome-keyring
+gnome-session
+gnome-shell
+gvfs
+mutter
+nautilus
+xdg-desktop-portal-gnome
+```
+
+Run it after the base-specific package installation, before publishing the
+image. Examples:
+
+```bash
+rpm -qa --qf '%{NAME}\\n' | \
+  python3 scripts/verify-gnome-desktop-experience.py /dev/stdin
+
+dpkg-query -W -f '${binary:Package}\\n' | \
+  python3 scripts/verify-gnome-desktop-experience.py /dev/stdin
+```
+
+The check deliberately validates names rather than image size or package
+count. Metapackages can expand to very different numbers of packages across
+openSUSE, Debian, and Ubuntu; a size threshold would miss a missing component
+or reject a valid but compact dependency closure. Base-specific translations
+should use the package names actually emitted by that package manager, and any
+name that cannot be resolved should fail the build rather than be ignored.

--- a/scripts/verify-gnome-desktop-experience.py
+++ b/scripts/verify-gnome-desktop-experience.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Fail when a GNOME image is only a session skeleton.
+
+The input is one installed package name per line, as produced by
+``rpm -qa --qf '%{NAME}\\n'`` or ``dpkg-query -W -f '${binary:Package}\\n'``.
+Keeping this check package-manager agnostic lets the image build use the same
+contract for RPM, DEB, and translated openSUSE package names.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Iterable
+
+
+REQUIRED_GNOME_PACKAGES = frozenset(
+    {
+        "gdm",
+        "gnome-keyring",
+        "gnome-session",
+        "gnome-shell",
+        "gvfs",
+        "mutter",
+        "nautilus",
+        "xdg-desktop-portal-gnome",
+    }
+)
+
+
+def missing_packages(installed: Iterable[str], required: Iterable[str] = REQUIRED_GNOME_PACKAGES) -> list[str]:
+    installed_names = {line.strip().split()[0] for line in installed if line.strip()}
+    return sorted(set(required) - installed_names)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("package_list", help="file containing one installed package name per line")
+    args = parser.parse_args()
+
+    with open(args.package_list, encoding="utf-8") as package_list:
+        missing = missing_packages(package_list)
+    if missing:
+        print("GNOME desktop contract failed; missing packages:", file=sys.stderr)
+        for package in missing:
+            print(f"  {package}", file=sys.stderr)
+        return 1
+    print("GNOME desktop contract passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_verify_gnome_desktop_experience.py
+++ b/tests/test_verify_gnome_desktop_experience.py
@@ -1,0 +1,32 @@
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "verify_gnome_desktop_experience",
+    ROOT / "scripts" / "verify-gnome-desktop-experience.py",
+)
+assert SPEC and SPEC.loader
+checker = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(checker)
+
+
+def test_accepts_a_complete_gnome_desktop_package_set() -> None:
+    installed = [f"{package} 1" for package in checker.REQUIRED_GNOME_PACKAGES]
+    assert checker.missing_packages(installed) == []
+
+
+def test_rejects_a_session_only_gnome_install() -> None:
+    installed = ["gdm", "gnome-session", "gnome-shell", "mutter"]
+    assert checker.missing_packages(installed) == [
+        "gnome-keyring",
+        "gvfs",
+        "nautilus",
+        "xdg-desktop-portal-gnome",
+    ]
+
+
+def test_ignores_empty_lines_and_metadata_columns() -> None:
+    installed = ["", "gnome-shell 50.1", "gdm 49.0", "mutter"]
+    assert checker.missing_packages(installed, ["gnome-shell", "gdm", "mutter"]) == []


### PR DESCRIPTION
## Summary

- add a package-manager-neutral GNOME desktop experience contract
- fail when GDM, GNOME session/shell, Mutter, GVFS, Nautilus, keyring, or the GNOME portal backend is absent
- add focused tests for complete and session-only package sets
- document RPM and DEB integration commands for downstream image builds

This avoids unreliable image-size/package-count heuristics and gives sailfin, flounder, and grouper a hard failure when their resolved desktop is only a session skeleton. The base-specific image pipelines still need to invoke the checker after package installation.

## Validation

- `python3 -m py_compile scripts/verify-gnome-desktop-experience.py tests/test_verify_gnome_desktop_experience.py`
- direct complete/missing contract assertions
- `git diff --check`

Refs tuna-os/tunaos-packages#132

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->