### PR TITLE
test(cosmic): add recipe-owned service install assertions

### DIFF
--- a/packages/cosmic-greeter/package.yaml
+++ b/packages/cosmic-greeter/package.yaml
@@ -26,7 +26,10 @@ dependencies:
       el10: [cargo, lld, wayland-devel, clang-devel, libxkbcommon-devel, just, libudev-devel, libinput-devel]
   runtime:
     targets:
-      el10: [dbus, greetd, greetd-selinux, fprintd-pam, pam, cosmic-comp >= 1.4.0, cosmic-icon-theme >= 1.4.0]
+      # CentOS Stream 10 has no greetd-selinux provider. Requiring a
+      # nonexistent subpackage made the first clean-install gate fail before
+      # the greeter itself could be tested (#169).
+      el10: [dbus, greetd, fprintd-pam, pam, cosmic-comp >= 1.4.0, cosmic-icon-theme >= 1.4.0]
 files:
   common: [usr/bin/cosmic-greeter, usr/bin/cosmic-greeter-daemon, usr/bin/cosmic-greeter-start, usr/share/dbus-1/system.d/com.system76.CosmicGreeter.conf, usr/lib/sysusers.d/cosmic-greeter.conf, usr/lib/tmpfiles.d/cosmic-greeter.conf, etc/greetd/cosmic-greeter.toml, usr/lib/systemd/system/cosmic-greeter.service, usr/lib/systemd/system/cosmic-greeter-daemon.service, etc/pam.d/cosmic-greeter]
 install:
@@ -41,4 +44,6 @@ install:
     - install -Dm0644 debian/cosmic-greeter.service {destdir}/usr/lib/systemd/system/cosmic-greeter.service
     - install -Dm0644 debian/cosmic-greeter-daemon.service {destdir}/usr/lib/systemd/system/cosmic-greeter-daemon.service
     - install -Dm0644 debian/greetd.pam {destdir}/etc/pam.d/cosmic-greeter
+verify:
+  smoke: test -x /usr/bin/cosmic-greeter && test -x /usr/bin/cosmic-greeter-daemon && test -f /usr/lib/systemd/system/cosmic-greeter.service && test -f /etc/greetd/cosmic-greeter.toml
 targets: [el10]

--- a/packages/cosmic-idle/package.yaml
+++ b/packages/cosmic-idle/package.yaml
@@ -38,4 +38,6 @@ files:
   common: [usr/bin/cosmic-idle]
 install:
   commands: ["just rootdir={destdir} prefix=/usr install"]
+verify:
+  smoke: test -x /usr/bin/cosmic-idle
 targets: [el10]

--- a/packages/cosmic-notifications/package.yaml
+++ b/packages/cosmic-notifications/package.yaml
@@ -38,4 +38,6 @@ files:
   common: [usr/bin/cosmic-notifications]
 install:
   commands: ["just rootdir={destdir} prefix=/usr install"]
+verify:
+  smoke: test -x /usr/bin/cosmic-notifications
 targets: [el10]

--- a/packages/cosmic-osd/package.yaml
+++ b/packages/cosmic-osd/package.yaml
@@ -38,4 +38,6 @@ files:
   common: [usr/bin/cosmic-osd]
 install:
   commands: ["just rootdir={destdir} prefix=/usr install"]
+verify:
+  smoke: test -x /usr/bin/cosmic-osd
 targets: [el10]

--- a/packages/cosmic-settings-daemon/package.yaml
+++ b/packages/cosmic-settings-daemon/package.yaml
@@ -41,7 +41,11 @@ dependencies:
       el10: [cargo, lld, just, patch, systemd-devel, libudev-devel, libinput-devel, wayland-devel, clang-devel, libxkbcommon-devel, pulseaudio-utils, pipewire-devel, openssl-devel]
   runtime:
     targets:
-      el10: [acpid, adw-gtk3-theme, sound-theme-freedesktop]
+      # The daemon does not load GTK themes; adw-gtk3-theme was inherited from
+      # the full desktop closure and has no EL10 provider. Keep the actual
+      # daemon runtime dependencies explicit so this package can be installed
+      # and asserted independently.
+      el10: [acpid, sound-theme-freedesktop]
 files:
   common:
     - usr/bin/cosmic-settings-daemon
@@ -49,4 +53,6 @@ files:
     - usr/share/polkit-1/rules.d/cosmic-settings-daemon.rules
 install:
   commands: ["make install DESTDIR={destdir} prefix=/usr"]
+verify:
+  smoke: test -x /usr/bin/cosmic-settings-daemon && test -f /usr/share/polkit-1/rules.d/cosmic-settings-daemon.rules
 targets: [el10]

--- a/packages/xdg-desktop-portal-cosmic/package.yaml
+++ b/packages/xdg-desktop-portal-cosmic/package.yaml
@@ -53,4 +53,6 @@ files:
     - usr/share/icons/hicolor/scalable/actions/screenshot-window-symbolic.svg
 install:
   commands: ["just rootdir={destdir} prefix=/usr install"]
+verify:
+  smoke: test -x /usr/libexec/xdg-desktop-portal-cosmic && test -f /usr/share/dbus-1/services/org.freedesktop.impl.portal.desktop.cosmic.service && test -f /usr/share/xdg-desktop-portal/cosmic-portals.conf
 targets: [el10]


### PR DESCRIPTION
Adds `verify: smoke` contracts to the six EL10 COSMIC service recipes (cosmic-greeter, cosmic-idle, cosmic-notifications, cosmic-osd, cosmic-settings-daemon, xdg-desktop-portal-cosmic) so the package factory asserts each installed binary/polkit rule at build time, replacing payload-only checks.

This is the **surviving portion of the original #357**. Its other hunks are moot under #430:
- `build-tideforge-supported.yml` — removed by #430 (replaced by the package factory)
- `scripts/plan_gate_matrix.py` — orphaned by #430 (`plan-package-factory.py` is the new planner)
- `tests/test_plan_gate_matrix.py` — deleted by #430

Closes #169.