### PR TITLE
security: install pinned, checksum-verified rclone instead of curl|sudo bash

### DIFF
--- a/.github/actions/install-rclone/action.yml
+++ b/.github/actions/install-rclone/action.yml
@@ -1,0 +1,58 @@
+name: "Install rclone (pinned)"
+description: >-
+  Installs a pinned, SHA-256-verified rclone .deb release instead of piping
+  the unauthenticated https://rclone.org/install.sh script into `sudo bash`
+  (tuna-os/tunaos#1327). Bump rclone-version + the matching hashes together
+  when updating; hashes are copied from the vendor's own published
+  SHA256SUMS for that release (https://downloads.rclone.org/vVERSION/SHA256SUMS).
+
+inputs:
+  rclone-version:
+    description: "rclone release to install, without the leading v"
+    required: false
+    default: "1.75.0"
+  amd64-sha256:
+    description: "Expected SHA-256 of the linux-amd64 .deb for rclone-version"
+    required: false
+    default: "266598b5c66a42b821571332013cc85a88ffcff8939cf0643861c8d033dd3a4a"
+  arm64-sha256:
+    description: "Expected SHA-256 of the linux-arm64 .deb for rclone-version"
+    required: false
+    default: "081c605cbf47ade3114e78db2130766a23281a12b79cdd5774b11dad6c6c0931"
+
+runs:
+  using: composite
+  steps:
+    - name: Install pinned, checksum-verified rclone
+      shell: bash
+      env:
+        RCLONE_VERSION: ${{ inputs.rclone-version }}
+        AMD64_SHA256: ${{ inputs.amd64-sha256 }}
+        ARM64_SHA256: ${{ inputs.arm64-sha256 }}
+      run: |
+        set -euo pipefail
+
+        case "$(uname -m)" in
+          x86_64)
+            RCLONE_ARCH="amd64"
+            RCLONE_SHA256="${AMD64_SHA256}"
+            ;;
+          aarch64)
+            RCLONE_ARCH="arm64"
+            RCLONE_SHA256="${ARM64_SHA256}"
+            ;;
+          *)
+            echo "::error::unsupported architecture $(uname -m) for pinned rclone install"
+            exit 1
+            ;;
+        esac
+
+        DEB="rclone-v${RCLONE_VERSION}-linux-${RCLONE_ARCH}.deb"
+        DEST="/tmp/${DEB}"
+
+        curl -fsSL -o "${DEST}" \
+          "https://downloads.rclone.org/v${RCLONE_VERSION}/${DEB}"
+        echo "${RCLONE_SHA256}  ${DEST}" | sha256sum -c -
+
+        sudo dpkg -i "${DEST}"
+        rclone version

--- a/.github/workflows/build-distributed.yml
+++ b/.github/workflows/build-distributed.yml
@@ -18,10 +18,10 @@ jobs:
         uses: actions/checkout@v7
       - name: Install dependencies
         run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Install rclone
+        uses: ./.github/actions/install-rclone
       - name: Configure rclone
-        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
-
-          mkdir -p ~/.config/rclone
+        run: 'mkdir -p ~/.config/rclone
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -1338,9 +1338,9 @@ jobs:
       - name: Install dependencies
         run: 'sudo apt-get update -q && sudo apt-get install -y -q rpm createrepo-c gpg gpgconf
 
-          curl -fsSL https://rclone.org/install.sh | sudo bash
-
           '
+      - name: Install rclone
+        uses: ./.github/actions/install-rclone
       - name: Download final repo
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/build-fprintd-aarch64.yml
+++ b/.github/workflows/build-fprintd-aarch64.yml
@@ -58,7 +58,7 @@ jobs:
           git_committer_email: rpm-signing@tunaos.org
 
       - name: Install rclone
-        run: curl -fsSL https://rclone.org/install.sh | sudo bash
+        uses: ./.github/actions/install-rclone
 
       - name: Configure rclone for R2
         env:

--- a/.github/workflows/build-gnome49-distributed.yml
+++ b/.github/workflows/build-gnome49-distributed.yml
@@ -18,10 +18,10 @@ jobs:
         uses: actions/checkout@v7
       - name: Install dependencies
         run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Install rclone
+        uses: ./.github/actions/install-rclone
       - name: Configure rclone
