### PR TITLE
docs: clarify GNOME R2 wipe impact (#158)

### DIFF
--- a/INCIDENT-repo-wipe-gnome.md
+++ b/INCIDENT-repo-wipe-gnome.md
@@ -27,6 +27,32 @@ The read-only `R2 Inventory` workflow settles what HTTP probing could not:
 | `tunaosdev/gnome50/10-stream-x86_64` | 0 | 0 | 0 |
 | `tunaosdev/gnome49/10-stream-x86_64` | 0 | 0 | 0 |
 
+## Impact and restore urgency
+
+The empty GNOME prefixes are a broken published artifact, but they are not a
+current tunaOS image-build outage. A search of the tunaOS desktop manifests,
+build scripts, and system files found no image installation path consuming
+either `bluefin/gnome49` or `bluefin/gnome50`. The EL10 GNOME image path gets
+its packages from the configured COPR projects instead.
+
+This distinction matters for restore planning: rebuilding the GNOME R2 chains
+is cleanup and restores the documented repository/install experience; it is
+not a prerequisite for the current GNOME image builds. The empty paths can
+still make the repository verification workflows fail and break anyone who
+uses the standalone GNOME install helper, so “not an image-build blocker” does
+not mean “healthy.”
+
+The active image-build consumers found in the same audit are:
+
+* `bluefin/xfce/10-stream-x86_64`, consumed by the XFCE EL10 manifest; and
+* the `bluefin/fprintd` path, consumed by the Cosmic EL10/aarch64 flow.
+
+Those prefixes should remain higher priority for restore and publish-integrity
+monitoring because an image build reads them directly. The GNOME prefixes
+should be restored on their own schedule, with the no-consumer finding kept in
+the incident record so an empty cleanup target is not presented as an active
+production outage.
+
 Conclusions, now evidenced rather than inferred:
 
 * **Both GNOME repos need a full chain rebuild.** A `createrepo_c` re-index was the


### PR DESCRIPTION
## Summary

- distinguish an empty published GNOME repository from an active tunaOS image-build outage
- record that current EL10 GNOME images consume COPR, not the wiped R2 prefixes
- identify XFCE and fprintd as active image-build repository consumers
- clarify that GNOME restore remains cleanup and standalone install/verification recovery

## Validation

- audited repository references and workflows
- `git diff --check`

Refs tuna-os/tunaos-packages#158

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->