### PR TITLE
fix(cosmic-session): correct cosmic-icons -> cosmic-icon-theme name mismatch (#169)

### DIFF
--- a/manifests/dependency-trees/cosmic.yaml
+++ b/manifests/dependency-trees/cosmic.yaml
@@ -3,7 +3,7 @@ tree: cosmic
 targets: [el10, ubuntu, debian]
 roots: [cosmic-session, cosmic-settings, cosmic-greeter, xdg-desktop-portal-cosmic]
 nodes:
-  cosmic-session: {source: pop-os/cosmic-epoch, needs: [cosmic-bg, cosmic-comp, cosmic-greeter, cosmic-idle, cosmic-notifications, cosmic-osd, cosmic-panel, cosmic-randr, cosmic-settings, cosmic-settings-daemon, xdg-desktop-portal-cosmic, greetd]}
+  cosmic-session: {source: pop-os/cosmic-epoch, needs: [cosmic-bg, cosmic-comp, cosmic-greeter, cosmic-icon-theme, cosmic-idle, cosmic-notifications, cosmic-osd, cosmic-panel, cosmic-randr, cosmic-settings, cosmic-settings-daemon, xdg-desktop-portal-cosmic, greetd]}
   cosmic-bg: {source: pop-os/cosmic-bg, needs: [cosmic-icon-theme, cargo-toolchain, wayland-stack]}
   cosmic-icon-theme: {source: pop-os/cosmic-icons, needs: [pop-icon-theme]}
   cosmic-idle: {source: pop-os/cosmic-idle, needs: [cosmic-icon-theme, cargo-toolchain, wayland-stack]}

--- a/packages/cosmic-session/package.yaml
+++ b/packages/cosmic-session/package.yaml
@@ -40,7 +40,7 @@ dependencies:
     # the gate's clean-install repo only holds the deb built by that cell, so
     # naming cosmic-comp there renders an unsatisfiable Depends.
     targets:
-      el10: [cosmic-app-library >= 1.4.0, cosmic-applets >= 1.4.0, cosmic-bg >= 1.4.0, cosmic-comp >= 1.4.0, cosmic-files >= 1.4.0, cosmic-greeter >= 1.4.0, cosmic-icons >= 1.4.0, cosmic-idle >= 1.4.0, cosmic-initial-setup >= 1.4.0, cosmic-launcher >= 1.4.0, cosmic-notifications >= 1.4.0, cosmic-osd >= 1.4.0, cosmic-panel >= 1.4.0, cosmic-randr >= 1.4.0, cosmic-screenshot >= 1.4.0, cosmic-settings >= 1.4.0, cosmic-settings-daemon >= 1.4.0, cosmic-term >= 1.4.0, cosmic-workspaces >= 1.4.0, xdg-desktop-portal-cosmic >= 1.4.0, open-sans-fonts, 'font(notosansmono)', xdg-user-dirs, system-cosmic-config]
+      el10: [cosmic-app-library >= 1.4.0, cosmic-applets >= 1.4.0, cosmic-bg >= 1.4.0, cosmic-comp >= 1.4.0, cosmic-files >= 1.4.0, cosmic-greeter >= 1.4.0, cosmic-icon-theme >= 1.4.0, cosmic-idle >= 1.4.0, cosmic-initial-setup >= 1.4.0, cosmic-launcher >= 1.4.0, cosmic-notifications >= 1.4.0, cosmic-osd >= 1.4.0, cosmic-panel >= 1.4.0, cosmic-randr >= 1.4.0, cosmic-screenshot >= 1.4.0, cosmic-settings >= 1.4.0, cosmic-settings-daemon >= 1.4.0, cosmic-term >= 1.4.0, cosmic-workspaces >= 1.4.0, xdg-desktop-portal-cosmic >= 1.4.0, open-sans-fonts, 'font(notosansmono)', xdg-user-dirs, system-cosmic-config]
       ubuntu: []
       debian: []
 files:


### PR DESCRIPTION
## Summary

#169 ("The entire COSMIC stack has 12 green checks and zero install
assertions") lists `cosmic-session`'s 10 unsatisfiable Requires, and calls
one of them out specifically: *"One is a pure name mismatch: it needs
`cosmic-icons`, we build `cosmic-icon-theme` with no `Provides:
cosmic-icons`. One-line fix; the other nine need recipes."*

Verified: `cosmic-icons` appears exactly once anywhere in this repo, in
`cosmic-session/package.yaml`'s own `dependencies.runtime.targets.el10`
list. It's a recipe we control, not an upstream RPM's real Requires, and
every sibling COSMIC recipe (`cosmic-bg`, `cosmic-comp`, `cosmic-idle`,
etc.) already depends on the correct name, `cosmic-icon-theme`. This is
the fix, not a bigger `Provides:` renderer feature (the renderer has no
`Provides:` support at all, checked via `grep -rn Provides scripts/`).

- `packages/cosmic-session/package.yaml`: `cosmic-icons >= 1.4.0` ->
  `cosmic-icon-theme >= 1.4.0`, byte-identical otherwise.
- `manifests/dependency-trees/cosmic.yaml`: added the corresponding
  `cosmic-icon-theme` edge to `cosmic-session`'s node —
  `test_dependency_tree_consistency.py::test_factory_runtime_deps_are_tree_edges`
  correctly caught the recipe/tree mismatch once the recipe named the
  real package ("the tree cannot derive the staging this package needs"),
  and every other node that runtime-requires `cosmic-icon-theme` already
  carries this edge.

## What this is not

This removes **one** of #169's ten unsatisfiable Requires for
`cosmic-session`. The other nine (`adw-gtk3-theme` for
`cosmic-settings-daemon`, `greetd-selinux` for `cosmic-greeter`, and
`cosmic-session`'s remaining nine) still need real new recipes or
Tideforge fixes, and `cosmic-session` stays payload-only in the `rpm-payload`
job (per its own comment: "a full staged install requires the remaining
runtime closure, which is not all factory-built yet") until all ten
clear — this change alone does not install-gate it.

Also worth noting while I was in here: #169's "Suggested first five" all
appear to have landed already — `pop-icon-theme`/`cosmic-randr`/`cosmic-panel`
are real gate cells in the `rpm:` matrix under a comment citing #169, plus
dedicated `cosmic-icon-theme-rpm`/`cosmic-comp-rpm` (and a bonus
`cosmic-bg-rpm`) jobs with real clean-install + smoke assertions. And
`cosmic-greeter`/`xdg-desktop-portal-cosmic` are now in the `rpm-payload`
matrix, with the trigger moved to unfiltered `pull_request`/`merge_group`
plus a `detect-changes` job rather than per-package `on: paths`. Just an
observation from reading the current workflow, not a claim that #169 is
fully done — the ~8 missing `dependency_catalog` capabilities
(wayland/libxkbcommon/libinput/pipewire/gbm/pixman/dav1d/libdisplay-info)
and the two genuine blockers above are still open.

## Test plan

- [x] `python3 scripts/tideforge.py validate packages/cosmic-session/package.yaml` — valid, before and after.
- [x] `pytest tests/ -q` — full suite, 769 passed (including
      `test_dependency_tree_consistency.py` and
      `test_gate_verify_consistency.py`, the two most relevant to this
      change).
---
🐝 **Hive Agent**: `contributor` | **SHA:** `dd7fbe6`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->