### PR TITLE
fix(hummingbird): key the mock cache on a digest, not the tier list

### DIFF
--- a/.github/workflows/build-hummingbird-desktops.yml
+++ b/.github/workflows/build-hummingbird-desktops.yml
@@ -201,6 +201,12 @@ jobs:
             --exclude-tiers "${IN_EXCLUDE}")
           echo "selected $(tr ',' '\n' <<< "$list" | wc -l) tiers: $list"
           echo "list=$list" >> "$GITHUB_OUTPUT"
+          # A digest of the same selection, for use in cache keys. `list` is
+          # comma-separated and actions/cache rejects a key containing a comma
+          # outright -- see the cache step below for what that cost. A digest
+          # is also bounded, so a larger desktop can never push the key past
+          # the 512-character limit.
+          echo "slug=$(printf '%s' "$list" | sha256sum | cut -c1-12)" >> "$GITHUB_OUTPUT"
 
       - name: Import Fedora Rawhide packaging for the selected tiers
         run: |
@@ -254,10 +260,25 @@ jobs:
           # re-dispatch of the same tiers should hit. github.run_id makes each
           # run's save unique so concurrent runs do not race, and the
           # restore-keys walk back to the most recent compatible entry.
-          key: hummingbird-mock-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ steps.tiers.outputs.list }}-${{ github.run_id }}
+          #
+          # steps.tiers.outputs.slug, NOT .list: the list is comma-separated,
+          # and actions/cache refuses any key containing a comma --
+          #
+          #   ##[error]Key Validation Error: hummingbird-mock-<hash>-\
+          #   bootstrap-00,bootstrap-01,...,layer-23-<run_id> cannot contain
+          #   commas.
+          #
+          # That fired on every desktop of every run, in the same second the
+          # step started. It is not a soft cache miss: the step fails, `Build
+          # tiers` is skipped as a result, and the job still went on to sign
+          # and publish whatever the R2 seed had already put in the local
+          # repo. So the run uploaded a 10 GB artifact and reported a package
+          # repository while building precisely zero packages -- the failure
+          # looked like a caching hiccup and was actually total.
+          key: hummingbird-mock-${{ matrix.desktop }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ steps.tiers.outputs.slug }}-${{ github.run_id }}
           restore-keys: |
