### PR TITLE
fix(build-chain): say why the buildroot failed, not just the last 40 lines

### DIFF
--- a/scripts/build-chain.sh
+++ b/scripts/build-chain.sh
@@ -89,10 +89,28 @@ _on_error() {
     echo "tier filter : ${FILTER_TIER:-<all>}" >&2
     echo "package     : ${pkg_name:-<none in scope>}" >&2
     # The build logs mock leaves behind, if this died during a package build.
-    local log
+    #
+    # A bare tail is not enough. root.log ends with dnf's transaction summary,
+    # and the line that explains a buildroot failure -- the "Problem:" chain,
+    # or "nothing provides X needed by Y" -- sits hundreds of lines above it.
+    # Retrieving those hundreds of lines from CI meant downloading the whole
+    # run's log archive, which for one Hummingbird run was a multi-megabyte
+    # zip that failed to transfer twice. So grep the reasons out first and
+    # print them before the tail, where the tail is all anyone gets.
+    #
+    # WHY_FAILED_PATTERN is a local, not a file-scope global: the tests for
+    # this handler run its body under the script's own `set -u`, and a global
+    # declared further down the file reads as unbound there.
+    local log why WHY_FAILED_PATTERN
+    WHY_FAILED_PATTERN='nothing provides|but none of the providers|conflicting requests|Problem: |Failed to resolve|No match for argument|Unable to find a match|is already installed|hunk FAILED|No such file or directory|Bad exit status from|error:'
     for log in "${builddir:-/nonexistent}/results/build.log" \
                "${builddir:-/nonexistent}/results/root.log"; do
         if [[ -r "$log" ]]; then
+            why="$(grep -E "$WHY_FAILED_PATTERN" "$log" | tail -n 20)" || true
+            if [[ -n "$why" ]]; then
+                echo "--- why ${log} says it failed ---" >&2
+                printf '%s\n' "$why" >&2
+            fi
             echo "--- tail of ${log} ---" >&2
             tail -n 40 "$log" >&2 || true
         fi

--- a/tests/test_build_chain_reports_why_it_died.py
+++ b/tests/test_build_chain_reports_why_it_died.py
@@ -130,3 +130,102 @@ def test_a_failed_package_does_not_claim_the_script_died(tmp_path: Path) -> None
         f"worker failure went unreported: {proc.stderr!r}"
     )
     assert "package     : somepkg" in proc.stderr
+
+
+def test_the_reason_is_pulled_out_of_the_middle_of_root_log(tmp_path: Path) -> None:
+    """A tail of root.log is the dnf summary, not the reason.
+
+    dnf prints the "Problem:" chain when it gives up resolving, then keeps
+    going for hundreds of lines of transaction bookkeeping. `tail -n 40`
+    therefore reliably returns the part that says nothing. Getting at the real
+    line meant downloading the run's whole log archive -- which, for one
+    Hummingbird run, was a multi-megabyte zip that failed to transfer twice
+    before being abandoned.
+
+    So the handler greps the reasons out and prints them ahead of the tail.
+    """
+    builddir = tmp_path / "build"
+    (builddir / "results").mkdir(parents=True)
+    (builddir / "results" / "root.log").write_text(
+        "\n".join(
+            ["DEBUG util.py:1 preparing transaction"]
+            + ["Problem: conflicting requests"]
+            + ["  - nothing provides perl(:MODULE_COMPAT_5.42.0) needed by libfoo-1.0"]
+            # Enough bookkeeping after it to push the reason clear of any tail.
+            + [f"DEBUG util.py:{i} Installing : filler-{i}.noarch" for i in range(200)]
+        )
+    )
+
+    proc = _drive_handler(tmp_path, f"""
+        FILTER_TIER=demo
+        builddir={builddir}
+        pkg_name=libfoo
+        false
+    """)
+
+    assert proc.returncode != 0
+    assert "why" in proc.stderr and "root.log" in proc.stderr, (
+        f"no reason section emitted: {proc.stderr!r}"
+    )
+    assert "nothing provides perl(:MODULE_COMPAT_5.42.0)" in proc.stderr, (
+        "the handler printed a tail but not the line that explains the "
+        f"failure: {proc.stderr!r}"
+    )
+    assert "Problem: conflicting requests" in proc.stderr
+
+
+def test_a_tail_alone_would_have_missed_it(tmp_path: Path) -> None:
+    """Guards the premise of the test above rather than assuming it.
+
+    If the filler ever stops being long enough to push the reason out of the
+    last 40 lines, the test above would pass on a handler that only tails, and
+    silently stop testing anything.
+    """
+    builddir = tmp_path / "build"
+    (builddir / "results").mkdir(parents=True)
+    log = builddir / "results" / "root.log"
+    log.write_text(
+        "\n".join(
+            ["Problem: conflicting requests"]
+            + [f"DEBUG util.py:{i} Installing : filler-{i}.noarch" for i in range(200)]
+        )
+    )
+    tail = log.read_text().splitlines()[-40:]
+    assert not any("Problem:" in line for line in tail), (
+        "the reason is inside the last 40 lines, so this fixture no longer "
+        "distinguishes a grep from a tail"
+    )
+
+
+def test_a_log_with_no_reason_in_it_still_gets_its_tail(tmp_path: Path) -> None:
+    """grep exits 1 on no match, and it must not cost us the tail.
+
+    Note what does NOT protect this: `_on_error` runs `set +e` on its first
+    line, so `set -e` is already off by the time the grep runs. The `|| true`
+    on that line is defence for a future edit that removes the `set +e`, not
+    the thing keeping this green today -- removing it changes nothing
+    observable, so this test deliberately does not claim to pin it.
+
+    What this does pin is the shape of the output when a log holds no
+    recognised reason, which is the common case for a package that failed at
+    compile time rather than in the buildroot: the tail still appears, and no
+    empty "why" banner appears above it promising an explanation that is not
+    there.
+    """
+    builddir = tmp_path / "build"
+    (builddir / "results").mkdir(parents=True)
+    (builddir / "results" / "build.log").write_text("everything was fine here\n")
+
+    proc = _drive_handler(tmp_path, f"""
+        FILTER_TIER=demo
+        builddir={builddir}
+        false
+    """)
+    assert "build-chain.sh FAILED" in proc.stderr
+    assert "tail of" in proc.stderr, (
+        f"handler stopped short after an empty grep: {proc.stderr!r}"
+    )
+    assert "why" not in proc.stderr, (
+        "an empty reason section was printed for a log with no reason in it, "
+        f"which reads as 'the cause is nothing': {proc.stderr!r}"
+    )


