### PR TITLE
fix: remove xfwl4 customManager left with an invalid empty fileMatch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -124,19 +124,6 @@
     },
     {
       "customType": "regex",
-      "description": "xfwl4: DISABLED (empty fileMatch). It tracked gitlab.xfce.org/xfce/xfwl4's main branch, but an xfwl4 bump is never a one-line edit and a regex manager can only ever make it one. Three values are coupled to the pinned commit: the commit itself, the pre-vendored vendor.tar.gz release asset keyed to it (Source1, xfwl4-vendor-<sha>), and the smithay git rev that the commit's Cargo.lock pins, which the spec repeats in its cargo source override. The Fedora build runs `cargo build --offline`, so when the override and the vendor tree do not match the commit's Cargo.lock, cargo cannot resolve smithay at all. This was already the documented reason packages/xfwl4/package.yaml was excluded; the spec and PKGBUILD carry the same coupling and were left in by oversight. #366 bumped the commit to c6c0e1c, upstream had moved smithay from 0a29aecf to 4cf0b620, and XFCE Wayland (Fedora) went red on main from 2026-08-12 through #367, #368 and #376 \u2014 four green-looking one-line PRs stacked on a build that had not compiled since the first of them. Re-enable only once a bump also regenerates the vendor asset and rewrites the smithay rev.",
-      "fileMatch": [],
-      "matchStrings": [
-        "(?:%global commit\\s+|\\n_commit=)(?<currentDigest>[a-f0-9]{40})"
-      ],
-      "currentValueTemplate": "main",
-      "datasourceTemplate": "git-refs",
-      "depNameTemplate": "xfwl4",
-      "depTypeTemplate": "upstream-source",
-      "packageNameTemplate": "https://gitlab.xfce.org/xfce/xfwl4"
-    },
-    {
-      "customType": "regex",
       "description": "fprintd: real version tags exist (unlike the xfce packages above), so track those directly instead of a branch tip.",
       "fileMatch": [
         "^src/deps/fprintd/fprintd\\.spec$"


### PR DESCRIPTION
## Summary

Fixes #380. #379 disabled the xfwl4 digest-bump regex manager (see #369/#379 — a bump is never a one-line edit because the pinned commit, the pre-vendored `vendor.tar.gz` release asset, and the smithay git rev in the spec's cargo override all have to move together) by emptying its `fileMatch` array in place, keeping the block around with a "DISABLED" description for context.

Renovate's schema doesn't allow that: every `customManager` entry requires a non-empty `managerFilePatterns`/`fileMatch` array, so the empty array made the *entire* `renovate.json` invalid — Renovate's own bot filed #380 (`Each Custom Manager must contain a non-empty managerFilePatterns array`) and halted all Renovate activity repo-wide, not just for xfwl4.

## What changed

There's no valid "present but disabled" state for a `customManager` short of a real non-empty pattern, so the fix removes the block outright — the same outcome #379 intended (xfwl4 untracked by Renovate), without breaking every other manager in the file. The full rationale for why it's disabled lives in #379's PR description and git history; a working manager can be re-added once a bump also regenerates the vendor asset and rewrites the smithay rev, per that PR's notes.

## Test plan

- [x] `python3 -c "import json; json.load(open('renovate.json'))"` — valid JSON
- [x] `npx -p renovate renovate-config-validator` — before: `Each Custom Manager must contain a non-empty managerFilePatterns array`; after: `Config validated successfully`

---
_Generated by [Claude Code](https://claude.ai/code/session_014mkpNM2ZMGG78bAiYM1osn)_