### PR TITLE
ci: regenerate XFCE repository metadata

### DIFF
--- a/.github/workflows/build-xfce-package.yml
+++ b/.github/workflows/build-xfce-package.yml
@@ -198,7 +198,14 @@ jobs:
 
       - name: Update local repo metadata
         run: |
-          createrepo_c --update "${HOME}/local-repo"
+          # Full regeneration, NOT --update: the seed step copies the
+          # currently published repodata into local-repo, and createrepo_c
+          # --update carries pre-existing entries forward VERBATIM without
+          # re-hashing the artifacts (gtkgreet-0.8-1.el10 incident). Drop
+          # the seeded repodata and rebuild from the actual files so
+          # repomd/primary always match what rclone sync uploads.
+          rm -rf "${HOME}/local-repo/repodata"
+          createrepo_c "${HOME}/local-repo"
 
       - name: Sync to R2
         env:


### PR DESCRIPTION
## Summary

- Replace incremental `createrepo_c --update` with a full metadata regeneration in the XFCE package publisher.
- Remove seeded `repodata` before rebuilding metadata from the RPMs actually present in `local-repo`.

The workflow seeds the currently published repository before building an incremental package. `--update` preserves pre-existing package metadata verbatim, so a stale gtkgreet checksum can remain live indefinitely. Full regeneration makes `primary.xml` and `repomd.xml` match the files uploaded by the subsequent R2 sync.

Fixes #358

## Validation

- `git diff --check`
- Workflow YAML reviewed; `actionlint` was unavailable locally.