-            hummingbird-mock-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ steps.tiers.outputs.list }}-
-            hummingbird-mock-${{ hashFiles('mock/hummingbird-ci.cfg') }}-
+            hummingbird-mock-${{ matrix.desktop }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-${{ steps.tiers.outputs.slug }}-
+            hummingbird-mock-${{ matrix.desktop }}-${{ hashFiles('mock/hummingbird-ci.cfg') }}-
 
       - name: Cache upstream source tarballs
         uses: actions/cache@v6

--- a/tests/test_hummingbird_cache_key_is_valid.py
+++ b/tests/test_hummingbird_cache_key_is_valid.py
@@ -1,0 +1,156 @@
+"""A cache key that GitHub rejects skips the build and still reports success.
+
+The Hummingbird desktop workflow keyed its mock-chroot cache on the selected
+tier list. That list is comma-separated, and actions/cache refuses any key
+containing a comma:
+
+    ##[error]Key Validation Error: hummingbird-mock-<cfghash>-bootstrap-00,
+    bootstrap-01,...,layer-23-<run_id> cannot contain commas.
+
+It fired on every desktop of every run, in the same second the step started.
+The damage was not a slow build from a cold cache. The cache step *fails*, so
+`Build tiers` is skipped -- and the job carried on to sign and publish
+whatever the R2 seed had already dropped into the local repo, then uploaded a
+10 GB artifact. Runs 31687135147, 31688105850 and their predecessors reported
+a published package repository having built exactly zero packages.
+
+These tests build the key the workflow would build, from the real tier
+selection, and check it against the constraints GitHub actually enforces.
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github/workflows/build-hummingbird-desktops.yml"
+SELECTOR = ROOT / "scripts/select-desktop-tiers.py"
+MANIFEST = ROOT / "build-order-hummingbird-desktops.yml"
+GAP_REPORT = ROOT / "docs/hummingbird-desktop-gap.json"
+
+DESKTOPS = ["gnome", "kde", "cosmic", "niri", "xfce"]
+
+# GitHub's documented cache-key limit.
+MAX_KEY_LEN = 512
+
+
+@pytest.fixture(scope="module")
+def build_steps():
+    workflow = yaml.safe_load(WORKFLOW.read_text())
+    return workflow["jobs"]["build"]["steps"]
+
+
+@pytest.fixture(scope="module")
+def cache_steps(build_steps):
+    steps = [s for s in build_steps if str(s.get("uses", "")).startswith("actions/cache")]
+    assert steps, "no actions/cache step left in the build job"
+    return steps
+
+
+def _select(desktop):
+    out = subprocess.run(
+        [
+            sys.executable,
+            str(SELECTOR),
+            "--manifest",
+            str(MANIFEST),
+            "--gap-report",
+            str(GAP_REPORT),
+            "--desktop",
+            desktop,
+            "--tiers",
+            "",
+            "--exclude-tiers",
+            "",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return out.stdout.strip()
+
+
+@pytest.mark.parametrize("desktop", DESKTOPS)
+def test_the_tier_list_really_does_contain_commas(desktop):
+    # The premise of every other test here. If the selector ever stops
+    # emitting a comma-separated list this file is guarding a ghost, and the
+    # failure below says so plainly rather than passing vacuously.
+    assert "," in _select(desktop), (
+        f"{desktop}'s tier list no longer contains commas -- re-check whether "
+        "the cache key still needs a digest"
+    )
+
+
+def test_no_cache_key_interpolates_the_raw_tier_list(cache_steps):
+    for step in cache_steps:
+        for field in ("key", "restore-keys"):
+            value = str(step["with"].get(field, ""))
+            assert "outputs.list" not in value, (
+                f"{step['name']!r} interpolates the comma-separated tier list "
+                f"into {field}; actions/cache rejects the key outright and the "
+                "build step is skipped"
+            )
+
+
+def test_the_selection_step_publishes_a_comma_free_digest(build_steps):
+    tiers = next((s for s in build_steps if s.get("id") == "tiers"), None)
+    assert tiers is not None, "the Select tiers step lost its id"
+    assert "slug=" in tiers["run"], (
+        "the Select tiers step must publish a digest of the selection for use "
+        "in cache keys"
+    )
+
+
+@pytest.mark.parametrize("desktop", DESKTOPS)
+def test_the_resolved_cache_key_is_one_github_accepts(cache_steps, desktop):
+    # Substitute what the runner would substitute, then apply GitHub's rules.
+    slug = subprocess.run(
+        ["sha256sum"],
+        input=_select(desktop),
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout[:12]
+    substitutions = {
+        r"\$\{\{ matrix\.desktop \}\}": desktop,
+        r"\$\{\{ hashFiles\('mock/hummingbird-ci\.cfg'\) \}\}": "f" * 64,
+        r"\$\{\{ hashFiles\('build-order-hummingbird-desktops\.yml'\) \}\}": "e" * 64,
+        r"\$\{\{ steps\.tiers\.outputs\.slug \}\}": slug,
+        r"\$\{\{ github\.run_id \}\}": "31688105850",
+    }
+
+    for step in cache_steps:
+        raw = [str(step["with"]["key"])]
+        raw += str(step["with"].get("restore-keys", "")).splitlines()
+        for key in (k.strip() for k in raw if k.strip()):
+            for pattern, value in substitutions.items():
+                key = re.sub(pattern, value, key)
+            assert "${{" not in key, (
+                f"{step['name']!r} still holds an unsubstituted expression "
+                f"after {desktop}: {key!r} -- this test cannot vouch for it"
+            )
+            assert "," not in key, (
+                f"{step['name']!r} resolves to a key with a comma for "
+                f"{desktop}: {key!r}"
+            )
+            assert len(key) <= MAX_KEY_LEN, (
+                f"{step['name']!r} resolves to a {len(key)}-character key for "
+                f"{desktop}, over GitHub's {MAX_KEY_LEN} limit"
+            )
+
+
+def test_the_build_step_is_what_the_cache_step_guards(build_steps):
+    # The reason a failed cache step was so expensive: `Build tiers` has no
+    # if: of its own, so it inherits the job's failed state and is skipped,
+    # while the publish steps that follow do not. Keep that adjacency visible
+    # -- if a future edit puts the cache step somewhere else, this bug's blast
+    # radius changes and the comment above should be re-read.
+    names = [s.get("name", "") for s in build_steps]
+    cache = next(i for i, n in enumerate(names) if n.startswith("Cache the mock chroot"))
+    build = next(i for i, n in enumerate(names) if n == "Build tiers")
+    assert cache < build, "the mock cache must be restored before the build runs"


### PR DESCRIPTION
**No Hummingbird desktop package has been built in any recent run.** Not "some failed" — zero built, while the runs reported a published repository.

## The failure

The mock-chroot cache is keyed on the selected tier list. That list is comma-separated, and `actions/cache` refuses any key containing a comma:

```
##[error]Key Validation Error: hummingbird-mock-4832b10bf11b233c963807b32e703e0ff84c707260443803280c5464367a7011-bootstrap-00,bootstrap-01,bootstrap-02,bootstrap-03,layer-00,layer-01,layer-02,layer-03,layer-04,layer-05,layer-06,layer-07,layer-08,layer-09,layer-10,layer-11,layer-12,layer-15,layer-16,layer-17,layer-18,layer-19,layer-20,layer-23-31688105850 cannot contain commas.
```

It fired on **all five desktops** of [run 31688105850](https://github.com/tuna-os/tunaos-packages/actions/runs/31688105850), in the same second the step started, and on every run before it.

## Why it was invisible

The cost is not a cold cache. The cache step *fails*, so `Build tiers` is skipped — but the steps after it are not, so each job went on to sign and publish whatever the R2 seed had already dropped into `local-repo-hummingbird`, then uploaded a 10 GB `hummingbird-rpms-gnome` artifact.

Step-level evidence from `build (gnome, hummingbird)`:

| # | Step | Conclusion |
| ---: | :--- | :--- |
| 8 | Import Fedora Rawhide packaging for the selected tiers | success (`imported=1084 skipped=0 failed=0`) |
| **10** | **Cache the mock chroot and its dnf downloads** | **failure** |
| 11 | Cache upstream source tarballs | skipped |
| **12** | **Build tiers** | **skipped** |
| 13 | Sign RPMs and publish | success |
| 14 | Publish signed rpm-md repository | success |
| 15 | Upload artifact (`10650492610` bytes) | success |

A run that built nothing looked, from its artifacts, exactly like a run that built everything. That is why the visible symptom has been package-level failures that nobody could reproduce — those logs predate the regression.

## The fix

Key on a 12-character sha256 of the same selection. It is comma-free by construction and bounded, so a larger desktop cannot push the key past GitHub's 512-character limit either — measured today, before the prefix and run id are added:

| Desktop | Tiers | Tier-list length | Commas |
| :--- | ---: | ---: | ---: |
| gnome | 24 | 231 | 23 |
| kde | 39 | 366 | 38 |
| cosmic | 23 | 222 | 22 |
| niri | 31 | 294 | 30 |
| xfce | 24 | 231 | 23 |

The desktop name goes into the key too, so entries stay legible now that the selection itself is a digest.

## Tests

`tests/test_hummingbird_cache_key_is_valid.py` (13 tests) resolves the key the runner would resolve — from the real output of `select-desktop-tiers.py` for each of the five desktops — and applies the rules GitHub actually enforces: no commas, within the length limit, nothing left unsubstituted.

It also asserts the tier list **still** contains commas, so the suite fails loudly rather than passing vacuously if the selector's output format ever changes, and pins that the cache step still precedes the build step it guards (that adjacency is what made this bug total rather than slow).

Mutation-verified:

| Mutation | Result |
| :--- | :--- |
| restore the raw tier list in the key | 6 failed, 7 passed |
| stop publishing the `slug` output | 1 failed, 12 passed |
| move `Build tiers` ahead of the cache step | 1 failed, 12 passed |

Full suite: `806 passed`.

## What this unblocks

#374 restored the perl and python ABI pins in `mock/hummingbird-ci.cfg` and merged an hour ago, auto-triggering [run 31696444706](https://github.com/tuna-os/tunaos-packages/actions/runs/31696444706). That run carries the same broken cache key, so it will skip `Build tiers` too and prove nothing about the pins. This needs to land before the restored buildroot can actually be exercised.

The previously-tracked package failures (qt6-qtserialport, qt6-qtlanguageserver, librist, openvr, python-setproctitle, python-regex, scotch) should be re-triaged against a run that actually builds, rather than against logs from before the regression.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->