-        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
-
-          mkdir -p ~/.config/rclone
+        run: 'mkdir -p ~/.config/rclone
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -971,9 +971,9 @@ jobs:
       - name: Install dependencies
         run: 'sudo apt-get update -q && sudo apt-get install -y -q rpm createrepo-c gpg gpgconf
 
-          curl -fsSL https://rclone.org/install.sh | sudo bash
-
           '
+      - name: Install rclone
+        uses: ./.github/actions/install-rclone
       - name: Download final repo
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/build-gnome49-package.yml
+++ b/.github/workflows/build-gnome49-package.yml
@@ -91,7 +91,9 @@ jobs:
         run: |
           sudo apt-get update -q
           sudo apt-get install -y -q podman createrepo-c rpm gpg gpgconf
-          curl -fsSL https://rclone.org/install.sh | sudo bash
+
+      - name: Install rclone
+        uses: ./.github/actions/install-rclone
 
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6

--- a/.github/workflows/build-gnome50-distributed.yml
+++ b/.github/workflows/build-gnome50-distributed.yml
@@ -18,10 +18,10 @@ jobs:
         uses: actions/checkout@v7
       - name: Install dependencies
         run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Install rclone
+        uses: ./.github/actions/install-rclone
       - name: Configure rclone
-        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
-
-          mkdir -p ~/.config/rclone
+        run: 'mkdir -p ~/.config/rclone
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -1478,9 +1478,9 @@ jobs:
       - name: Install dependencies
         run: 'sudo apt-get update -q && sudo apt-get install -y -q rpm createrepo-c gpg gpgconf
 
-          curl -fsSL https://rclone.org/install.sh | sudo bash
-
           '
+      - name: Install rclone
+        uses: ./.github/actions/install-rclone
       - name: Download final repo
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/build-gnome50-package.yml
+++ b/.github/workflows/build-gnome50-package.yml
@@ -88,7 +88,9 @@ jobs:
         run: |
           sudo apt-get update -q
           sudo apt-get install -y -q podman createrepo-c rpm gpg gpgconf
-          curl -fsSL https://rclone.org/install.sh | sudo bash
+
+      - name: Install rclone
+        uses: ./.github/actions/install-rclone
 
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6

--- a/.github/workflows/build-gnome51-package.yml
+++ b/.github/workflows/build-gnome51-package.yml
@@ -104,7 +104,9 @@ jobs:
         run: |
           sudo apt-get update -q
           sudo apt-get install -y -q podman createrepo-c rpm gpg gpgconf
-          curl -fsSL https://rclone.org/install.sh | sudo bash
+
+      - name: Install rclone
+        uses: ./.github/actions/install-rclone
 
       - name: Cache CentOS Stream 10 image
         uses: actions/cache@v6

--- a/.github/workflows/build-hummingbird-desktops.yml
+++ b/.github/workflows/build-hummingbird-desktops.yml
@@ -152,13 +152,15 @@ jobs:
       - name: Pull mock runner
         run: podman pull "${MOCK_RUNNER_IMAGE}"
 
+      - name: Install rclone
+        uses: ./.github/actions/install-rclone
+
       - name: Configure R2 access
         env:
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: |
-          curl -fsSL https://rclone.org/install.sh | sudo bash
           mkdir -p ~/.config/rclone
           cat > ~/.config/rclone/rclone.conf <<EOF
           [r2]

--- a/.github/workflows/build-xfce-distributed.yml
+++ b/.github/workflows/build-xfce-distributed.yml
@@ -18,10 +18,10 @@ jobs:
         uses: actions/checkout@v7
       - name: Install dependencies
         run: sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+      - name: Install rclone
+        uses: ./.github/actions/install-rclone
       - name: Configure rclone
-        run: 'curl -fsSL https://rclone.org/install.sh | sudo bash
-
-          mkdir -p ~/.config/rclone
+        run: 'mkdir -p ~/.config/rclone
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -998,9 +998,9 @@ jobs:
       - name: Install dependencies
         run: 'sudo apt-get update -q && sudo apt-get install -y -q rpm createrepo-c gpg gpgconf
 
-          curl -fsSL https://rclone.org/install.sh | sudo bash
-
           '
