### PR TITLE
ci(gnome50): handle unpublished repo HTTP 404 in Verify GNOME 50 Repo (#179)

### DIFF
--- a/.github/workflows/build-gnome50-verify.yml
+++ b/.github/workflows/build-gnome50-verify.yml
@@ -28,12 +28,22 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Check repomd.xml is accessible (published repo)
+        id: check-repo
         run: |
           STATUS=$(curl -sI https://repo.tunaos.org/gnome50/10-stream-x86_64/repodata/repomd.xml | awk 'NR==1{print $2}')
           echo "HTTP status: ${STATUS}"
-          [[ "${STATUS}" == "200" ]] || (echo "ERROR: Published repo not accessible!" && exit 1)
+          if [[ "${STATUS}" == "404" ]]; then
+            echo "::warning::Published GNOME 50 repository does not exist yet (HTTP 404). Skipping verification until initial repo publication."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          elif [[ "${STATUS}" == "200" ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ERROR: Published repo returned unexpected HTTP status: ${STATUS}"
+            exit 1
+          fi
 
       - name: Verify packages installable in CentOS Stream 10 container
+        if: steps.check-repo.outputs.exists == 'true'
         run: |
           cat > /tmp/verify.sh << 'EOF'
           #!/bin/bash
@@ -56,7 +66,23 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     steps:
+      - name: Check repomd.xml is accessible (published repo)
+        id: check-repo
+        run: |
+          STATUS=$(curl -sI https://repo.tunaos.org/gnome50/10-stream-x86_64/repodata/repomd.xml | awk 'NR==1{print $2}')
+          echo "HTTP status: ${STATUS}"
+          if [[ "${STATUS}" == "404" ]]; then
+            echo "::warning::Published GNOME 50 repository does not exist yet (HTTP 404). Skipping GDM verification until initial repo publication."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          elif [[ "${STATUS}" == "200" ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ERROR: Published repo returned unexpected HTTP status: ${STATUS}"
+            exit 1
+          fi
+
       - name: Enable KVM
+        if: steps.check-repo.outputs.exists == 'true'
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
@@ -64,6 +90,7 @@ jobs:
           ls -la /dev/kvm
 
       - name: Install QEMU and Lima
+        if: steps.check-repo.outputs.exists == 'true'
         run: |
           sudo apt-get update -q
           sudo apt-get install -y -q qemu-system-x86 qemu-utils ovmf
@@ -71,9 +98,11 @@ jobs:
           limactl --version
 
       - name: Install vncdotool
+        if: steps.check-repo.outputs.exists == 'true'
         run: pip install vncdotool
 
       - name: Create Lima VM config
+        if: steps.check-repo.outputs.exists == 'true'
         run: |
           cat > /tmp/gnome50-verify.yaml << 'EOF'
           vmType: qemu
@@ -118,11 +147,13 @@ jobs:
           EOF
 
       - name: Start Lima VM
+        if: steps.check-repo.outputs.exists == 'true'
         run: |
           limactl start --name=gnome50-verify /tmp/gnome50-verify.yaml --timeout=25m
           echo "VM started"
 
       - name: Wait for GDM to become active
+        if: steps.check-repo.outputs.exists == 'true'
         run: |
           echo "Waiting for GDM to start (up to 5 minutes)..."
           for i in $(seq 1 30); do
@@ -138,6 +169,7 @@ jobs:
           fi
 
       - name: Check gnome-shell greeter stability
+        if: steps.check-repo.outputs.exists == 'true'
         id: greeter-check
         run: |
           echo "Checking gnome-shell greeter stability (no crash-loop)..."
@@ -167,11 +199,13 @@ jobs:
           fi
 
       - name: Check GDM and GNOME Shell status
+        if: steps.check-repo.outputs.exists == 'true'
         run: |
           limactl shell gnome50-verify -- systemctl status gdm --no-pager || true
           limactl shell gnome50-verify -- rpm -q gdm gnome-shell mutter glib2
 
       - name: Scan journal for gnome-shell crash signatures
+        if: steps.check-repo.outputs.exists == 'true'
         id: crash-scan
         run: |
           echo "Scanning journal for gnome-shell crash patterns..."
@@ -188,6 +222,7 @@ jobs:
           fi
 
       - name: Check results and file issue if broken
+        if: steps.check-repo.outputs.exists == 'true'
         run: |
           STABLE="${{ steps.greeter-check.outputs.greeter_stable }}"
           CRASHES="${{ steps.crash-scan.outputs.crash_matches }}"
@@ -233,6 +268,7 @@ jobs:
         # missing screenshot never overrides the real result.
         timeout-minutes: 3
         continue-on-error: true
+        if: steps.check-repo.outputs.exists == 'true'
         run: |
           # Lima exposes VNC — find the port from the QEMU process
           VNC_DISPLAY=$(cat /proc/$(pgrep -f 'qemu.*gnome50-verify' | head -1)/cmdline \
@@ -251,12 +287,12 @@ jobs:
 
       - name: Upload login screen screenshot
         uses: actions/upload-artifact@v7
-        if: always()
+        if: always() && steps.check-repo.outputs.exists == 'true'
         with:
           name: gdm-login-screen
           path: gdm-login-screen.png
           retention-days: 7
 
       - name: Stop Lima VM
-        if: always()
+        if: always() && steps.check-repo.outputs.exists == 'true'
         run: limactl stop gnome50-verify --force || true


### PR DESCRIPTION
Fixes #179

### Summary
- Updated `.github/workflows/build-gnome50-verify.yml` so that `verify-repo` and `verify-gdm` check the repository HTTP status first.
- If the repository returns HTTP 404 (because GNOME 50 has not yet been initially published to R2), a GitHub Actions warning is logged and downstream package verification / GDM VM installation steps are safely skipped rather than failing with error exit codes.
- Once the repository is published and returns HTTP 200, the verification steps run normally. Any unexpected status code (non-200/non-404) continues to raise an error.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `0e26aff`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->