### PR TITLE
fix(hummingbird): exclude golang1.26 to stop it colliding with Rawhide's golang

### DIFF
--- a/mock/hummingbird-ci.cfg
+++ b/mock/hummingbird-ci.cfg
@@ -92,6 +92,40 @@
 # Remove this pin when Hummingbird's own perl reaches Rawhide's, and the
 # python half when its own python3 does.  They move independently.
 #
+# GOLANG.  Not a version split like the two above -- a NAME split, and it
+# hangs the job rather than failing it cleanly.  From run 31697678706 (the
+# first run #377's cache-key fix let reach `Build tiers` at all), every one
+# of the five desktop jobs died the same way inside swig's own dnf5 builddep
+# transaction:
+#
+#     Transaction failed: Rpm transaction failed.
+#      - file /usr/lib/golang/src/... conflicts between attempted installs
+#        of golang-src-1.27~rc2-2.fc45.noarch and
+#        golang1.26-src-1.26.5-0.1.1.hum1.noarch
+#
+# swig's spec (imported live from Rawhide) BuildRequires plain `golang` for
+# its optional Go bindings. Hummingbird does not publish a package literally
+# named `golang` -- only `golang1.26`/-bin/-src -- so the priority filter
+# that protects perl/python (it drops a NAME entirely from the losing repo)
+# never engages: `golang` and `golang1.26` are two different names, and both
+# install candidates satisfy the transaction until dnf commits the file
+# layout conflict above. Nothing in this repo's own build closure asks for
+# `golang1.26` by name (grepped every package.yaml and .spec here; the five
+# Go-targeting recipes -- dankcalendar, dgop, danksearch, dms-cli, uupd --
+# don't even build for hummingbird/kde), so its presence in this transaction
+# looks incidental, not a real dependency.
+#
+# Unlike perl/python, this is safe to resolve by exclusion rather than by
+# adding another pinned Fedora release: Go produces static binaries with no
+# runtime library to version-match, so a BuildRequires: golang built against
+# Rawhide's 1.27~rc2 carries no soname coupling to Hummingbird's own 1.26
+# runtime the way libperl.so/python(abi) do. Excluding golang1.26* from the
+# hummingbird repo leaves every `golang` BuildRequires resolving from
+# Rawhide only -- which is what swig was already getting for the winning
+# half of the conflict anyway.
+#
+# tests/test_hummingbird_golang_name_split.py guards this.
+#
 # Repository priority (lower wins in dnf):
 #   1  local-build      RPMs produced by earlier tiers of this same run
 #   10 hummingbird      the target's own signed RPMs — the ABI we must match
@@ -130,6 +164,7 @@ baseurl=https://packages.redhat.com/api/pulp-content/public-hummingbird/$basearc
 gpgcheck=0
 enabled=1
 priority=10
+excludepkgs=golang1.26*
 
 [fedora-44-python]
 name=Fedora 44 - Python 3.14 build inputs only

