### PR TITLE
docs(roadmap): document Gentoo overlay decision for guppy:cosmic and guppy:niri (#162)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,6 +34,7 @@ Mock to Cloudflare R2 (COPR is bootstrap/compatibility only, being retired).
 | P0 | Keep GNOME 51 EL10 bootstrap green | build-order-gnome51.yml | 🟡 In progress |
 | P1 | XFWL4 parity across Debian/Ubuntu (flounder/grouper xfce) | #136, #137 | 🟡 In progress |
 | P1 | Tideforge dependency/metadata correctness (RPM+DEB) | #117, #118 | 🔴 Open |
+| P1 | Decide Gentoo path for guppy:cosmic and guppy:niri | #162 | 🟢 Closed — Use Gentoo overlays (::guru & ::cosmic-overlay); no Tideforge emitter needed |
 | P2 | EL10 peripheral/security-key tooling (input-remapper, evtest, …) | #122, #126 | 🔴 Open |
 
 ---


### PR DESCRIPTION
Resolves #162.

### Summary
Evaluated Option A (consuming Gentoo overlays) vs Option B (adding an ebuild emitter to Tideforge) for  and .

- **Option A confirmed**:
  - : Available in  ( & ) with  keywords.
  - : Available in  () under  with  up to 1.5.0.
- **Option B rejected**: Adding a whole Gentoo/ebuild emitter to Tideforge for only two variant cells is unnecessary when maintained upstream overlays exist.

Updated [ROADMAP.md](file:///home/dev/workspace/tuna-os/tunaos-packages/ROADMAP.md) to record this decision.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `816955c`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->