### PR TITLE
fix(hummingbird): pin F44 mpich — hummingbird ships hdf5-mpich but no mpich

### DIFF
--- a/mock/hummingbird-ci.cfg
+++ b/mock/hummingbird-ci.cfg
@@ -126,6 +126,36 @@
 #
 # tests/test_hummingbird_golang_name_split.py guards this.
 #
+# MPICH.  A third shape: a package hummingbird DEPENDS ON but does not
+# ship at all.  From run 31732589290, netcdf's builddep:
+#
+#     Problem: package doxygen-2:1.17.0-3.hum1 from hummingbird requires
+#       graphviz, but none of the providers can be installed
+#      - package graphviz-...hum1 requires /usr/bin/python3, ...
+#      - package mpich-4.2.2-10.fc45 from fedora requires
+#        (python(abi) = 3.15 if python3), but none of the providers can
+#        be installed
+#
+# Measured against the hummingbird index itself: it ships hdf5-mpich
+# (requiring libmpi.so.12(mpich-x86_64)) but NO mpich.  The only provider
+# is Rawhide's, whose rich dep demands python(abi) = 3.15 the moment
+# python3 enters the transaction -- and graphviz/doxygen need
+# hummingbird's python3 = 3.14 in the SAME transaction.  Unsolvable, so
+# every package whose builddep touches both doxygen and hdf5-mpich-devel
+# (netcdf first among them) fails before building anything.
+#
+# F44's mpich is 4.2.2-7.fc44: the SAME upstream version as Rawhide's
+# 4.2.2-10.fc45, provides the exact libmpi.so.12()(64bit)(mpich-x86_64)
+# hummingbird's hdf5-mpich requires, and its rich dep is
+# (python(abi) = 3.14 if python3) -- hummingbird's own interpreter.  All
+# three facts measured from the repos' primary.xml, not inferred.  The
+# name pin drops Rawhide's mpich from resolution entirely, same
+# mechanism as the perl/python pins above.
+#
+# Remove when hummingbird ships its own mpich, or its python3 reaches
+# Rawhide's -- either dissolves the conflict.
+# tests/test_hummingbird_mpich_pin.py guards this.
+#
 # Repository priority (lower wins in dnf):
 #   1  local-build      RPMs produced by earlier tiers of this same run
 #   10 hummingbird      the target's own signed RPMs — the ABI we must match
@@ -197,6 +227,22 @@ gpgcheck=0
 enabled=1
 priority=50
 includepkgs=perl-*
