### PR TITLE
security: stop world-readable R2 secrets in rclone.conf

### DIFF
--- a/.github/workflows/build-distributed.yml
+++ b/.github/workflows/build-distributed.yml
@@ -23,6 +23,8 @@ jobs:
 
           mkdir -p ~/.config/rclone
 
+          umask 077
+
           cat > ~/.config/rclone/rclone.conf << EOF
 
           [r2]
@@ -31,15 +33,19 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          endpoint = https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com
 
           EOF
 
           '
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - name: Seed local repo from R2
         run: 'mkdir -p local-repo
 
@@ -1371,6 +1377,8 @@ jobs:
       - name: Configure rclone
         run: 'mkdir -p ~/.config/rclone
 
+          umask 077
+
           cat > ~/.config/rclone/rclone.conf << EOF
 
           [r2]
@@ -1379,23 +1387,21 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          endpoint = https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com
 
           EOF
 
           '
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - name: Refuse to publish an empty result
-        run: 'RPM_COUNT=$(find local-repo -name "*.rpm" ! -name "*.src.rpm" | wc -l)
-
-          echo "RPMs in local-repo: ${RPM_COUNT}"
-
-          if [ "${RPM_COUNT}" -eq 0 ]; then echo "::error::0 RPMs in local-repo — refusing to sync. rclone sync makes the destination match its source EXACTLY, so this would DELETE the published repo rather than fail to update it. See INCIDENT-repo-wipe-gnome.md."; exit 1; fi
-
-          '
+        run: "RPM_COUNT=$(find local-repo -name \"*.rpm\" ! -name \"*.src.rpm\" | wc -l)\necho \"RPMs in local-repo: ${RPM_COUNT}\"\nif [ \"${RPM_COUNT}\" -eq 0 ]; then echo \"::error::0 RPMs in local-repo \u2014 refusing to sync. rclone sync makes the destination match its source EXACTLY, so this would DELETE the published repo rather than fail to update it. See INCIDENT-repo-wipe-gnome.md.\"; exit 1; fi\n"
       - name: Upload to R2
         run: 'echo "Uploading to 10-stream-x86_64..."
 

--- a/.github/workflows/build-fprintd-aarch64.yml
+++ b/.github/workflows/build-fprintd-aarch64.yml
@@ -67,6 +67,7 @@ jobs:
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: |
           mkdir -p ~/.config/rclone
+          umask 077
           cat > ~/.config/rclone/rclone.conf << EOF
           [r2]
           type = s3

--- a/.github/workflows/build-gnome49-distributed.yml
+++ b/.github/workflows/build-gnome49-distributed.yml
@@ -23,6 +23,8 @@ jobs:
 
           mkdir -p ~/.config/rclone
 
+          umask 077
+
           cat > ~/.config/rclone/rclone.conf << EOF
 
           [r2]
@@ -31,15 +33,19 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          endpoint = https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com
 
           EOF
 
           '
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - name: Seed local repo from R2
         run: 'mkdir -p local-repo
 
@@ -1004,6 +1010,8 @@ jobs:
       - name: Configure rclone
         run: 'mkdir -p ~/.config/rclone
 
+          umask 077
+
           cat > ~/.config/rclone/rclone.conf << EOF
 
           [r2]
@@ -1012,15 +1020,19 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          endpoint = https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com
 
           EOF
 
           '
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - name: Upload to R2
         run: 'echo "Uploading to 10-stream-x86_64..."
 

--- a/.github/workflows/build-gnome49-package.yml
+++ b/.github/workflows/build-gnome49-package.yml
@@ -110,15 +110,20 @@ jobs:
           podman pull ${{ env.MOCK_RUNNER_IMAGE }}
 
       - name: Configure rclone
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           mkdir -p ~/.config/rclone
+          umask 077
           cat > ~/.config/rclone/rclone.conf << EOF
           [r2]
           type = s3
           provider = Cloudflare
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          endpoint = https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          access_key_id = ${R2_ACCESS_KEY_ID}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
+          endpoint = https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com
           EOF
 
       # copy, not sync: this direction must never delete local files, and the

--- a/.github/workflows/build-gnome50-distributed.yml
+++ b/.github/workflows/build-gnome50-distributed.yml
@@ -23,6 +23,8 @@ jobs:
 
           mkdir -p ~/.config/rclone
 
