### PR TITLE
fix(xfwl4): pin back to the last commit its vendor tree can build

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -124,11 +124,8 @@
     },
     {
       "customType": "regex",
-      "description": "xfwl4: tracks gitlab.xfce.org/xfce/xfwl4's main branch \u2014 pre-1.0 compositor, no tagged releases to pin to instead. Deliberately NOT packages/xfwl4/package.yaml, for the checksum reason on the xfconf manager plus a worse one: an `archive/` digest match is not repository-scoped, so #340 also rewrote the recipe's xfce-wayland-protocols source to xfwl4's own commit, a ref that does not exist there (that URL now 404s). The recipe's vendor.tar.gz release asset is keyed to the pinned commit as well, so bumping it is never a one-line edit (#170).",
-      "fileMatch": [
-        "^src/xfce-wayland/xfwl4/xfwl4\\.spec$",
-        "^src/xfce-wayland/xfwl4/packaging/arch/PKGBUILD$"
-      ],
+      "description": "xfwl4: DISABLED (empty fileMatch). It tracked gitlab.xfce.org/xfce/xfwl4's main branch, but an xfwl4 bump is never a one-line edit and a regex manager can only ever make it one. Three values are coupled to the pinned commit: the commit itself, the pre-vendored vendor.tar.gz release asset keyed to it (Source1, xfwl4-vendor-<sha>), and the smithay git rev that the commit's Cargo.lock pins, which the spec repeats in its cargo source override. The Fedora build runs `cargo build --offline`, so when the override and the vendor tree do not match the commit's Cargo.lock, cargo cannot resolve smithay at all. This was already the documented reason packages/xfwl4/package.yaml was excluded; the spec and PKGBUILD carry the same coupling and were left in by oversight. #366 bumped the commit to c6c0e1c, upstream had moved smithay from 0a29aecf to 4cf0b620, and XFCE Wayland (Fedora) went red on main from 2026-08-12 through #367, #368 and #376 \u2014 four green-looking one-line PRs stacked on a build that had not compiled since the first of them. Re-enable only once a bump also regenerates the vendor asset and rewrites the smithay rev.",
+      "fileMatch": [],
       "matchStrings": [
         "(?:%global commit\\s+|\\n_commit=)(?<currentDigest>[a-f0-9]{40})"
       ],

--- a/src/xfce-wayland/xfwl4/packaging/arch/PKGBUILD
+++ b/src/xfce-wayland/xfwl4/packaging/arch/PKGBUILD
@@ -10,7 +10,7 @@
 pkgname=xfwl4
 pkgver=4.21.0
 pkgrel=1
-_commit=179316f5c4332d748d199b79da36dc0027917acb
+_commit=cbcc18be01d41ea6635c6f6ddd67b825e2d7244e
 # Custom XFCE Wayland protocol XML — a git submodule, absent from the archive.
 _protocols_commit=55dbf3e3d2a91b525c528c0dd4c1a7805a99364b
 pkgdesc="Wayland compositor for Xfce4"

--- a/src/xfce-wayland/xfwl4/xfwl4.spec
+++ b/src/xfce-wayland/xfwl4/xfwl4.spec
@@ -1,4 +1,4 @@
-%global commit 179316f5c4332d748d199b79da36dc0027917acb
+%global commit cbcc18be01d41ea6635c6f6ddd67b825e2d7244e
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 # resources/xfce-wayland-protocols submodule gitlink at %{commit}. It must be
 # bumped in lockstep with it: the XML defines the interfaces, requests and

--- a/tests/test_renovate_never_bumps_a_vendored_pin.py
+++ b/tests/test_renovate_never_bumps_a_vendored_pin.py
@@ -1,0 +1,119 @@
+"""A one-line digest bump must not be possible where the pin is not one line.
+
+Some sources carry a pre-vendored dependency tree, published as a release
+asset whose name embeds the commit it was vendored from, plus a cargo source
+override repeating a git rev that the upstream commit's Cargo.lock chose.
+Bumping the commit without regenerating both leaves `cargo build --offline`
+unable to resolve the dependency at all.
+
+That is not hypothetical. renovate bumped src/xfce-wayland/xfwl4/xfwl4.spec's
+`%global commit` -- and nothing else -- four times:
+
+    9ed4f7c (#376)  179316f5   vendor 5c2802c0   smithay 0a29aecf
+    a6e8b62 (#368)  718c7c19   vendor 5c2802c0   smithay 0a29aecf
+    fddc3b9 (#366)  c6c0e1ca   vendor 5c2802c0   smithay 0a29aecf
+    7e6fe4d (#361)  cbcc18be   vendor 5c2802c0   smithay 0a29aecf   <- last green
+
+It worked while upstream still pinned smithay at 0a29aecf and stopped the
+moment upstream moved to 4cf0b620, at #366. XFCE Wayland (Fedora) was red on
+main from 2026-08-12 onward while three more one-line bumps landed on top,
+each looking like an ordinary dependency chore.
+
+renovate.json already carried this exact reasoning as the justification for
+keeping packages/xfwl4/package.yaml out of the manager. The spec and the
+PKGBUILD have the same coupling and were left in.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+RENOVATE = ROOT / "renovate.json"
+
+# A release asset whose name embeds the commit it was vendored from.
+VENDORED_ASSET = re.compile(r"releases/download/[A-Za-z0-9._-]+-vendor-[0-9a-f]{6,40}/")
+
+SEARCH_ROOTS = ("src", "packages")
+SEARCH_SUFFIXES = (".spec", ".yaml", ".yml", "PKGBUILD")
+
+
+def _managers():
+    return json.loads(RENOVATE.read_text()).get("customManagers", [])
+
+
+def _files_with_a_vendored_pin():
+    found = []
+    for root in SEARCH_ROOTS:
+        base = ROOT / root
+        if not base.is_dir():
+            continue
+        for path in base.rglob("*"):
+            if not path.is_file():
+                continue
+            if not path.name.endswith(SEARCH_SUFFIXES):
+                continue
+            try:
+                text = path.read_text(errors="ignore")
+            except OSError:
+                continue
+            if VENDORED_ASSET.search(text):
+                found.append(path.relative_to(ROOT))
+    return sorted(found)
+
+
+def test_the_repo_still_has_a_vendored_pin_to_guard():
+    """Otherwise every assertion below is vacuously true."""
+    assert _files_with_a_vendored_pin(), (
+        "no commit-keyed vendor asset found under "
+        f"{SEARCH_ROOTS}; this guard is no longer testing anything"
+    )
+
+
+def test_renovate_json_is_valid():
+    json.loads(RENOVATE.read_text())
+
+
+@pytest.mark.parametrize("path", _files_with_a_vendored_pin(), ids=str)
+def test_no_regex_manager_matches_a_file_with_a_vendored_pin(path):
+    posix = path.as_posix()
+    for manager in _managers():
+        for pattern in manager.get("fileMatch", []):
+            assert not re.search(pattern, posix), (
+                f"renovate manager {manager.get('depNameTemplate')!r} matches "
+                f"{posix}, which pins a vendored dependency tree by commit. A "
+                "regex manager can only rewrite the digest, so it will ship a "
+                "commit whose vendor asset and cargo source override still "
+                "point at the old one, and the offline build cannot resolve "
+                "the dependency. Bump this by hand, regenerating the vendor "
+                "asset and the rev, or leave the manager disabled."
+            )
+
+
+def test_the_disabled_xfwl4_manager_says_why():
+    xfwl4 = [m for m in _managers() if m.get("depNameTemplate") == "xfwl4"]
+    if not xfwl4:
+        pytest.skip("the xfwl4 manager was removed outright rather than disabled")
+    description = xfwl4[0].get("description", "")
+    assert "vendor" in description and "smithay" in description, (
+        "a disabled manager with no stated reason gets re-enabled by the next "
+        f"person who notices xfwl4 is not being updated: {description!r}"
+    )
+
+
+def test_the_spec_and_the_pkgbuild_pin_the_same_commit():
+    """They are two packagings of one source; a split is a silent skew."""
+    spec = (ROOT / "src/xfce-wayland/xfwl4/xfwl4.spec").read_text()
+    pkgbuild = (ROOT / "src/xfce-wayland/xfwl4/packaging/arch/PKGBUILD").read_text()
+
+    spec_commit = re.search(r"^%global commit ([0-9a-f]{40})", spec, re.M)
+    pkg_commit = re.search(r"^_commit=([0-9a-f]{40})", pkgbuild, re.M)
+    assert spec_commit and pkg_commit, "could not read both pinned commits"
+    assert spec_commit.group(1) == pkg_commit.group(1), (
+        f"spec pins {spec_commit.group(1)} but the Arch PKGBUILD pins "
+        f"{pkg_commit.group(1)}"
+    )


### PR DESCRIPTION
`XFCE Wayland (Fedora)` has been **red on main since 2026-08-12**.

## The failure

```
cargo build --release --offline … --features …,smithay/renderer_gl
error: failed to get `smithay` as a dependency of package `xfwl4 v4.21.1+dev`
Caused by: unable to update https://github.com/smithay/smithay?rev=4cf0b62028039661477d482ec4758b687d8f4392
Caused by: can't checkout from 'https://github.com/smithay/smithay': you are in the offline mode (--offline)
```

## Why

Three values are coupled to the pinned commit:

1. `%global commit` itself
2. the pre-vendored `vendor.tar.gz` release asset keyed to it — `Source1`, `xfwl4-vendor-<sha>`
3. the **smithay git rev** the commit's `Cargo.lock` chose, which the spec repeats in its cargo source override

A regex manager can rewrite exactly one of them. Every bump renovate made changed only `%global commit`:

| commit | `%global commit` | vendor asset | smithay rev | Fedora build |
| :--- | :--- | :--- | :--- | :--- |
| 9ed4f7c (#376) | `179316f5` | `…-5c2802c0` | `0a29aecf` | ❌ |
| a6e8b62 (#368) | `718c7c19` | `…-5c2802c0` | `0a29aecf` | ❌ |
| fddc3b9 (#366) | `c6c0e1ca` | `…-5c2802c0` | `0a29aecf` | ❌ first red |
| 7e6fe4d (#361) | `cbcc18be` | `…-5c2802c0` | `0a29aecf` | ✅ |

Harmless while upstream still pinned smithay at `0a29aecf`; fatal the moment upstream moved to `4cf0b620`, at #366. **Three more one-line bumps then landed on top of an already-broken build**, each looking like a routine dependency chore.

## The change

**Pin back to `cbcc18be`**, in the spec and the Arch PKGBUILD. That exact triple isn't a guess — [run 31554385166](https://github.com/tuna-os/tunaos-packages/actions/runs/31554385166) built it green.

Only the Fedora path was broken (makepkg builds with the network up, so the Arch side resolved smithay's git dep regardless), but both are packagings of one source and letting them skew is its own trap.

**Disable the renovate manager** rather than leave it able to repeat this. `renovate.json` already carried this reasoning — it is the stated reason `packages/xfwl4/package.yaml` is excluded:

> *"The recipe's vendor.tar.gz release asset is keyed to the pinned commit as well, so bumping it is never a one-line edit (#170)."*

The spec and PKGBUILD have the same coupling and were left in. The description now records what a real bump must do, so the next person who notices xfwl4 isn't updating re-enables it deliberately.

## Tests

`tests/test_renovate_never_bumps_a_vendored_pin.py` generalises the rule: **any** file under `src/` or `packages/` referencing a commit-keyed vendor asset must not be matched by a renovate regex manager. It also asserts such a file still exists (so the guard fails loudly instead of passing vacuously), that the disabled manager states its reason, and that the spec and PKGBUILD pin the same commit.

| Mutation | Result |
| :--- | :--- |
| re-enable the manager for the spec | 1 failed, 5 passed |
| strip the reason from the description | 1 failed, 5 passed |
| let the spec and PKGBUILD drift apart | 1 failed, 5 passed |

Full suite: `812 passed`.

## What this does not do

It does **not** update xfwl4 to current main. That needs a vendor tree regenerated at the new commit and the smithay rev rewritten to match — real work, not a digest edit, and better done deliberately than by a bot. Filing that as follow-up is the right call if tracking upstream head matters here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->