### PR TITLE
fix(ci): add ghcr.io fallback mirror for docker.io image pulls (#284)

### DIFF
--- a/scripts/pull-container-image.sh
+++ b/scripts/pull-container-image.sh
@@ -25,17 +25,39 @@ fi
 attempts=5
 
 for image in "$@"; do
-    delay=5
-    for attempt in $(seq 1 "$attempts"); do
-        if docker pull "$image"; then
-            break
-        fi
-        if [ "$attempt" -eq "$attempts" ]; then
-            echo "pull-container-image: giving up on $image after $attempts attempts" >&2
-            exit 1
-        fi
-        echo "pull-container-image: attempt $attempt/$attempts failed for $image; retrying in ${delay}s" >&2
-        sleep "$delay"
-        delay=$((delay * 2))
+    # Fallback list for image pull: if pulling from docker.io fails or is rate-limited,
+    # fallback to ghcr.io/tuna-os mirror if applicable.
+    pull_targets=("$image")
+    if [[ "$image" =~ ^(docker\.io/library/|docker\.io/)?(ubuntu|debian|archlinux)(:.*)?$ ]]; then
+        prefix_clean="${image#docker.io/}"
+        prefix_clean="${prefix_clean#library/}"
+        # E.g. ubuntu:26.04 -> ghcr.io/tuna-os/ubuntu:26.04
+        pull_targets=("$image" "ghcr.io/tuna-os/$prefix_clean")
+    fi
+
+    success=0
+    for target in "${pull_targets[@]}"; do
+        delay=5
+        for attempt in $(seq 1 "$attempts"); do
+            if docker pull "$target"; then
+                if [ "$target" != "$image" ]; then
+                    docker tag "$target" "$image"
+                fi
+                success=1
+                break 2
+            fi
+            if [ "$attempt" -eq "$attempts" ]; then
+                echo "pull-container-image: attempt $attempts failed for $target" >&2
+            else
+                echo "pull-container-image: attempt $attempt/$attempts failed for $target; retrying in ${delay}s" >&2
+                sleep "$delay"
+                delay=$((delay * 2))
+            fi
+        done
     done
+
+    if [ "$success" -ne 1 ]; then
+        echo "pull-container-image: giving up on $image after trying all mirrors" >&2
+        exit 1
+    fi
 done


### PR DESCRIPTION
Fixes #284.

Updates `scripts/pull-container-image.sh` to include a fallback pull target for `docker.io` base images (`ubuntu`, `debian`, `archlinux`). If pulls from `docker.io` fail or are rate-limited, the script falls back to pulling from the `ghcr.io/tuna-os` mirror and tagging the image locally.
---
🐝 **Hive Agent**: `contributor` | **SHA:** `bd3db40`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->