+          umask 077
+
           cat > ~/.config/rclone/rclone.conf << EOF
 
           [r2]
@@ -31,15 +33,19 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          endpoint = https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com
 
           EOF
 
           '
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - name: Seed local repo from R2
         run: 'mkdir -p local-repo
 
@@ -1511,6 +1517,8 @@ jobs:
       - name: Configure rclone
         run: 'mkdir -p ~/.config/rclone
 
+          umask 077
+
           cat > ~/.config/rclone/rclone.conf << EOF
 
           [r2]
@@ -1519,15 +1527,19 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          endpoint = https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com
 
           EOF
 
           '
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - name: Upload to R2
         run: 'echo "Uploading to 10-stream-x86_64..."
 

--- a/.github/workflows/build-gnome50-package.yml
+++ b/.github/workflows/build-gnome50-package.yml
@@ -107,15 +107,20 @@ jobs:
           podman pull ${{ env.MOCK_RUNNER_IMAGE }}
 
       - name: Configure rclone
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           mkdir -p ~/.config/rclone
+          umask 077
           cat > ~/.config/rclone/rclone.conf << EOF
           [r2]
           type = s3
           provider = Cloudflare
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          endpoint = https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          access_key_id = ${R2_ACCESS_KEY_ID}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
+          endpoint = https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com
           EOF
 
       # copy, not sync: this direction must never delete local files, and the

--- a/.github/workflows/build-gnome51-distributed.yml
+++ b/.github/workflows/build-gnome51-distributed.yml
@@ -21,7 +21,13 @@ jobs:
 
           sudo apt-get install -y -q createrepo-c rclone'
       - name: Configure rclone
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -31,11 +37,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          endpoint = https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com
 
           EOF
 
@@ -1677,7 +1683,13 @@ jobs:
 
           '
       - name: Configure rclone
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -1687,11 +1699,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          endpoint = https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com
 
           EOF
 

--- a/.github/workflows/build-gnome51-package.yml
+++ b/.github/workflows/build-gnome51-package.yml
@@ -143,6 +143,7 @@ jobs:
             exit 1
           fi
           mkdir -p ~/.config/rclone
+          umask 077
           cat > ~/.config/rclone/rclone.conf << EOF
           [r2]
           type = s3

--- a/.github/workflows/build-hummingbird-desktops.yml
+++ b/.github/workflows/build-hummingbird-desktops.yml
@@ -160,6 +160,7 @@ jobs:
         run: |
           curl -fsSL https://rclone.org/install.sh | sudo bash
           mkdir -p ~/.config/rclone
+          umask 077
           cat > ~/.config/rclone/rclone.conf <<EOF
           [r2]
           type = s3

