### PR TITLE
ci: start GDM in GNOME Lima verification VMs

### DIFF
--- a/.github/workflows/build-gnome50-verify.yml
+++ b/.github/workflows/build-gnome50-verify.yml
@@ -110,11 +110,16 @@ jobs:
                   mutter \
                   gdm \
                   gnome-session-wayland-session \
+                  dbus-daemon \
                   glib2
                 glib-compile-schemas /usr/share/glib-2.0/schemas/
                 printf '[daemon]\nWaylandEnable=true\n' > /etc/gdm/custom.conf
                 systemctl enable gdm
                 systemctl set-default graphical.target
+                # Lima provisions an already-booted cloud image. Enabling the
+                # unit and changing the default target only affect the next
+                # boot, so start GDM explicitly for this verification run.
+                systemctl start gdm
           EOF
 
       - name: Start Lima VM

--- a/.github/workflows/build-gnome51-verify.yml
+++ b/.github/workflows/build-gnome51-verify.yml
@@ -94,11 +94,16 @@ jobs:
                   mutter \
                   gdm \
                   gnome-session-wayland-session \
+                  dbus-daemon \
                   glib2
                 glib-compile-schemas /usr/share/glib-2.0/schemas/
                 printf '[daemon]\nWaylandEnable=true\n' > /etc/gdm/custom.conf
                 systemctl enable gdm
                 systemctl set-default graphical.target
+                # Lima provisions an already-booted cloud image. Enabling the
+                # unit and changing the default target only affect the next
+                # boot, so start GDM explicitly for this verification run.
+                systemctl start gdm
           EOF
 
       - name: Start Lima VM


### PR DESCRIPTION
Fixes #364

The Lima provisioner runs after the CentOS cloud image has already booted. `systemctl enable gdm` and `systemctl set-default graphical.target` only affect a subsequent boot, so GDM never starts during the verification run.

- Explicitly install `dbus-daemon`, required by the GDM session bus.
- Explicitly start GDM after enabling it in both GNOME 50 and GNOME 51 verification VMs.

`git diff --check` passes. Python/PyYAML and pytest are not installed in the workspace, so repository test execution was unavailable.