### PR TITLE
fix(ci): add COSMIC install assertions

### DIFF
--- a/.github/workflows/build-tideforge-supported.yml
+++ b/.github/workflows/build-tideforge-supported.yml
@@ -218,10 +218,16 @@ jobs:
           # get dedicated jobs below.
           - package: pop-icon-theme
             target: el10
+            install_name: pop-icon-theme
+            smoke: test -d /usr/share/icons/Pop
           - package: cosmic-randr
             target: el10
+            install_name: cosmic-randr
+            smoke: cosmic-randr --help
           - package: cosmic-panel
             target: el10
+            install_name: cosmic-panel
+            smoke: test -x /usr/bin/cosmic-panel
           - package: evtest
             target: el10
           - package: python3-evdev

--- a/.github/workflows/build-tideforge-supported.yml
+++ b/.github/workflows/build-tideforge-supported.yml
@@ -80,6 +80,7 @@ jobs:
       cosmic_icon_theme_rpm_run: ${{ steps.plan.outputs.cosmic_icon_theme_rpm_run }}
       cosmic_comp_rpm_run: ${{ steps.plan.outputs.cosmic_comp_rpm_run }}
       cosmic_bg_rpm_run: ${{ steps.plan.outputs.cosmic_bg_rpm_run }}
+      cosmic_services_rpm_run: ${{ steps.plan.outputs.cosmic_services_rpm_run }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -228,6 +229,8 @@ jobs:
             target: el10
             install_name: cosmic-panel
             smoke: test -x /usr/bin/cosmic-panel
+          - package: cosmic-settings-daemon
+            target: el10
           - package: evtest
             target: el10
           - package: python3-evdev
@@ -995,6 +998,10 @@ jobs:
       - name: Render and fetch the exact source archive
         run: |
           set -euo pipefail
+          # This job owns the staged COSMIC icon closure consumed by the
+          # service gates below. Keep these recipe paths visible to the planner
+          # so a service-only change also reruns this prerequisite job.
+          echo packages/cosmic-idle/package.yaml packages/cosmic-notifications/package.yaml packages/cosmic-osd/package.yaml packages/xdg-desktop-portal-cosmic/package.yaml
           recipe=packages/cosmic-icon-theme/package.yaml
           root="$PWD/.tideforge/cosmic-icon-theme"
           python3 scripts/tideforge.py validate "$recipe"
@@ -1035,6 +1042,89 @@ jobs:
         with:
           name: cosmic-icon-theme-el10-rpm
           path: .tideforge/cosmic-icon-theme/rpmbuild/RPMS/
+          if-no-files-found: warn
+
+  # These services have the same small staged runtime closure: the EL10
+  # recipe itself plus cosmic-icon-theme, which in turn needs pop-icon-theme.
+  # Keep them in one matrix so every cell performs a real clean install and
+  # runs the recipe-owned smoke assertion instead of returning a payload-only
+  # green check (#169).
+  cosmic_services_rpm:
+    name: ${{ matrix.package }} (el10 RPM)
+    needs: [detect-changes, plan, rpm, cosmic-icon-theme-rpm]
+    if: ${{ needs.plan.outputs.cosmic_services_rpm_run == 'true' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package: [cosmic-idle, cosmic-notifications, cosmic-osd, xdg-desktop-portal-cosmic]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.14'
+      - run: pip install pyyaml
+      - uses: ./.github/actions/tideforge-source-cache
+        with:
+          recipe: packages/${{ matrix.package }}/package.yaml
+      - uses: actions/download-artifact@v8
+        with:
+          name: pop-icon-theme-el10-rpm
+          path: .tideforge/cosmic-services/${{ matrix.package }}/prerequisite
+      - uses: actions/download-artifact@v8
+        with:
+          name: cosmic-icon-theme-el10-rpm
+          path: .tideforge/cosmic-services/${{ matrix.package }}/prerequisite
+      - name: Render and fetch the exact source archive
+        run: |
+          set -euo pipefail
+          # Keep the matrix-owned recipes visible to plan_gate_matrix.py; a
+          # computed matrix has no literal include entries for the planner to
+          # inspect.
+          echo packages/cosmic-idle/package.yaml packages/cosmic-notifications/package.yaml packages/cosmic-osd/package.yaml packages/xdg-desktop-portal-cosmic/package.yaml
+          recipe="packages/${{ matrix.package }}/package.yaml"
+          root="$PWD/.tideforge/cosmic-services/${{ matrix.package }}"
+          python3 scripts/tideforge.py validate "$recipe"
+          python3 scripts/verify-tideforge-source.py "$recipe" --cache-dir "$HOME/.cache/tideforge/sources"
+          python3 scripts/tideforge.py render "$recipe" --target el10 --output "$root/rpmbuild/SPECS"
+          mkdir -p "$root/rpmbuild"/{BUILD,BUILDROOT,RPMS,SOURCES,SRPMS}
+          python3 scripts/fetch-tideforge-sources.py "$recipe" "$root/rpmbuild/SOURCES" --cache-dir "$HOME/.cache/tideforge/sources"
+      - name: Pull the build image
+        run: scripts/pull-container-image.sh quay.io/centos/centos:stream10
+      - name: Build generated RPM
+        run: |
+          set -euo pipefail
+          root="$PWD/.tideforge/cosmic-services/${{ matrix.package }}"
+          docker run --rm --volume "$root:/work" quay.io/centos/centos:stream10 bash -lc '
+            set -euo pipefail
+            dnf -y install dnf-plugins-core epel-release rpm-build
+            dnf config-manager --set-enabled crb
+            dnf -y builddep /work/rpmbuild/SPECS/*.spec
+            rpmbuild -ba --define "_topdir /work/rpmbuild" /work/rpmbuild/SPECS/*.spec
+          '
+      - name: Clean-install RPM and run its assertion
+        run: |
+          set -euo pipefail
+          recipe="packages/${{ matrix.package }}/package.yaml"
+          root="$PWD/.tideforge/cosmic-services/${{ matrix.package }}"
+          install_name=$(python3 scripts/tideforge.py verify "$recipe" --target el10 --field install_name)
+          python3 scripts/tideforge.py verify "$recipe" --target el10 --field smoke > "$root/verify-smoke.sh"
+          docker run --rm --env INSTALL_NAME="$install_name" --volume "$root:/work:ro" quay.io/centos/centos:stream10 bash -lc '
+            set -euo pipefail
+            dnf -y install epel-release createrepo_c
+            mkdir -p /tmp/tideforge-rpms
+            cp -a /work/prerequisite/. /tmp/tideforge-rpms/
+            cp -a /work/rpmbuild/RPMS/. /tmp/tideforge-rpms/
+            createrepo_c /tmp/tideforge-rpms
+            dnf -y install --nogpgcheck --repofrompath tideforge,file:///tmp/tideforge-rpms --setopt=tideforge.priority=1 --enablerepo=tideforge "$INSTALL_NAME"
+            rpm -q "$INSTALL_NAME"
+            bash /work/verify-smoke.sh
+          '
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: ${{ matrix.package }}-el10-rpm
+          path: .tideforge/cosmic-services/${{ matrix.package }}/rpmbuild/RPMS/
           if-no-files-found: warn
 
   cosmic-comp-rpm:
@@ -1718,7 +1808,7 @@ jobs:
 
   tideforge-gate:
     name: Tideforge gate
-    needs: [detect-changes, plan, rpm-payload, rpm, opensuse-rpm, xfconf-split, gtkgreet-rpm, cpptrace-rpm, input-remapper-rpm, quickshell-rpm, niri-rpm, iio-niri-rpm, dms-stack-rpm, cosmic-icon-theme-rpm, cosmic-comp-rpm, cosmic-bg-rpm, deb, cosmic-icon-theme-deb, cosmic-comp-deb]
+    needs: [detect-changes, plan, rpm-payload, rpm, opensuse-rpm, xfconf-split, gtkgreet-rpm, cpptrace-rpm, input-remapper-rpm, quickshell-rpm, niri-rpm, iio-niri-rpm, dms-stack-rpm, cosmic-icon-theme-rpm, cosmic_services_rpm, cosmic-comp-rpm, cosmic-bg-rpm, deb, cosmic-icon-theme-deb, cosmic-comp-deb]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-tideforge-supported.yml
+++ b/.github/workflows/build-tideforge-supported.yml
@@ -217,18 +217,15 @@ jobs:
           # tideforge-built runtime deps, so the plain matrix cell suffices.
           # cosmic-icon-theme and cosmic-comp need staged prerequisites and
           # get dedicated jobs below.
+          # The install contract is not repeated here: the gate derives
+          # install_name and smoke from each recipe's verify: block, so a
+          # matrix copy is redundant today and stale tomorrow.
           - package: pop-icon-theme
             target: el10
-            install_name: pop-icon-theme
-            smoke: test -d /usr/share/icons/Pop
           - package: cosmic-randr
             target: el10
-            install_name: cosmic-randr
-            smoke: cosmic-randr --help
           - package: cosmic-panel
             target: el10
-            install_name: cosmic-panel
-            smoke: test -x /usr/bin/cosmic-panel
           - package: cosmic-settings-daemon
             target: el10
           - package: evtest
@@ -998,10 +995,6 @@ jobs:
       - name: Render and fetch the exact source archive
         run: |
           set -euo pipefail
-          # This job owns the staged COSMIC icon closure consumed by the
-          # service gates below. Keep these recipe paths visible to the planner
-          # so a service-only change also reruns this prerequisite job.
-          echo packages/cosmic-idle/package.yaml packages/cosmic-notifications/package.yaml packages/cosmic-osd/package.yaml packages/xdg-desktop-portal-cosmic/package.yaml
           recipe=packages/cosmic-icon-theme/package.yaml
           root="$PWD/.tideforge/cosmic-icon-theme"
           python3 scripts/tideforge.py validate "$recipe"
@@ -1050,14 +1043,26 @@ jobs:
   # runs the recipe-owned smoke assertion instead of returning a payload-only
   # green check (#169).
   cosmic_services_rpm:
-    name: ${{ matrix.package }} (el10 RPM)
+    name: ${{ matrix.package }} (${{ matrix.target }} RPM)
     needs: [detect-changes, plan, rpm, cosmic-icon-theme-rpm]
     if: ${{ needs.plan.outputs.cosmic_services_rpm_run == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        package: [cosmic-idle, cosmic-notifications, cosmic-osd, xdg-desktop-portal-cosmic]
+        # Declared as include cells, not a bare package list: that is the shape
+        # plan_gate_matrix.py and the coverage/verify cross-checks read, so a
+        # change to one of these recipes reaches this job (and its staged
+        # prerequisites) without the workflow restating anything.
+        include:
+          - package: cosmic-idle
+            target: el10
+          - package: cosmic-notifications
+            target: el10
+          - package: cosmic-osd
+            target: el10
+          - package: xdg-desktop-portal-cosmic
+            target: el10
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -1078,10 +1083,6 @@ jobs:
       - name: Render and fetch the exact source archive
         run: |
           set -euo pipefail
-          # Keep the matrix-owned recipes visible to plan_gate_matrix.py; a
-          # computed matrix has no literal include entries for the planner to
-          # inspect.
-          echo packages/cosmic-idle/package.yaml packages/cosmic-notifications/package.yaml packages/cosmic-osd/package.yaml packages/xdg-desktop-portal-cosmic/package.yaml
           recipe="packages/${{ matrix.package }}/package.yaml"
           root="$PWD/.tideforge/cosmic-services/${{ matrix.package }}"
           python3 scripts/tideforge.py validate "$recipe"

--- a/packages/cosmic-idle/package.yaml
+++ b/packages/cosmic-idle/package.yaml
@@ -38,4 +38,6 @@ files:
   common: [usr/bin/cosmic-idle]
 install:
   commands: ["just rootdir={destdir} prefix=/usr install"]
+verify:
+  smoke: test -x /usr/bin/cosmic-idle
 targets: [el10]

--- a/packages/cosmic-notifications/package.yaml
+++ b/packages/cosmic-notifications/package.yaml
@@ -38,4 +38,6 @@ files:
   common: [usr/bin/cosmic-notifications]
 install:
   commands: ["just rootdir={destdir} prefix=/usr install"]
+verify:
+  smoke: test -x /usr/bin/cosmic-notifications
 targets: [el10]

--- a/packages/cosmic-osd/package.yaml
+++ b/packages/cosmic-osd/package.yaml
@@ -38,4 +38,6 @@ files:
   common: [usr/bin/cosmic-osd]
 install:
   commands: ["just rootdir={destdir} prefix=/usr install"]
+verify:
+  smoke: test -x /usr/bin/cosmic-osd
 targets: [el10]

--- a/packages/cosmic-settings-daemon/package.yaml
+++ b/packages/cosmic-settings-daemon/package.yaml
@@ -41,7 +41,11 @@ dependencies:
       el10: [cargo, lld, just, patch, systemd-devel, libudev-devel, libinput-devel, wayland-devel, clang-devel, libxkbcommon-devel, pulseaudio-utils, pipewire-devel, openssl-devel]
   runtime:
     targets:
-      el10: [acpid, adw-gtk3-theme, sound-theme-freedesktop]
+      # The daemon does not load GTK themes; adw-gtk3-theme was inherited from
+      # the full desktop closure and has no EL10 provider. Keep the actual
+      # daemon runtime dependencies explicit so this package can be installed
+      # and asserted independently.
+      el10: [acpid, sound-theme-freedesktop]
 files:
   common:
     - usr/bin/cosmic-settings-daemon
@@ -49,4 +53,6 @@ files:
     - usr/share/polkit-1/rules.d/cosmic-settings-daemon.rules
 install:
   commands: ["make install DESTDIR={destdir} prefix=/usr"]
+verify:
+  smoke: test -x /usr/bin/cosmic-settings-daemon && test -f /usr/share/polkit-1/rules.d/cosmic-settings-daemon.rules
 targets: [el10]

--- a/packages/xdg-desktop-portal-cosmic/package.yaml
+++ b/packages/xdg-desktop-portal-cosmic/package.yaml
@@ -53,4 +53,6 @@ files:
     - usr/share/icons/hicolor/scalable/actions/screenshot-window-symbolic.svg
 install:
   commands: ["just rootdir={destdir} prefix=/usr install"]
+verify:
+  smoke: test -x /usr/libexec/xdg-desktop-portal-cosmic && test -f /usr/share/dbus-1/services/org.freedesktop.impl.portal.desktop.cosmic.service && test -f /usr/share/xdg-desktop-portal/cosmic-portals.conf
 targets: [el10]

--- a/scripts/plan_gate_matrix.py
+++ b/scripts/plan_gate_matrix.py
@@ -135,6 +135,19 @@ def running_jobs(workflow: dict, seeds: set[str]) -> tuple[set[str], set[str]]:
             if set(job_needs(job)) & running:
                 running.add(name)
                 changed = True
+    # Staged jobs also need their prerequisites. For example, a change to
+    # cosmic-idle reaches cosmic_services_rpm, which needs
+    # cosmic-icon-theme-rpm, which needs the plain rpm job for pop-icon-theme.
+    # Without this reverse closure, GitHub skips a prerequisite job and the
+    # consumer cannot download the artifact it is supposed to install.
+    changed = True
+    while changed:
+        changed = False
+        for name in tuple(running):
+            for prerequisite in job_needs(jobs[name]):
+                if prerequisite in jobs and prerequisite not in running:
+                    running.add(prerequisite)
+                    changed = True
     return seeded, running - seeded
 
 

--- a/tests/test_plan_gate_matrix.py
+++ b/tests/test_plan_gate_matrix.py
@@ -147,6 +147,13 @@ def test_transitive_closure_reaches_two_hops(workflow):
     assert {"quickshell-rpm", "dms-stack-rpm"} <= downstream
 
 
+def test_staged_service_change_runs_its_prerequisites(workflow):
+    """A service gate must bring along the icon and pop-icon artifacts."""
+    result = plan(workflow, ["packages/cosmic-idle/package.yaml"], root=ROOT)
+    live = running(result)
+    assert {"cosmic_services_rpm", "cosmic-icon-theme-rpm", "rpm"} <= live
+
+
 # ── phase 2: fingerprints ──────────────────────────────────────────────────
 
 def test_fingerprint_is_stable_and_target_scoped(workflow):
@@ -210,7 +217,7 @@ def test_every_skip_carries_a_reason(workflow):
 
 WIRED_JOBS = {
     "gtkgreet-rpm", "cpptrace-rpm", "quickshell-rpm", "niri-rpm", "iio-niri-rpm",
-    "dms-stack-rpm", "cosmic-icon-theme-rpm", "cosmic-comp-rpm", "cosmic-bg-rpm",
+    "dms-stack-rpm", "cosmic-icon-theme-rpm", "cosmic_services_rpm", "cosmic-comp-rpm", "cosmic-bg-rpm",
 }
 
 


### PR DESCRIPTION
## Summary

Closes #169.

- Add clean-install and recipe-owned smoke assertions for the first COSMIC gate cells.
- Stage pop-icon-theme and cosmic-icon-theme artifacts for the COSMIC service gates.
- Add verify contracts for cosmic-idle, cosmic-notifications, cosmic-osd, cosmic-settings-daemon, and xdg-desktop-portal-cosmic.
- Extend planner coverage so service changes pull their prerequisite artifacts into the run.
- Remove the invalid adw-gtk3-theme runtime dependency from cosmic-settings-daemon.

## Validation

- `git diff --check`
- Python bytecode compilation and recipe verify/target presence checks
- Full pytest/tideforge validation could not run locally because this environment lacks pytest, PyYAML, and pip; CI installs PyYAML in the workflow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->