--- a/.github/workflows/build-hummingbird-distributed.yml
+++ b/.github/workflows/build-hummingbird-distributed.yml
@@ -21,7 +21,13 @@ jobs:
 
           sudo apt-get install -y -q createrepo-c rclone'
       - name: Configure rclone
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -31,11 +37,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -75,7 +81,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -85,11 +97,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -147,7 +159,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -157,11 +175,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -195,7 +213,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -205,11 +229,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -267,7 +291,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -277,11 +307,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -312,7 +342,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -322,11 +358,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -384,7 +420,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -394,11 +436,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -430,7 +472,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -440,11 +488,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -502,7 +550,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -512,11 +566,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -753,7 +807,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -763,11 +823,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -825,7 +885,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -835,11 +901,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -948,7 +1014,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -958,11 +1030,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -1020,7 +1092,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -1030,11 +1108,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -1087,7 +1165,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -1097,11 +1181,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -1159,7 +1243,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -1169,11 +1259,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -1211,7 +1301,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -1221,11 +1317,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -1283,7 +1379,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -1293,11 +1395,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -1344,7 +1446,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -1354,11 +1462,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -1416,7 +1524,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -1426,11 +1540,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -1542,7 +1656,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -1552,11 +1672,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -1614,7 +1734,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -1624,11 +1750,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -1696,7 +1822,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -1706,11 +1838,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -1768,7 +1900,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -1778,11 +1916,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -1841,7 +1979,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -1851,11 +1995,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -1913,7 +2057,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -1923,11 +2073,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -1977,7 +2127,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -1987,11 +2143,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -2049,7 +2205,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -2059,11 +2221,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -2117,7 +2279,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -2127,11 +2295,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -2189,7 +2357,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -2199,11 +2373,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -2246,7 +2420,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -2256,11 +2436,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -2318,7 +2498,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -2328,11 +2514,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -2400,7 +2586,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -2410,11 +2602,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -2472,7 +2664,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -2482,11 +2680,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -2546,7 +2744,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -2556,11 +2760,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -2618,7 +2822,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -2628,11 +2838,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -2666,7 +2876,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -2676,11 +2892,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -2738,7 +2954,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -2748,11 +2970,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -2797,7 +3019,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -2807,11 +3035,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -2869,7 +3097,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -2879,11 +3113,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -3163,7 +3397,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -3173,11 +3413,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -3242,7 +3482,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -3252,11 +3498,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -3316,7 +3562,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -3326,11 +3578,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -3502,7 +3754,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -3512,11 +3770,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -3574,7 +3832,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -3584,11 +3848,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -3692,7 +3956,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -3702,11 +3972,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -3764,7 +4034,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -3774,11 +4050,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -3837,7 +4113,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -3847,11 +4129,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -3909,7 +4191,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -3919,11 +4207,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -3979,7 +4267,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -3989,11 +4283,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -4051,7 +4345,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -4061,11 +4361,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -4101,7 +4401,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -4111,11 +4417,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -4173,7 +4479,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -4183,11 +4495,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -4219,7 +4531,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -4229,11 +4547,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -4291,7 +4609,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -4301,11 +4625,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -4342,7 +4666,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -4352,11 +4682,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -4414,7 +4744,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -4424,11 +4760,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -4471,7 +4807,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -4481,11 +4823,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -4543,7 +4885,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -4553,11 +4901,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -4593,7 +4941,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -4603,11 +4957,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -4665,7 +5019,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -4675,11 +5035,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -4714,7 +5074,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -4724,11 +5090,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -4786,7 +5152,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -4796,11 +5168,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -4836,7 +5208,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -4846,11 +5224,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -4908,7 +5286,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -4918,11 +5302,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -4953,7 +5337,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -4963,11 +5353,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -5025,7 +5415,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -5035,11 +5431,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -5070,7 +5466,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -5080,11 +5482,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -5142,7 +5544,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -5152,11 +5560,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -5198,7 +5606,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -5208,11 +5622,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -5270,7 +5684,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -5280,11 +5700,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -5324,7 +5744,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -5334,11 +5760,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -5396,7 +5822,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -5406,11 +5838,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -5450,7 +5882,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -5460,11 +5898,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -5522,7 +5960,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -5532,11 +5976,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -5570,7 +6014,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -5580,11 +6030,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -5642,7 +6092,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -5652,11 +6108,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -5687,7 +6143,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -5697,11 +6159,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -5759,7 +6221,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -5769,11 +6237,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -5804,7 +6272,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -5814,11 +6288,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -5876,7 +6350,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -5886,11 +6366,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -5924,7 +6404,13 @@ jobs:
       - name: Load or pull image
         run: "if [[ -f /tmp/cs10-image.tar ]]; then\n  podman load -i /tmp/cs10-image.tar\nelse\n  podman pull quay.io/centos/centos:stream10\n  podman save -o /tmp/cs10-image.tar quay.io/centos/centos:stream10\nfi\npodman pull ${{ env.MOCK_RUNNER_IMAGE }}\n"
       - name: Seed local repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -5934,11 +6420,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -5996,7 +6482,13 @@ jobs:
           path: local-repo
           merge-multiple: true
       - name: Publish this tier to R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -6006,11 +6498,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -6029,7 +6521,13 @@ jobs:
 
           sudo apt-get install -y -q rpm createrepo-c gpg gpgconf rclone'
       - name: Seed final repo from R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -6039,11 +6537,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 
@@ -6075,7 +6573,13 @@ jobs:
 
           '
       - name: Configure rclone
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: 'mkdir -p ~/.config/rclone
+
+          umask 077
 
           cat > ~/.config/rclone/rclone.conf << EOF
 
@@ -6085,11 +6589,11 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = ${{ secrets.R2_ENDPOINT }}
+          endpoint = ${R2_ENDPOINT}
 
           EOF
 