### PR DESCRIPTION
Now that #377 lets `Build tiers` actually run, package failures are about to become visible again. This makes them readable when they do.

## The problem

The ERR trap tails `build.log` and `root.log` when a package dies. For a buildroot failure that is the wrong 40 lines: dnf prints its `Problem:` chain when it gives up resolving, then keeps going for hundreds of lines of transaction bookkeeping. The tail reliably returns the part that says nothing.

Reaching the real line meant downloading the run's whole log archive. For one Hummingbird run that was a multi-megabyte zip that failed to transfer twice — HTTP/2 `CANCEL`, then `transfer closed with outstanding read data` — before being abandoned, on a box with 1.2 GB free. The same information was three greps away if anything had gone looking while the log was still on the runner.

## The change

Grep the reasons out and print them above the tail:

```
nothing provides | but none of the providers | conflicting requests | Problem:
| Failed to resolve | No match for argument | Unable to find a match
| is already installed | hunk FAILED | No such file or directory
| Bad exit status from | error:
```

`WHY_FAILED_PATTERN` is a **local**, not a file-scope global, on purpose: the tests for this handler extract everything above `SCRIPT_DIR=` and run it under the script's own `set -u`, where a global declared further down the file reads as unbound — turning the diagnostic into a second failure.

## Tests

Three added to `tests/test_build_chain_reports_why_it_died.py`:

- drive the **real** handler against a `root.log` with the reason buried under 200 lines of filler, and assert `nothing provides perl(:MODULE_COMPAT_5.42.0)` reaches stderr
- assert the fixture **actually buries it** — otherwise a handler that only tailed would pass and the suite would quietly stop testing anything
- pin that a log with no recognised reason still gets its tail and does *not* get an empty `why` banner promising an explanation that isn't there

Mutation-verified:

| Mutation | Result |
| :--- | :--- |
| drop the grep, keep only the tail (the pre-fix state) | 1 failed, 8 passed |
| make `WHY_FAILED_PATTERN` a file-scope global | 2 failed, 7 passed |
| print the `why` header unconditionally | 1 failed, 8 passed |
| **drop the `\|\| true` on the grep** | **9 passed — not caught** |

That last row is deliberate and called out in the code. `_on_error` runs `set +e` on its first line, so `set -e` is already off by the time the grep runs and removing `|| true` changes nothing observable. It stays as defence for a future edit that drops the `set +e`, and the test's docstring says it does not pin it rather than implying coverage it doesn't have.

Full suite: `809 passed`.

## Correction to the record

I had been carrying the belief that this extraction landed with #308. It did not — `git log -S WHY_FAILED_PATTERN -- scripts/build-chain.sh` returns no commit. #308 landed the ERR trap and the tail; the reason-extraction was never merged. This is not a regression being restored, it is work that was never done.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->