+
+[fedora-44-mpich]
+name=Fedora 44 - mpich only (hummingbird ships hdf5-mpich but no mpich)
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-44&arch=$basearch
+gpgcheck=0
+enabled=1
+priority=50
+includepkgs=mpich*
+
+[fedora-44-mpich-updates]
+name=Fedora 44 updates - mpich only (hummingbird ships hdf5-mpich but no mpich)
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f44&arch=$basearch
+gpgcheck=0
+enabled=1
+priority=50
+includepkgs=mpich*
 """
 config_opts['plugin_conf']['bind_mount_enable'] = True
 config_opts['plugin_conf']['bind_mount_opts']['dirs'].append(('/local-repo', '/local-repo'))

--- a/tests/test_hummingbird_mpich_pin.py
+++ b/tests/test_hummingbird_mpich_pin.py
@@ -1,0 +1,106 @@
+"""Hummingbird ships hdf5-mpich but no mpich; the gap must be bridged.
+
+From run 31732589290, netcdf's builddep failed to resolve:
+
+    - package mpich-4.2.2-10.fc45 from fedora requires
+      (python(abi) = 3.15 if python3), but none of the providers can
+      be installed
+
+Measured against the hummingbird index itself: it ships hdf5-mpich
+(requiring libmpi.so.12(mpich-x86_64)) but NO package named mpich.  The
+only provider is Rawhide's, whose rich dep demands python(abi) = 3.15
+the moment python3 enters the transaction -- while graphviz/doxygen need
+hummingbird's python3 = 3.14 in the SAME transaction.  Unsolvable, so
+every package whose builddep touches both doxygen and hdf5-mpich-devel
+fails before building anything.
+
+F44's mpich is the same upstream version (4.2.2), provides the exact
+libmpi.so.12()(64bit)(mpich-x86_64) hummingbird's hdf5-mpich requires,
+and its rich dep is (python(abi) = 3.14 if python3) -- hummingbird's own
+interpreter.  Pinning it drops Rawhide's mpich from resolution by name,
+the same mechanism the perl/python pins in this config rely on.
+"""
+
+from __future__ import annotations
+
+import configparser
+import io
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+CFG = ROOT / "mock" / "hummingbird-ci.cfg"
+MPICH_REPOS = ("fedora-44-mpich", "fedora-44-mpich-updates")
+RAWHIDE_PRIORITY = 99
+
+
+@pytest.fixture(scope="module")
+def conf() -> configparser.ConfigParser:
+    text = CFG.read_text()
+    blocks = re.findall(r'config_opts\[.dnf\.conf.\]\s*\+=\s*"""(.*?)"""', text, re.S)
+    assert blocks, "hummingbird-ci.cfg appends no dnf.conf repositories"
+    parser = configparser.ConfigParser(strict=False)
+    parser.read_file(io.StringIO("\n".join(blocks)))
+    return parser
+
+
+def test_an_mpich_repository_is_pinned(conf) -> None:
+    for repo in MPICH_REPOS:
+        assert conf.has_section(repo), (
+            f"{repo} is gone, so Rawhide's mpich (python 3.15 world) is the "
+            "only provider of libmpi.so.12(mpich-x86_64) and every builddep "
+            "touching both doxygen and hdf5-mpich-devel fails to resolve"
+        )
+        assert conf.get(repo, "enabled") == "1", f"{repo} is disabled"
+
+
+def test_the_pin_is_confined_to_the_mpich_namespace(conf) -> None:
+    """includepkgs is the whole safety argument for adding an older Fedora."""
+    for repo in MPICH_REPOS:
+        globs = [g.strip() for g in conf.get(repo, "includepkgs", fallback="").split(",")]
+        globs = [g for g in globs if g]
+        assert globs, (
+            f"{repo} has no includepkgs, so an entire Fedora 44 -- two releases "
+            "of C libraries -- can enter the chroot"
+        )
+        assert "*" not in globs, f"{repo} includepkgs is unrestricted"
+        for glob in globs:
+            assert glob.startswith("mpich"), (
+                f"{repo} includepkgs carries {glob!r}, which is outside the "
+                "mpich namespace this pin exists for"
+            )
+
+
+def test_the_pin_outranks_rawhide_but_never_hummingbird(conf) -> None:
+    hummingbird = conf.getint("hummingbird", "priority")
+    local = conf.getint("local-build", "priority")
+    for repo in MPICH_REPOS:
+        pinned = conf.getint(repo, "priority")
+        assert pinned > hummingbird, (
+            f"{repo} priority {pinned} is at least as good as hummingbird's "
+            f"{hummingbird}; if hummingbird ever ships its own mpich it must win"
+        )
+        assert pinned < RAWHIDE_PRIORITY, (
+            f"{repo} priority {pinned} does not beat Rawhide's "
+            f"{RAWHIDE_PRIORITY}, so Rawhide's python-3.15 mpich still wins"
+        )
+        assert local < pinned, "packages this run built must outrank Fedora 44"
+
+
+def test_the_reason_travels_with_the_config() -> None:
+    """A pin with no stated expiry outlives the problem it was added for."""
+    text = CFG.read_text()
+    assert "hdf5-mpich" in text and "libmpi.so.12" in text, (
+        "the config does not record the dependency gap the pin bridges "
+        "(hummingbird ships hdf5-mpich but no mpich)"
+    )
+    assert "python(abi) = 3.15" in text, (
+        "the config does not record WHY Rawhide's mpich cannot resolve "
+        "(its rich dep conflicts with hummingbird's python3), which is the "
+        "load-bearing fact"
+    )
+    assert "Remove when hummingbird ships its own mpich" in text, (
+        "no removal condition, so this outlives the gap"
+    )


### PR DESCRIPTION
## Summary

- From run 31732589290, netcdf's builddep failed to resolve:
  ```
  Problem: package doxygen-2:1.17.0-3.hum1 from hummingbird requires graphviz,
    but none of the providers can be installed
   - package mpich-4.2.2-10.fc45 from fedora requires
     (python(abi) = 3.15 if python3), but none of the providers can be installed
  ```
- Measured against the hummingbird index itself: it ships `hdf5-mpich` (requiring `libmpi.so.12(mpich-x86_64)`) but **no package named `mpich`**. The only provider is Rawhide's, whose rich dep demands python(abi) = 3.15 the moment python3 enters the transaction — while graphviz/doxygen need hummingbird's python3 = 3.14 in the *same* transaction. Unsolvable, so every package whose builddep touches both doxygen and hdf5-mpich-devel (netcdf first among them) fails before building anything.
- Adds `[fedora-44-mpich]`/`[fedora-44-mpich-updates]` sections with `includepkgs=mpich*` at priority 50 — the same mechanism as the existing perl/python pins. Safety, all measured from the repos' primary.xml rather than inferred: F44's mpich is **4.2.2-7.fc44, the same upstream version** as Rawhide's 4.2.2-10.fc45; it provides the exact `libmpi.so.12()(64bit)(mpich-x86_64)` hummingbird's hdf5-mpich requires; and its rich dep is `(python(abi) = 3.14 if python3)` — hummingbird's own interpreter.

## Test plan

- [x] `tests/test_hummingbird_mpich_pin.py` (new, 4 tests) mirrors the perl-pin suite: sections exist, includepkgs confined to `mpich*`, priority outranks Rawhide but never hummingbird, and the config records why with a removal condition.
- [x] Mutation-verified: deleting both repo sections fails 3 of the 4 new tests.
- [x] `python3 -m pytest tests/test_hummingbird_{mpich_pin,perl_abi_pin,python_abi_pin,golang_name_split}.py -q` → 20 passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gu5fBnu8whXPqCFKd5aA7B)_