### PR TITLE
fix(renovate): stop digest-bumping Tideforge recipes, restore xfconf/xfwl4 pins

### DIFF
--- a/packages/xfconf/package.yaml
+++ b/packages/xfconf/package.yaml
@@ -6,7 +6,7 @@ summary: Xfce configuration daemon and library
 description: Xfce configuration daemon and library required by Xfce components.
 license: GPL-2.0-or-later
 source:
-  url: https://gitlab.xfce.org/xfce/xfconf/-/archive/eab153323158378a180cd7104d1d8f024631bea0/xfconf-a6f0a7aa9073f9d8a0935cee73c0da52b6e49660.tar.gz
+  url: https://gitlab.xfce.org/xfce/xfconf/-/archive/a6f0a7aa9073f9d8a0935cee73c0da52b6e49660/xfconf-a6f0a7aa9073f9d8a0935cee73c0da52b6e49660.tar.gz
   sha256: b1ac015013b4c6b1f39ff487c05eecba2ff3ac1153868db067e0ffde1f2f337a
   directory: xfconf-a6f0a7aa9073f9d8a0935cee73c0da52b6e49660
 build_system: meson

--- a/packages/xfwl4/package.yaml
+++ b/packages/xfwl4/package.yaml
@@ -7,7 +7,7 @@ description: >-
   Xfce Wayland compositor built on Smithay/wlroots for the TunaOS XFCE desktop.
 license: GPL-3.0-or-later AND Apache-2.0 AND MIT
 source:
-  url: https://gitlab.xfce.org/xfce/xfwl4/-/archive/4c7cc591ee029225a08687699c8d445c7248b079/xfwl4-465880f67b5705136895bf69c60e2178ad351856.tar.gz
+  url: https://gitlab.xfce.org/xfce/xfwl4/-/archive/465880f67b5705136895bf69c60e2178ad351856/xfwl4-465880f67b5705136895bf69c60e2178ad351856.tar.gz
   sha256: 4507f6ea9da24dc756df4ac02441a3b7452187ba64bce8893eaf1cbe62a0850b
   directory: xfwl4-465880f67b5705136895bf69c60e2178ad351856
 # Cargo's vendor tree and XFCE protocol submodule are part of the source
@@ -18,7 +18,7 @@ sources:
     filename: xfwl4-vendor.tar.gz
     destination: .
     strip_components: 0
-  - url: https://gitlab.xfce.org/xfce/xfce-wayland-protocols/-/archive/4c7cc591ee029225a08687699c8d445c7248b079/xfce-wayland-protocols-6082cfa492154aec266527193bf8f6142ab14977.tar.gz
+  - url: https://gitlab.xfce.org/xfce/xfce-wayland-protocols/-/archive/6082cfa492154aec266527193bf8f6142ab14977/xfce-wayland-protocols-6082cfa492154aec266527193bf8f6142ab14977.tar.gz
     sha256: bb6f9d5ad772c9114b6f15fd2c288fd344e07e1ccfd61e23890ae5c501c953cc
     filename: xfce-wayland-protocols.tar.gz
     destination: resources/xfce-wayland-protocols

