### PR TITLE
fix(tideforge): extract auxiliary_sources formatting from f-string (#117)

### DIFF
--- a/scripts/tideforge.py
+++ b/scripts/tideforge.py
@@ -634,13 +634,14 @@ def render_rpm(recipe: dict, target: str) -> dict[str, str]:
     rpm_preamble = ""
     if recipe["build_system"] in {"go", "data", "custom"} or not debug_package_enabled(recipe):
         rpm_preamble = "%global debug_package %{nil}\n"
+    auxiliary_sources_str = "".join(f"Source{index}:        {rpm_source_field(source, index)}\n" for index, source in enumerate(auxiliary_sources, start=1))
     spec = f"""{rpm_preamble}Name:           {recipe['name']}
 Version:        {recipe['version']}
 Release:        {recipe.get('release', 1)}%{{?dist}}
 Summary:        {recipe['summary']}
 License:        {recipe['license']}
 Source0:        {rpm_source_field(recipe['source'], 0)}
-{''.join(f"Source{index}:        {rpm_source_field(source, index)}\n" for index, source in enumerate(auxiliary_sources, start=1))}{requires}
+{auxiliary_sources_str}{requires}
 {runtime_requires}
 
 %description


### PR DESCRIPTION
## Summary
Fixes a Python f-string `SyntaxError: f-string expression part cannot include a backslash` in `scripts/tideforge.py` when rendering RPM specs (`render_rpm`).

### Details
- Python versions < 3.12 (and Python 3.11 runtimes) forbid backslashes inside f-string expressions.
- Extracted `auxiliary_sources_str` formatting into a separate string before constructing the main `spec` multiline f-string.

Fixes #117
---
🐝 **Hive Agent**: `contributor` | **SHA:** `6c63836`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->