### PR TITLE
fix(build-chain): bound each mock build so a wedged container fails, not hangs

### DIFF
--- a/scripts/build-chain.sh
+++ b/scripts/build-chain.sh
@@ -708,8 +708,26 @@ build_package_podman() {
     # Wrapped in a function so the retry below re-runs the IDENTICAL
     # invocation with one extra mock argument, rather than a second copy
     # of it drifting out of sync with this one.
+    #
+    # timeout(1) around the whole container, because a wedged mock hangs
+    # the tier SILENTLY: runs 31732589290 and 31757583258 each sat 2+
+    # hours with zero further log output after netcdf's builddep retry
+    # entered chroot init, held the workflow's concurrency lock the whole
+    # time, and only died when a human cancelled them. GitHub's own
+    # step timeout cannot help here -- the runner agent stays healthy, it
+    # is the container that never returns. An external bound converts the
+    # hang into a visible per-package failure (exit 124) that the tier
+    # retry logic treats like any other failed package and moves past.
+    #
+    # 180 minutes default: generous enough for the largest single package
+    # a desktop tier carries on a 4-core runner, an order of magnitude
+    # above the tier median, and still a third of the 6-hour job budget a
+    # single hung package used to consume. MOCK_TIMEOUT_MINUTES overrides
+    # it for a known-slow rebuild. --kill-after covers a container that
+    # ignores SIGTERM.
     _run_mock_container() {
         local mock_extra_args="${1:-}"
+        timeout --kill-after=60s "${MOCK_TIMEOUT_MINUTES:-180}m" \
         podman run --rm --privileged \
             --pull=always \
             -v "${builddir}:/builddir:Z" \

--- a/tests/test_mock_build_has_a_time_bound.py
+++ b/tests/test_mock_build_has_a_time_bound.py
@@ -1,0 +1,66 @@
+"""A wedged mock build must fail visibly, not hold the tier hostage.
+
+Runs 31732589290 and 31757583258 each sat 2+ hours with ZERO further log
+output after netcdf's builddep retry entered mock chroot init. The runner
+agent stayed healthy the whole time -- it was the podman container that
+never returned -- so GitHub's step timeout never fired, the workflow's
+concurrency group stayed locked (queueing every later dispatch behind the
+zombie), and both runs ended only when a human cancelled them.
+
+An external timeout(1) around the container converts that hang into an
+ordinary per-package failure (exit 124) that the existing tier-retry logic
+skips past, the same external-bound pattern tunaOS#1572 applied to the
+syft scan for the same reason: the process that hangs cannot be the one
+enforcing its own deadline.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "build-chain.sh"
+
+
+def _mock_container_fn() -> str:
+    """The real _run_mock_container body, not a reimplementation."""
+    text = SCRIPT.read_text()
+    match = re.search(
+        r"_run_mock_container\(\)\s*\{.*?\n    \}", text, re.S
+    )
+    assert match, "_run_mock_container not found in build-chain.sh"
+    return match.group(0)
+
+
+def test_the_container_run_is_time_bounded() -> None:
+    fn = _mock_container_fn()
+    assert re.search(r"timeout\s+.*podman run", fn, re.S), (
+        "_run_mock_container invokes podman with no external time bound, so "
+        "a wedged mock hangs the tier silently until a human cancels the "
+        "job -- the exact failure of runs 31732589290 and 31757583258"
+    )
+
+
+def test_the_bound_is_overridable_but_has_a_default() -> None:
+    """A hard-coded bound would need a code change for a known-slow rebuild;
+    an env var with no default protects nothing on the runs that matter."""
+    fn = _mock_container_fn()
+    assert re.search(r"\$\{MOCK_TIMEOUT_MINUTES:-\d+\}", fn), (
+        "the timeout is not MOCK_TIMEOUT_MINUTES with a numeric default"
+    )
+
+
+def test_a_stuck_container_is_killed_not_just_asked() -> None:
+    fn = _mock_container_fn()
+    assert "--kill-after" in fn, (
+        "timeout has no --kill-after, so a container that ignores SIGTERM "
+        "still hangs forever"
+    )
+
+
+def test_the_reason_travels_with_the_code() -> None:
+    """An unexplained timeout wrapper reads as paranoia and invites removal."""
+    text = SCRIPT.read_text()
+    assert "31732589290" in text or "31757583258" in text, (
+        "the script does not cite the hung runs that motivated the bound"
+    )


### PR DESCRIPTION
## Summary

- Runs 31732589290 and 31757583258 each sat **2+ hours with zero further log output** after netcdf's builddep retry entered mock chroot init. The runner agent stayed healthy the whole time — it was the podman container that never returned — so no step timeout fired, the workflow's `hummingbird-desktops-*` concurrency group stayed locked (queueing every later dispatch behind the zombie), and both runs ended only when manually cancelled.
- Wraps `_run_mock_container`'s podman invocation in `timeout --kill-after=60s "${MOCK_TIMEOUT_MINUTES:-180}m"`. A hang becomes an ordinary per-package failure (exit 124) that the existing tier-retry logic skips past — the same external-bound pattern tunaOS#1572 just applied to the syft scan, for the same reason: the process that hangs cannot be the one enforcing its own deadline.
- 180-minute default is generous for the largest single package a desktop tier carries on a 4-core runner and still a third of the 6-hour job budget a single hung package used to consume; `MOCK_TIMEOUT_MINUTES` overrides it for a known-slow rebuild.

## Test plan

- [x] `bash -n scripts/build-chain.sh` passes.
- [x] `tests/test_mock_build_has_a_time_bound.py` (new, 4 tests) extracts the real `_run_mock_container` body and pins: the podman run is time-bounded, the bound is `MOCK_TIMEOUT_MINUTES` with a numeric default, `--kill-after` is present, and the script cites the hung runs that motivated it.
- [x] Mutation-verified: removing the timeout wrapper fails 3 of the 4 new tests.
- [x] `python3 -m pytest tests/test_mock_build_has_a_time_bound.py tests/test_build_chain_reports_why_it_died.py -q` → 13 passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_