### PR TITLE
fix(hummingbird): replace general Fedora 44 fallback with self-hosted closure

### DIFF
--- a/manifests/package-factory.yaml
+++ b/manifests/package-factory.yaml
@@ -79,7 +79,7 @@ targets:
     # Rawhide supplies -devel headers and build backends Hummingbird has no
     # build of yet; Fedora 44 supplies the Python namespace at the target's
     # own ABI (3.14, where Rawhide is 3.15).
-    build_repositories: [fedora-rawhide, fedora-44]
+    build_repositories: [fedora-rawhide, fedora-44-python]
   opensuse-tumbleweed:
     status: scaffold
     format: rpm

--- a/mock/hummingbird-ci.cfg
+++ b/mock/hummingbird-ci.cfg
@@ -55,26 +55,12 @@
 # Repository priority (lower wins in dnf):
 #   1  local-build      RPMs produced by earlier tiers of this same run
 #   10 hummingbird      the target's own signed RPMs — the ABI we must match
-#   40 fedora-44       general BuildRequires: fallback -- see below
 #   50 fedora-44-python Python 3.14 modules, buildroot only, includepkgs-confined
 #   99 rawhide          (inherited) last-resort BuildRequires: fallback
 #
-# EXPERIMENT (see #289). Rawhide is a different distribution at the ABI level:
-# python 3.15 vs Hummingbird's 3.14, perl 5.44 vs 5.42. Every gnome-00 failure
-# in run 31272392927 was a Rawhide package that could not coexist with what
-# Hummingbird ships --
-#
-#   dconf       gobject-introspection-devel   python(abi) = 3.15
-#   libuser     perl-XML-Parser               libperl.so.5.44
-#   mozjs140    perl-Devel-PPPort             libperl.so.5.44
-#   v4l-utils   mesa-libEGL, SDL3, libdecor   libwayland-client, libgtk-3
-#
-# -- and in every case Fedora 44 has a copy built against the ABI Hummingbird
-# actually has. Fedora 44 at priority 40 makes that copy win, with Rawhide
-# still available for anything F44 genuinely lacks.
-#
-# The alternative is building the full transitive BuildRequires closure, which
-# #289 measures at ~2900 source packages per desktop.
+# General Fedora 44 BuildRequires fallback was removed in #317 as Hummingbird now
+# hosts its self-hosted closure. Fedora 44 is retained ONLY for the Python 3.14
+# module pin via `includepkgs`.
 #
 # Hummingbird stays at 10 so its own python3, setuptools, pip, packaging and
 # pytest keep winning: dnf's priority filter drops a package name entirely from
@@ -104,20 +90,6 @@ baseurl=https://packages.redhat.com/api/pulp-content/public-hummingbird/$basearc
 gpgcheck=0
 enabled=1
 priority=10
-
-[fedora-44]
-name=Fedora 44 - general BuildRequires fallback
-metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-44&arch=$basearch
-gpgcheck=0
-enabled=1
-priority=40
-
-[fedora-44-updates]
-name=Fedora 44 updates - general BuildRequires fallback
-metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f44&arch=$basearch
-gpgcheck=0
-enabled=1
-priority=40
 
 [fedora-44-python]
 name=Fedora 44 - Python 3.14 build inputs only


### PR DESCRIPTION
Closes #317. Removes the general Fedora 44 BuildRequires fallback (`[fedora-44]` and `[fedora-44-updates]` at priority 40) from `mock/hummingbird-ci.cfg` and updates `manifests/package-factory.yaml`. The Python 3.14 pin (`[fedora-44-python]`) remains intact with `includepkgs` restriction to support the Python 3.14 module namespace until Hummingbird updates to Python 3.15.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `b220f78`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->