+      - name: Install rclone
+        uses: ./.github/actions/install-rclone
       - name: Download final repo
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/build-xfce-fedora.yml
+++ b/.github/workflows/build-xfce-fedora.yml
@@ -73,7 +73,7 @@ jobs:
           git_committer_email: rpm-signing@tunaos.org
 
       - name: Install rclone
-        run: curl -fsSL https://rclone.org/install.sh | sudo bash
+        uses: ./.github/actions/install-rclone
 
       - name: Configure rclone for R2
         env:

--- a/.github/workflows/build-xfce-package.yml
+++ b/.github/workflows/build-xfce-package.yml
@@ -101,8 +101,7 @@ jobs:
           git_committer_email: rpm-signing@tunaos.org
 
       - name: Install rclone
-        run: |
-          curl -fsSL https://rclone.org/install.sh | sudo bash
+        uses: ./.github/actions/install-rclone
 
       - name: Configure rclone for R2
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,9 @@ jobs:
           sudo apt-get install -y -q \
             podman createrepo-c rpm python3-yaml \
             gpg gpgconf
-          curl -fsSL https://rclone.org/install.sh | sudo bash
+
+      - name: Install rclone
+        uses: ./.github/actions/install-rclone
 
       - name: Cache CentOS Stream 10 container image
         id: cache-cs10

--- a/.github/workflows/publish-tideforge-debs.yml
+++ b/.github/workflows/publish-tideforge-debs.yml
@@ -127,7 +127,8 @@ jobs:
         run: |
           sudo apt-get update -q
           sudo apt-get install -y -q apt-utils gpg gpgconf
-          curl -fsSL https://rclone.org/install.sh | sudo bash
+      - name: Install rclone
+        uses: ./.github/actions/install-rclone
       - name: Import GPG key
         id: import-gpg
         uses: crazy-max/ghaction-import-gpg@v7

--- a/.github/workflows/r2-inventory.yml
+++ b/.github/workflows/r2-inventory.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install rclone
-        run: curl -fsSL https://rclone.org/install.sh | sudo bash
+        uses: ./.github/actions/install-rclone
 
       - name: Configure rclone
         run: |

--- a/.github/workflows/refresh-gnome50-r2.yml
+++ b/.github/workflows/refresh-gnome50-r2.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install rclone
-        run: curl -fsSL https://rclone.org/install.sh | sudo bash
+        uses: ./.github/actions/install-rclone
 
       - name: Configure rclone for R2
         run: |


### PR DESCRIPTION
## Summary

tuna-os/tunaos#1327 flagged 19 occurrences across 15 workflows in this repo piping `https://rclone.org/install.sh` into `sudo bash` — unpinned, unverified, root code execution from a remote script. A prior attempt at this fix (referenced in the issue's comments) was blocked on the agent's token lacking `workflows` permission; this PR implements it via the normal fork+PR flow.

- New composite action `.github/actions/install-rclone`: downloads a specific, pinned rclone `.deb` release and verifies it against a SHA-256 hash before `dpkg -i`. Auto-detects `amd64`/`arm64` via `uname -m` (needed for `build-fprintd-aarch64.yml`'s `ubuntu-24.04-arm` runner). Defaults to rclone v1.75.0 with hashes copied from the vendor's own published `SHA256SUMS` for that release — verified live against `https://downloads.rclone.org/v1.75.0/SHA256SUMS` before writing them into the action.
- All 15 workflows now call `uses: ./.github/actions/install-rclone` instead of the inline curl-pipe. No other behavior change — same rclone version that `install.sh` would have installed today, just pinned and checksum-verified. Bumping rclone in the future means updating one file's version+hash inputs instead of 19 call sites.

## Test plan
- [x] `grep -rl "rclone.org/install.sh" .github/workflows/` — zero remaining matches
- [x] `python3 -c "import yaml; ..."` on every modified workflow + the new `action.yml` — all parse cleanly
- [x] Verified the pinned SHA-256 hashes live against `downloads.rclone.org/v1.75.0/SHA256SUMS` for both `linux-amd64.deb` and `linux-arm64.deb`
- [x] Confirmed the arm64 path is exercised by `build-fprintd-aarch64.yml` (`runs-on: ubuntu-24.04-arm`) — the action's arch-detection branch covers it
- [x] Reviewed each of the 15 diffs individually — every one replaces exactly the flagged line(s), no unrelated step reordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
🐝 **Hive Agent**: `contributor` | **SHA:** `1011175`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->