--- a/.github/workflows/build-xfce-distributed.yml
+++ b/.github/workflows/build-xfce-distributed.yml
@@ -23,6 +23,8 @@ jobs:
 
           mkdir -p ~/.config/rclone
 
+          umask 077
+
           cat > ~/.config/rclone/rclone.conf << EOF
 
           [r2]
@@ -31,15 +33,19 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          endpoint = https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com
 
           EOF
 
           '
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - name: Seed local repo from R2
         run: 'mkdir -p local-repo
 
@@ -1031,6 +1037,8 @@ jobs:
       - name: Configure rclone
         run: 'mkdir -p ~/.config/rclone
 
+          umask 077
+
           cat > ~/.config/rclone/rclone.conf << EOF
 
           [r2]
@@ -1039,15 +1047,19 @@ jobs:
 
           provider = Cloudflare
 
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
+          access_key_id = ${R2_ACCESS_KEY_ID}
 
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
 
-          endpoint = https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          endpoint = https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com
 
           EOF
 
           '
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       - name: Upload to R2
         run: 'echo "Uploading to 10-stream-x86_64..."
 

--- a/.github/workflows/build-xfce-fedora.yml
+++ b/.github/workflows/build-xfce-fedora.yml
@@ -82,6 +82,7 @@ jobs:
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: |
           mkdir -p ~/.config/rclone
+          umask 077
           cat > ~/.config/rclone/rclone.conf << EOF
           [r2]
           type = s3

--- a/.github/workflows/build-xfce-package.yml
+++ b/.github/workflows/build-xfce-package.yml
@@ -111,6 +111,7 @@ jobs:
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: |
           mkdir -p ~/.config/rclone
+          umask 077
           cat > ~/.config/rclone/rclone.conf << EOF
           [r2]
           type = s3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,15 +78,20 @@ jobs:
           echo "%__gpg_sign_cmd %{__gpg} gpg --batch --no-verbose --no-armor --use-agent --no-secmem-warning -u \"%{_gpg_name}\" -sbo %{__signature_filename} %{__plaintext_filename}" >> ~/.rpmmacros
 
       - name: Configure rclone for R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           mkdir -p ~/.config/rclone
+          umask 077
           cat > ~/.config/rclone/rclone.conf << EOF
           [r2]
           type = s3
           provider = Cloudflare
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          endpoint = https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          access_key_id = ${R2_ACCESS_KEY_ID}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
+          endpoint = https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com
           EOF
 
       - name: Pull mock runner image

--- a/.github/workflows/publish-tideforge-debs.yml
+++ b/.github/workflows/publish-tideforge-debs.yml
@@ -141,6 +141,7 @@ jobs:
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
         run: |
           mkdir -p ~/.config/rclone
+          umask 077
           cat > ~/.config/rclone/rclone.conf << EOF
           [r2]
           type = s3

--- a/.github/workflows/r2-inventory.yml
+++ b/.github/workflows/r2-inventory.yml
@@ -31,15 +31,20 @@ jobs:
         run: curl -fsSL https://rclone.org/install.sh | sudo bash
 
       - name: Configure rclone
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           mkdir -p ~/.config/rclone
+          umask 077
           cat > ~/.config/rclone/rclone.conf << EOF
           [r2]
           type = s3
           provider = Cloudflare
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          endpoint = https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          access_key_id = ${R2_ACCESS_KEY_ID}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
+          endpoint = https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com
           EOF
 
       - name: List buckets

--- a/.github/workflows/refresh-gnome50-r2.yml
+++ b/.github/workflows/refresh-gnome50-r2.yml
@@ -11,15 +11,20 @@ jobs:
         run: curl -fsSL https://rclone.org/install.sh | sudo bash
 
       - name: Configure rclone for R2
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           mkdir -p ~/.config/rclone
+          umask 077
           cat > ~/.config/rclone/rclone.conf << EOF
           [r2]
           type = s3
           provider = Cloudflare
-          access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}
-          secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          endpoint = https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          access_key_id = ${R2_ACCESS_KEY_ID}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
+          endpoint = https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com
           EOF
 
       - name: Download live COPR repo contents

--- a/scripts/generate-distributed-workflow.py
+++ b/scripts/generate-distributed-workflow.py
@@ -25,6 +25,26 @@ MAX_MATRIX_JOBS = 250
 RCLONE_FLAGS = "--transfers 32 --checkers 64 --fast-list --stats 30s --stats-one-line"
 
 
