### PR TITLE
docs(hummingbird): document throughput status and evaluation (#267)

### DIFF
--- a/docs/hummingbird-throughput.md
+++ b/docs/hummingbird-throughput.md
@@ -173,3 +173,11 @@ Concurrency, for the record, is now 74.2 m of mock over 39.02 m of wall =
 time roughly doubled (median 77.5 s at jobs=2-but-serialised, 138.5 s at
 jobs=4) because four builds share four cores with `%{_smp_mflags}`.  That is
 the ceiling more machines address and in-job concurrency does not.
+
+## Summary Status (#267)
+
+* **One runner per dispatch**: Matrixed plan/build jobs implemented in PR #277.
+* **Mock chroot root cache**: Shared cache directory with `-p` flag implemented in PR #277.
+* **Runner size**: GitHub-hosted 4-vCPU standard runners in use across org.
+* **DAG wavefront**: Documented; evaluated for higher worker concurrency tiers.
+


### PR DESCRIPTION
## Description

Follow-up documentation update and throughput status summary for issue #267.

### Summary of Status & Optimizations
- **One runner per dispatch (#2)**: Solved in PR #277. `desktop: all` fans out via a `plan` job into matrixed per-desktop jobs running concurrently.
- **Mock chroot root cache**: Implemented in PR #277 by persisting `MOCK_CACHE_DIR` and using `cp -p` for mock profiles to preserve mtimes.
- **Runner size (#3)**: Standard GitHub-hosted 4-vCPU runners in use across org.
- **DAG wavefront (#1)**: Documented in `docs/hummingbird-throughput.md`. Packing remains full at current worker concurrency per desktop.

Reflects status and conclusions in `docs/hummingbird-throughput.md`.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `b787584`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->