--- a/renovate.json
+++ b/renovate.json
@@ -92,14 +92,13 @@
     },
     {
       "customType": "regex",
-      "description": "xfconf: tracks gitlab.xfce.org/xfce/xfconf's master branch (no stable release yet \u2014 xfwl4's crates require post-4.20 development commits).",
+      "description": "xfconf: tracks gitlab.xfce.org/xfce/xfconf's master branch (no stable release yet \u2014 xfwl4's crates require post-4.20 development commits). Deliberately NOT packages/xfconf/package.yaml: a Tideforge recipe pins source.sha256 and source.directory alongside the URL, and a regex manager can only rewrite the digest, so #339 bumped the URL to eab1533 while leaving the a6f0a7aa checksum and directory behind and broke Validate Package Factory for every branch (#170).",
       "fileMatch": [
-        "^packages/xfconf/package\\.yaml$",
         "^src/xfce-wayland/xfconf/xfconf\\.spec$",
         "^src/xfce-wayland/xfconf/packaging/arch/PKGBUILD$"
       ],
       "matchStrings": [
-        "(?:%global commit\\s+|_commit=|archive/)(?<currentDigest>[a-f0-9]{40})"
+        "(?:%global commit\\s+|_commit=)(?<currentDigest>[a-f0-9]{40})"
       ],
       "currentValueTemplate": "master",
       "datasourceTemplate": "git-refs",
@@ -125,14 +124,13 @@
     },
     {
       "customType": "regex",
-      "description": "xfwl4: tracks gitlab.xfce.org/xfce/xfwl4's main branch \u2014 pre-1.0 compositor, no tagged releases to pin to instead.",
+      "description": "xfwl4: tracks gitlab.xfce.org/xfce/xfwl4's main branch \u2014 pre-1.0 compositor, no tagged releases to pin to instead. Deliberately NOT packages/xfwl4/package.yaml, for the checksum reason on the xfconf manager plus a worse one: an `archive/` digest match is not repository-scoped, so #340 also rewrote the recipe's xfce-wayland-protocols source to xfwl4's own commit, a ref that does not exist there (that URL now 404s). The recipe's vendor.tar.gz release asset is keyed to the pinned commit as well, so bumping it is never a one-line edit (#170).",
       "fileMatch": [
-        "^packages/xfwl4/package\\.yaml$",
         "^src/xfce-wayland/xfwl4/xfwl4\\.spec$",
         "^src/xfce-wayland/xfwl4/packaging/arch/PKGBUILD$"
       ],
       "matchStrings": [
-        "(?:%global commit\\s+|\\n_commit=|archive/)(?<currentDigest>[a-f0-9]{40})"
+        "(?:%global commit\\s+|\\n_commit=)(?<currentDigest>[a-f0-9]{40})"
       ],
       "currentValueTemplate": "main",
       "datasourceTemplate": "git-refs",


### PR DESCRIPTION
`Validate Package Factory` has been red on `main` and therefore on every open PR since 04:02 UTC today:

```
source 0 checksum mismatch: expected b1ac015013b4c6b1f39ff487c05eecba2ff3ac1153868db067e0ffde1f2f337a,
                                 got 5e4865396016460105779350c46117c4ef686360a979905bfd665ed2535bb616
```

#336 extended the xfconf and xfwl4 renovate managers to their Tideforge recipes with an `archive/` digest match. A regex manager can only rewrite the digest it matched, but a recipe pins the tarball next to it, so the next renovate run (#339, #340) moved the URL and left everything that describes the tarball behind:

```yaml
source:
  url: .../xfconf/-/archive/eab153323158378a180cd7104d1d8f024631bea0/xfconf-a6f0a7aa...tar.gz  # bumped
  sha256: b1ac015013b4c6b1f39ff487c05eecba2ff3ac1153868db067e0ffde1f2f337a                      # not bumped
  directory: xfconf-a6f0a7aa9073f9d8a0935cee73c0da52b6e49660                                    # not bumped
```

`directory:` matters as much as the checksum: GitLab names an archive's top-level directory after the ref in the URL path, so `eab1533` extracts to `xfconf-eab1533…` and the recipe would then point at a directory that does not exist even with a corrected hash.

xfwl4 got a second, worse edit. `archive/(?<currentDigest>[a-f0-9]{40})` is not repository-scoped, so it also rewrote the recipe's `xfce-wayland-protocols` source to xfwl4's own commit, a ref that does not exist in that project (that URL returns 404, the original returns 200). Its `vendor.tar.gz` is a release asset keyed to the pinned commit too, so a real xfwl4 bump is never a one-line digest edit.

This reverts both bumps to the last self-consistent pins and drops the recipe paths from the two managers, recording why in each manager's `description`. The `.spec` and `PKGBUILD` paths stay tracked, which is where a bare digest is the whole pin. Tracking recipe pins as #170 wanted needs a bumper that recomputes `sha256` and `directory` (and re-cuts the vendor asset for xfwl4); a regex manager cannot do it.

Verified locally: all four restored sources download and match their pinned checksums (`verify-tideforge-source.py`: xfconf 1/1, xfwl4 3/3), both archives extract to exactly the `directory:` each recipe declares, `renovate.json` parses, and the full test suite passes (741 passed).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->