+def _rclone_env(r2_state):
+    """The env: block every rclone-configuring step needs (tunaos-packages#353).
+
+    Secrets get interpolated into the run script text by the Actions runner
+    before the shell ever sees it -- ${{ secrets.X }} inline in a heredoc
+    means the raw value sits in the compiled script (and workflow logs, if
+    debug logging is on). Passing them as env: keeps the value out of the
+    script text; the shell only ever sees an env-var reference.
+    """
+    env = {
+        'R2_ACCESS_KEY_ID': '${{ secrets.R2_ACCESS_KEY_ID }}',
+        'R2_SECRET_ACCESS_KEY': '${{ secrets.R2_SECRET_ACCESS_KEY }}',
+    }
+    if r2_state:
+        env['R2_ENDPOINT'] = '${{ secrets.R2_ENDPOINT }}'
+    else:
+        env['CLOUDFLARE_ACCOUNT_ID'] = '${{ secrets.CLOUDFLARE_ACCOUNT_ID }}'
+    return env
+
+
 def _rclone_conf(r2_state):
     """One rclone endpoint for the whole workflow.
 
@@ -34,13 +54,17 @@ def _rclone_conf(r2_state):
     unrelated to the change that introduced it. --r2-state makes every job
     use R2_ENDPOINT, which is the secret the existing Hummingbird workflow
     has been publishing with.
+
+    Secrets arrive via env: (_rclone_env, added by every caller) rather than
+    inlined here, and umask 077 keeps the written config from being
+    world-readable for the rest of the job (tunaos-packages#353).
     """
