### PR TITLE
fix(mock-runner): exclude openssl-libs/fips-provider from F44 releasever install

### DIFF
--- a/mock/Containerfile
+++ b/mock/Containerfile
@@ -39,7 +39,19 @@ RUN dnf install -y \
 # newer distribution-gpg-keys (>= 1.117) than F41 ships, so plain rpm -i
 # cannot resolve that — dnf against the F44 repos does, and --best keeps it
 # from silently settling for an older, still-broken candidate.
-RUN dnf --releasever=44 install -y --best mock-core-configs \
+#
+# --exclude=openssl-libs,fips-provider: without it, dnf's depsolver treats
+# the switch to F44 repos as license to reconcile *other* already-installed
+# packages too, not just install mock-core-configs itself. It offers an
+# F44-tagged openssl-libs (already satisfied by the F45 base image) as an
+# "upgrade", which ships /usr/lib64/ossl-modules/fips.so — a file the F45
+# fips-provider package already owns. Two RPMs claiming the same file path
+# fails the transaction outright (`Rpm transaction failed`), not just a
+# resolvable dependency conflict. Excluding both keeps the base image's F45
+# openssl-libs/fips-provider untouched; mock-core-configs does not need a
+# newer openssl-libs, only the newer distribution-gpg-keys the comment above
+# describes.
+RUN dnf --releasever=44 install -y --best --exclude=openssl-libs --exclude=fips-provider mock-core-configs \
     && rm -rf /var/cache/dnf \
     && test ! -L /etc/mock/fedora-44-x86_64.cfg
 


### PR DESCRIPTION
## Summary

Fixes #382. `Build Mock Runner Image` fails on every main push:

```
file /usr/lib64/ossl-modules/fips.so from install of openssl-libs-1:3.5.7-2.fc44.x86_64 conflicts with file from package fips-provider-1.5.2-3.fc45.x86_64
```

## Root cause

The image is `FROM fedora:45`, but installs `mock-core-configs` a second time with `--releasever=44` to get an un-symlinked `fedora-44-x86_64.cfg` (existing comment explains why). That releasever switch lets dnf's depsolver reconsider *other* already-installed packages too, not just `mock-core-configs` — it offers an F44-tagged `openssl-libs` as an "upgrade" over the F45 base's own copy, and that build of `openssl-libs` ships `/usr/lib64/ossl-modules/fips.so`, a file the F45 `fips-provider` package already owns. Two RPMs claiming the same file path fails the whole transaction outright.

## What changed

Excludes both packages from that specific `dnf` invocation — matching the issue's own suggested fix ("exclude fips-provider in the install") plus `openssl-libs` itself, the package actually offering the conflicting file. `mock-core-configs` needs a newer `distribution-gpg-keys` from F44's repos (per the existing comment), not a newer `openssl-libs`, so excluding it shouldn't affect what the step is actually trying to accomplish.

## Test plan

- [ ] Not build-verified locally — no `podman` available in this environment to actually run the Containerfile build. Flagging that explicitly rather than claiming a build-tested fix; the CI run on this PR (`Build Mock Runner Image`) is the real verification.

---
_Generated by [Claude Code](https://claude.ai/code/session_014mkpNM2ZMGG78bAiYM1osn)_