### PR TITLE
fix(renovate): track Tideforge package.yaml pins for xfconf and xfwl4 (#170)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
       "platformAutomerge": true
     },
     {
-      "description": "Upstream package source pins (commits/versions this repo packages) still automerge, but only once the real mock/podman build for that package passes as a required status check \u2014 a bare version bump alone has repeatedly hidden real breakage (new MSRV, new/dropped files) that only a build catches. See build-xfce-fedora.yml / build-xfce-package.yml / build-fprintd-validation.yml / build-xfce-arch-validation.yml path triggers.",
+      "description": "Upstream package source pins (commits/versions this repo packages) still automerge, but only once the real mock/podman build for that package passes as a required status check \u2014 a bare version bump alone has repeatedly hidden real breakage (new MSRV, new/dropped files) that only a build catches. See build-tideforge-supported.yml / build-xfce-package.yml / build-fprintd-validation.yml / build-xfce-arch-validation.yml path triggers.",
       "matchDepTypes": [
         "upstream-source"
       ],
@@ -94,11 +94,12 @@
       "customType": "regex",
       "description": "xfconf: tracks gitlab.xfce.org/xfce/xfconf's master branch (no stable release yet \u2014 xfwl4's crates require post-4.20 development commits).",
       "fileMatch": [
+        "^packages/xfconf/package\\.yaml$",
         "^src/xfce-wayland/xfconf/xfconf\\.spec$",
         "^src/xfce-wayland/xfconf/packaging/arch/PKGBUILD$"
       ],
       "matchStrings": [
-        "(?:%global commit\\s+|_commit=)(?<currentDigest>[a-f0-9]{40})"
+        "(?:%global commit\\s+|_commit=|archive/)(?<currentDigest>[a-f0-9]{40})"
       ],
       "currentValueTemplate": "master",
       "datasourceTemplate": "git-refs",
@@ -126,11 +127,12 @@
       "customType": "regex",
       "description": "xfwl4: tracks gitlab.xfce.org/xfce/xfwl4's main branch \u2014 pre-1.0 compositor, no tagged releases to pin to instead.",
       "fileMatch": [
+        "^packages/xfwl4/package\\.yaml$",
         "^src/xfce-wayland/xfwl4/xfwl4\\.spec$",
         "^src/xfce-wayland/xfwl4/packaging/arch/PKGBUILD$"
       ],
       "matchStrings": [
-        "(?:%global commit\\s+|\\n_commit=)(?<currentDigest>[a-f0-9]{40})"
+        "(?:%global commit\\s+|\\n_commit=|archive/)(?<currentDigest>[a-f0-9]{40})"
       ],
       "currentValueTemplate": "main",
       "datasourceTemplate": "git-refs",


### PR DESCRIPTION
Fixes #170

### Summary
- Added `^packages/xfconf/package\.yaml$` and `^packages/xfwl4/package\.yaml$` to Renovate's `fileMatch` rules so Renovate tracks the actual package source pins that are tested by the Tideforge gates (`build-tideforge-supported.yml`).
- Updated the match regex to match commit hashes in archive URLs within `package.yaml` (`(?:%global commit\s+|_commit=|archive/)(?<currentDigest>[a-f0-9]{40})`).
- Updated `renovate.json` comments/descriptions referencing gating workflows.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `0724de8`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->