-    endpoint = ('${{ secrets.R2_ENDPOINT }}' if r2_state
-                else 'https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com')
-    return ('mkdir -p ~/.config/rclone\ncat > ~/.config/rclone/rclone.conf << EOF\n'
+    endpoint = ('${R2_ENDPOINT}' if r2_state
+                else 'https://${CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com')
+    return ('mkdir -p ~/.config/rclone\numask 077\ncat > ~/.config/rclone/rclone.conf << EOF\n'
             '[r2]\ntype = s3\nprovider = Cloudflare\n'
-            'access_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}\n'
-            'secret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}\n'
+            'access_key_id = ${R2_ACCESS_KEY_ID}\n'
+            'secret_access_key = ${R2_SECRET_ACCESS_KEY}\n'
             f'endpoint = {endpoint}\nEOF\n')
 
 
@@ -88,7 +112,7 @@ def generate_workflow(manifest_path, output_path, workflow_name='Distributed Bui
         'steps': [
             {'name': 'Checkout', 'uses': 'actions/checkout@v7'},
             {'name': 'Install dependencies', 'run': 'sudo apt-get update -q || sudo apt-get update -q || true\nsudo apt-get install -y -q createrepo-c rclone'},
-            {'name': 'Configure rclone', 'run': _rclone_conf(r2_state)},
+            {'name': 'Configure rclone', 'env': _rclone_env(r2_state), 'run': _rclone_conf(r2_state)},
             {'name': 'Seed local repo from R2', 'run': f'mkdir -p local-repo\necho "Downloading existing repo from R2..."\nrclone sync "r2:${{R2_BUCKET}}/{r2_path}/" "local-repo/" --exclude "repodata/**" {RCLONE_FLAGS} || true\ncreaterepo_c local-repo\n'},
             # With R2 as the shared state this job exists to guarantee the
             # repository has valid metadata before any runner seeds from it;
@@ -162,7 +186,7 @@ def generate_workflow(manifest_path, output_path, workflow_name='Distributed Bui
                         # Correctness is unchanged because the barrier is unchanged:
                         # a tier's runners start only after the previous tier's
                         # consolidate job has published to R2.
-                        {'name': 'Seed local repo from R2', 'run': ('mkdir -p ~/.config/rclone\ncat > ~/.config/rclone/rclone.conf << EOF\n[r2]\ntype = s3\nprovider = Cloudflare\naccess_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}\nsecret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}\nendpoint = ${{ secrets.R2_ENDPOINT }}\nEOF\nmkdir -p local-repo\nrclone copy "r2:${R2_BUCKET}/%s/" local-repo/ ' + RCLONE_FLAGS + ' || true\ncreaterepo_c local-repo\n') % r2_path},
+                        {'name': 'Seed local repo from R2', 'env': _rclone_env(r2_state), 'run': ('mkdir -p ~/.config/rclone\numask 077\ncat > ~/.config/rclone/rclone.conf << EOF\n[r2]\ntype = s3\nprovider = Cloudflare\naccess_key_id = ${R2_ACCESS_KEY_ID}\nsecret_access_key = ${R2_SECRET_ACCESS_KEY}\nendpoint = ${R2_ENDPOINT}\nEOF\nmkdir -p local-repo\nrclone copy "r2:${R2_BUCKET}/%s/" local-repo/ ' + RCLONE_FLAGS + ' || true\ncreaterepo_c local-repo\n') % r2_path},
                     ] if r2_state else [
                         {'name': 'Download previous repo', 'uses': 'actions/download-artifact@v8', 'with': {'name': prev_tier_repo, 'path': 'local-repo'}},
                     ]),
@@ -242,7 +266,7 @@ def generate_workflow(manifest_path, output_path, workflow_name='Distributed Bui
                 *([
                     # copy, not sync: this tier adds to what earlier tiers
                     # published and must never delete it.
-                    {'name': 'Publish this tier to R2', 'run': ('mkdir -p ~/.config/rclone\ncat > ~/.config/rclone/rclone.conf << EOF\n[r2]\ntype = s3\nprovider = Cloudflare\naccess_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}\nsecret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}\nendpoint = ${{ secrets.R2_ENDPOINT }}\nEOF\nrclone copy local-repo/ "r2:${R2_BUCKET}/%s/" ' + RCLONE_FLAGS + '\n') % r2_path},
+                    {'name': 'Publish this tier to R2', 'env': _rclone_env(r2_state), 'run': ('mkdir -p ~/.config/rclone\numask 077\ncat > ~/.config/rclone/rclone.conf << EOF\n[r2]\ntype = s3\nprovider = Cloudflare\naccess_key_id = ${R2_ACCESS_KEY_ID}\nsecret_access_key = ${R2_SECRET_ACCESS_KEY}\nendpoint = ${R2_ENDPOINT}\nEOF\nrclone copy local-repo/ "r2:${R2_BUCKET}/%s/" ' + RCLONE_FLAGS + '\n') % r2_path},
                 ] if r2_state else [
                     {'name': 'Update repo', 'run': 'createrepo_c --update local-repo'},
                     {'name': 'Upload updated repo', 'uses': 'actions/upload-artifact@v7', 'with': {'name': repo_artifact_name, 'path': 'local-repo', 'retention-days': 1}},
@@ -263,14 +287,14 @@ def generate_workflow(manifest_path, output_path, workflow_name='Distributed Bui
             {'name': 'Checkout', 'uses': 'actions/checkout@v7'},
             {'name': 'Install dependencies', 'run': 'sudo apt-get update -q || sudo apt-get update -q || true\nsudo apt-get install -y -q rpm createrepo-c gpg gpgconf rclone'},
             *([
-                {'name': 'Seed final repo from R2', 'run': ('mkdir -p ~/.config/rclone\ncat > ~/.config/rclone/rclone.conf << EOF\n[r2]\ntype = s3\nprovider = Cloudflare\naccess_key_id = ${{ secrets.R2_ACCESS_KEY_ID }}\nsecret_access_key = ${{ secrets.R2_SECRET_ACCESS_KEY }}\nendpoint = ${{ secrets.R2_ENDPOINT }}\nEOF\nmkdir -p local-repo\nrclone copy "r2:${R2_BUCKET}/%s/" local-repo/ ' + RCLONE_FLAGS + '\n') % r2_path},
+                {'name': 'Seed final repo from R2', 'env': _rclone_env(r2_state), 'run': ('mkdir -p ~/.config/rclone\numask 077\ncat > ~/.config/rclone/rclone.conf << EOF\n[r2]\ntype = s3\nprovider = Cloudflare\naccess_key_id = ${R2_ACCESS_KEY_ID}\nsecret_access_key = ${R2_SECRET_ACCESS_KEY}\nendpoint = ${R2_ENDPOINT}\nEOF\nmkdir -p local-repo\nrclone copy "r2:${R2_BUCKET}/%s/" local-repo/ ' + RCLONE_FLAGS + '\n') % r2_path},
             ] if r2_state else [
                 {'name': 'Download final repo', 'uses': 'actions/download-artifact@v8', 'with': {'name': prev_tier_repo, 'path': 'local-repo'}},
             ]),
             {'name': 'Import GPG key', 'id': 'import-gpg', 'uses': 'crazy-max/ghaction-import-gpg@v7', 'with': {'gpg_private_key': '${{ secrets.GPG_PRIVATE_KEY }}', 'passphrase': '${{ secrets.GPG_PASSPHRASE }}', 'git_committer_name': 'RPM Builder', 'git_committer_email': 'rpm-signing@tunaos.org'}},
             {'name': 'Configure RPM macros', 'run': 'echo "%_signature gpg" > ~/.rpmmacros\necho "%_gpg_name ${{ steps.import-gpg.outputs.keyid }}" >> ~/.rpmmacros\necho "%__gpg_sign_cmd %{__gpg} gpg --batch --no-verbose --no-armor --use-agent --no-secmem-warning -u \\"%{_gpg_name}\\" -sbo %{__signature_filename} %{__plaintext_filename}" >> ~/.rpmmacros\n'},
             {'name': 'Sign RPMs', 'run': 'find local-repo -name "*.rpm" -exec rpmsign --addsign {} \\;\ncreaterepo_c --update local-repo\n'},
-            {'name': 'Configure rclone', 'run': _rclone_conf(r2_state)},
+            {'name': 'Configure rclone', 'env': _rclone_env(r2_state), 'run': _rclone_conf(r2_state)},
             {'name': 'Upload to R2', 'run': _build_upload_run(r2_path, secondary_r2_path, install_script, install_r2_dest)}
         ]
     }


### PR DESCRIPTION
Fixes #353.

## Scope correction

Grepped the whole tree rather than trusting the issue's file list — found **17** affected files, not the 11 named. 6 more either existed already or grew more occurrences since the finding was filed.

## Two of the 6 generated `-distributed.yml` files: fixed the generator

`build-gnome51-distributed.yml` and `build-hummingbird-distributed.yml` are produced by `scripts/generate-distributed-workflow.py` and currently match what it emits. Fixed the generator itself (`_rclone_conf` plus three call sites that inlined the same heredoc directly instead of calling it) and regenerated both.

Verified with a structural diff against the pre-fix committed files that **only** the rclone-config steps changed — nothing else. `tests/test_distributed_workflow_is_regenerated.py` and `tests/test_generate_distributed_workflow.py` both still pass.

## The other 4 generated files: patched in place, not regenerated

`build-distributed.yml`, `build-xfce-distributed.yml`, `build-gnome49-distributed.yml`, `build-gnome50-distributed.yml` turned out to be substantially drifted from what the *current* generator produces — for reasons unrelated to this fix (different retry logic, job/step counts, `if` conditions — generator features added since these were last regenerated). Regenerating them fully would have mixed this security fix into a large, unrelated, hard-to-review diff.

Instead: parsed each file, patched only the matching rclone-conf steps (same transform as the generator fix), and re-dumped with the same YAML style — leaving everything else exactly as committed.

## The 11 hand-authored workflows

- **5** (`build.yml`, `build-gnome49-package.yml`, `build-gnome50-package.yml`, `r2-inventory.yml`, `refresh-gnome50-r2.yml`) still inlined secrets directly — moved to `env:` + added `umask 077`, matching the issue's own recommended fix exactly.
- **6** (`build-fprintd-aarch64.yml`, `build-gnome51-package.yml`, `build-hummingbird-desktops.yml`, `build-xfce-fedora.yml`, `build-xfce-package.yml`, `publish-tideforge-debs.yml`) already used `env:` for the secrets but were still missing `umask 077` — added just that.

## Verification

Programmatic, not eyeballed — full YAML parse + walk across all 17 files confirms:
- **Zero** `secrets.R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY`/`CLOUDFLARE_ACCOUNT_ID`/`R2_ENDPOINT` references remain inside any `run:` block (only inside `env:`, which is the point).
- **Every** `cat > ~/.config/rclone/rclone.conf` write is preceded by `umask 077`.

Plus: `pytest tests/ -k "distributed or generate"` — 31 passed.