--- a/tests/test_hummingbird_golang_name_split.py
+++ b/tests/test_hummingbird_golang_name_split.py
@@ -1,0 +1,100 @@
+"""Hummingbird publishes golang1.26/-bin/-src, never a plain `golang`.
+
+This is not the python(abi)/perl MODULE_COMPAT version split -- it's a NAME
+split, and it doesn't fail the transaction cleanly, it hangs the job. Every
+one of run 31697678706's five desktop jobs died inside swig's own dnf5
+builddep transaction:
+
+    Transaction failed: Rpm transaction failed.
+     - file /usr/lib/golang/src/... conflicts between attempted installs of
+       golang-src-1.27~rc2-2.fc45.noarch and
+       golang1.26-src-1.26.5-0.1.1.hum1.noarch
+
+swig BuildRequires plain `golang`. Hummingbird has no package by that exact
+name, so dnf's priority filter -- which drops a NAME entirely from the
+losing repo, the mechanism the perl/python pins rely on -- never engages:
+`golang` and `golang1.26` are different names, both install, and only their
+file layout collides. Nothing in this repo's own build closure needs
+golang1.26 by name (the Go-targeting recipes don't even build for
+hummingbird/kde), so excluding it from the hummingbird repo is safe: unlike
+perl/python, Go produces static binaries with no runtime soname to
+version-match, so every `golang` BuildRequires can resolve from Rawhide
+alone without an ABI mismatch.
+"""
+
+from __future__ import annotations
+
+import configparser
+import io
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+CFG = ROOT / "mock" / "hummingbird-ci.cfg"
+
+
+@pytest.fixture(scope="module")
+def conf() -> configparser.ConfigParser:
+    text = CFG.read_text()
+    blocks = re.findall(r'config_opts\[.dnf\.conf.\]\s*\+=\s*"""(.*?)"""', text, re.S)
+    assert blocks, "hummingbird-ci.cfg appends no dnf.conf repositories"
+    parser = configparser.ConfigParser(strict=False)
+    parser.read_file(io.StringIO("\n".join(blocks)))
+    return parser
+
+
+def test_golang1_26_is_excluded_from_the_hummingbird_repo(conf) -> None:
+    excludes = [
+        g.strip()
+        for g in conf.get("hummingbird", "excludepkgs", fallback="").split(",")
+        if g.strip()
+    ]
+    assert excludes, (
+        "hummingbird repo has no excludepkgs, so golang1.26* is still an "
+        "install candidate alongside Rawhide's golang -- the exact file "
+        "conflict that hung run 31697678706"
+    )
+    assert any(g.startswith("golang1.26") for g in excludes), (
+        "excludepkgs does not cover golang1.26 -- the transaction can still "
+        "select both golang-src (Rawhide) and golang1.26-src (hummingbird)"
+    )
+
+
+def test_the_exclusion_is_confined_to_golang1_26(conf) -> None:
+    """This must not become a blanket exclude that also drops a future
+    plain `golang` package Hummingbird might start publishing."""
+    excludes = [g.strip() for g in conf.get("hummingbird", "excludepkgs").split(",") if g.strip()]
+    assert "*" not in excludes, "hummingbird excludepkgs is unrestricted"
+    for glob in excludes:
+        assert glob.startswith("golang1.26"), (
+            f"hummingbird excludepkgs carries {glob!r}, which is outside the "
+            "golang1.26 name-split this exclusion exists for"
+        )
+
+
+def test_hummingbird_still_wins_every_other_package(conf) -> None:
+    """The exclusion is scoped to one name family -- it must not lower
+    hummingbird's priority or otherwise weaken its claim on everything
+    else it ships."""
+    assert conf.getint("hummingbird", "priority") == 10, (
+        "hummingbird's priority moved; the golang1.26 fix should only add "
+        "excludepkgs, not touch priority"
+    )
+
+
+def test_the_reason_travels_with_the_config() -> None:
+    """A silent exclude with no citation looks like a typo to the next
+    person who reads this file, and invites being 'cleaned up'."""
+    text = CFG.read_text()
+    assert "31697678706" in text, "the config does not cite the run that surfaced this"
+    assert "golang1.26" in text and "golang-src" in text, (
+        "the config does not name both sides of the conflicting install"
+    )
+    assert "static binaries" in text or "no runtime library" in text, (
+        "the config does not record WHY excluding golang1.26 is safe -- "
+        "that Go binaries carry no soname coupling to the toolchain "
+        "version, unlike perl/python -- which is the load-bearing fact "
+        "that distinguishes this from the perl/python pins"
+    )


### PR DESCRIPTION
## Summary

- Run 31697678706 — the first run #377's cache-key fix let reach `Build tiers` at all — hung all five desktop jobs (gnome/kde/cosmic/niri/xfce) inside swig's own `dnf5 builddep` transaction:
  ```
  Transaction failed: Rpm transaction failed.
   - file /usr/lib/golang/src/... conflicts between attempted installs of
     golang-src-1.27~rc2-2.fc45.noarch and
     golang1.26-src-1.26.5-0.1.1.hum1.noarch
  ```
  swig BuildRequires plain `golang`. Hummingbird has no package by that exact name, only `golang1.26`/-bin/-src, so the priority filter that already protects the perl/python pins in this same file (it drops a package NAME entirely from the losing repo) never engages here — `golang` and `golang1.26` are different names, both install candidates, and only their file layout collides. The job didn't fail cleanly on this either: no further log output for over an hour while GitHub still reported it `in_progress`.
- Nothing in this repo's own build closure needs `golang1.26` by name — the five Go-targeting recipes (dankcalendar, dgop, danksearch, dms-cli, uupd) don't even build for hummingbird/kde — so its presence in this transaction looks incidental rather than a real dependency.
- Excludes `golang1.26*` from the `[hummingbird]` repo section (same `includepkgs`/`excludepkgs` scoping mechanism already used for the python3/perl namespace pins). Unlike those pins, this is safe to resolve by exclusion instead of adding another pinned Fedora release: Go produces static binaries with no runtime soname to version-match, so every `golang` BuildRequires can resolve from Rawhide alone without an ABI mismatch.

## Test plan

- [x] `tests/test_hummingbird_golang_name_split.py` (new) pins that `golang1.26*` is excluded from the hummingbird repo, that the exclusion is confined to that name (not a blanket exclude), that hummingbird's repo priority is untouched, and that the config records why.
- [x] Mutation-verified: removing the `excludepkgs` line fails 2 of the 4 new tests.
- [x] `python3 -m pytest tests/test_hummingbird_golang_name_split.py tests/test_hummingbird_perl_abi_pin.py tests/test_hummingbird_python_abi_pin.py -q` → 16 passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/tuna-os/codesmith/tunaos-packages/pr/381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->