### PR TITLE
docs: rename stale tuna-os/github-copr refs to tunaos-packages

### DIFF
--- a/.github/workflows/build-xfce-arch-validation.yml
+++ b/.github/workflows/build-xfce-arch-validation.yml
@@ -2,7 +2,7 @@
 # libxfce4ui -> xfwl4) — no equivalent of build-chain.sh/mock exists for
 # Arch, so this drives makepkg directly in an archlinux container, same
 # steps as the manual session that first got these three PKGBUILDs
-# building (tuna-os/github-copr#101).
+# building (tuna-os/tunaos-packages#101).
 #
 # No signing, no publish — this exists purely so a Renovate bump to any of
 # these three PKGBUILDs' _commit= pins is CI-gated instead of landing

--- a/.github/workflows/build-xfce-package.yml
+++ b/.github/workflows/build-xfce-package.yml
@@ -158,7 +158,7 @@ jobs:
             --force
 
       # Same macro shape as build-xfce-distributed.yml's publish job (and
-      # build-xfce-fedora.yml as of tuna-os/github-copr#102) — the
+      # build-xfce-fedora.yml as of tuna-os/tunaos-packages#102) — the
       # hand-rolled __gpg_sign_cmd this replaced was missing the actual
       # "-u ... -sbo ..." signing directive and instead piped into an
       # unrelated --import-options import-show --import, which made every

--- a/build-order-xfce.yml
+++ b/build-order-xfce.yml
@@ -3,7 +3,7 @@
 # Packages within a tier build in parallel; tiers are sequential.
 # Each package entry is a path relative to the repo root.
 #
-# Resolves issue: https://github.com/tuna-os/github-copr/issues/65
+# Resolves issue: https://github.com/tuna-os/tunaos-packages/issues/65
 #
 # Target: almalinux-kitten-10-x86_64 (also centos-stream-10-x86_64)
 # R2 path: repo/10/x86_64 (same as main GNOME 50 repo — XFCE packages

--- a/docs/superpowers/plans/2026-03-15-gnome49-gha-pipeline.md
+++ b/docs/superpowers/plans/2026-03-15-gnome49-gha-pipeline.md
@@ -612,7 +612,7 @@ set -euo pipefail
 
 WORKFLOW_BOOTSTRAP="build-gnome49-distributed.yml"
 WORKFLOW_PACKAGE="build-gnome49-package.yml"
-REPO="tuna-os/github-copr"
+REPO="tuna-os/tunaos-packages"
 BRANCH="gnome-49-pipeline"
 
 cmd="${1:-status}"
@@ -774,7 +774,7 @@ git commit -m "feat: add Renovate config to track GNOME 49 versions against Fedo
 
 ### Task 8.2: Enable Renovate on the GitHub repository
 
-- [ ] Install the [Renovate GitHub App](https://github.com/apps/renovate) on the `tuna-os/github-copr` repository (or verify it's already installed).
+- [ ] Install the [Renovate GitHub App](https://github.com/apps/renovate) on the `tuna-os/tunaos-packages` repository (or verify it's already installed).
 - [ ] Trigger a Renovate run: go to the Renovate App dashboard or push a commit to the branch.
 - [ ] Verify Renovate finds the spec files and creates (or would create) PRs.
 

--- a/src/deps/gnome50-el10-compat/useradd-wrapper
+++ b/src/deps/gnome50-el10-compat/useradd-wrapper
@@ -17,7 +17,7 @@
 # exists, it strips -m/--create-home, adds -M, invokes the real useradd,
 # then chowns and restorecons the existing directory.
 #
-# See: https://github.com/tuna-os/github-copr/issues/17
+# See: https://github.com/tuna-os/tunaos-packages/issues/17
 
 set -euo pipefail
 

--- a/src/gnome-49/gnome49-el10-compat/useradd-wrapper
+++ b/src/gnome-49/gnome49-el10-compat/useradd-wrapper
@@ -17,7 +17,7 @@
 # exists, it strips -m/--create-home, adds -M, invokes the real useradd,
 # then chowns and restorecons the existing directory.
 #
-# See: https://github.com/tuna-os/github-copr/issues/17
+# See: https://github.com/tuna-os/tunaos-packages/issues/17
 
 set -euo pipefail
 

--- a/src/xfce-wayland/garcon/garcon.spec
+++ b/src/xfce-wayland/garcon/garcon.spec
@@ -49,5 +49,5 @@ autoreconf -fi
 
 %changelog
 * Thu Jul 03 2026 TunaOS Bot <bot@tunaos.org> - %{version}-%{release}
-- Packaged for the XFCE Wayland stack (tuna-os/github-copr#65)
+- Packaged for the XFCE Wayland stack (tuna-os/tunaos-packages#65)
 

--- a/src/xfce-wayland/libxfce4ui/libxfce4ui.spec
+++ b/src/xfce-wayland/libxfce4ui/libxfce4ui.spec
@@ -64,5 +64,5 @@ building against libxfce4ui.
 
 %changelog
 * Thu Jul 03 2026 TunaOS Bot <bot@tunaos.org> - %{version}-%{release}
-- Packaged for the XFCE Wayland stack (tuna-os/github-copr#65)
+- Packaged for the XFCE Wayland stack (tuna-os/tunaos-packages#65)
 

--- a/src/xfce-wayland/libxfce4windowing/libxfce4windowing.spec
+++ b/src/xfce-wayland/libxfce4windowing/libxfce4windowing.spec
@@ -43,5 +43,5 @@ Headers and pkgconfig files for building against libxfce4windowing.
 
 %changelog
 * Thu Jul 03 2026 TunaOS Bot <bot@tunaos.org> - %{version}-%{release}
-- Packaged for the XFCE Wayland stack (tuna-os/github-copr#65)
+- Packaged for the XFCE Wayland stack (tuna-os/tunaos-packages#65)
 

--- a/src/xfce-wayland/xfconf/xfconf.spec
+++ b/src/xfce-wayland/xfconf/xfconf.spec
@@ -63,5 +63,5 @@ building against xfconf.
 
 %changelog
 * Thu Jul 03 2026 TunaOS Bot <bot@tunaos.org> - %{version}-%{release}
-- Packaged for the XFCE Wayland stack (tuna-os/github-copr#65)
+- Packaged for the XFCE Wayland stack (tuna-os/tunaos-packages#65)
 


### PR DESCRIPTION
## Summary

Fixes the `tunaos-packages` half of tuna-os/tunaOS#1680, which enumerated the remaining stale `tuna-os/github-copr` references left over from the repo rename (github-copr → tunaos-packages).

## What changed

Renamed `tuna-os/github-copr` → `tuna-os/tunaos-packages` (or bare `github-copr` → `tunaos-packages` in prose) in 10 files:

- `src/xfce-wayland/{garcon,xfconf,libxfce4ui,libxfce4windowing}/*.spec` — changelog comment `(tuna-os/github-copr#65)`
- `src/deps/gnome50-el10-compat/useradd-wrapper` and `src/gnome-49/gnome49-el10-compat/useradd-wrapper` — `# See: https://github.com/tuna-os/github-copr/issues/17`
- `build-order-xfce.yml` — `# Resolves issue: https://github.com/tuna-os/github-copr/issues/65`
- `.github/workflows/build-xfce-arch-validation.yml` — `(tuna-os/github-copr#101)`
- `.github/workflows/build-xfce-package.yml` — `(tuna-os/github-copr#102)`
- `docs/superpowers/plans/2026-03-15-gnome49-gha-pipeline.md` — a `REPO="tuna-os/github-copr"` line in an embedded historical script snippet, plus a Renovate-install instruction

`tests/bats/README.md` already correctly described the rename ("formerly the `github-copr` repo") from an earlier fix — no change needed there.

## Verification

All four issue/PR numbers referenced (#17, #65, #101, #102) were confirmed to still exist and match their original topic under `tuna-os/tunaos-packages` before renaming — issue/PR numbers survive a GitHub repo rename, per the maintainer's guidance on the parent issue.

The one functional (non-prose) string checked here, `scripts/watch-pipeline.sh`'s `REPO=` variable, was already correctly set to `tuna-os/tunaos-packages` — only the historical plan doc's embedded copy of that snippet was stale.

- [x] `grep -rn "github-copr"` across the repo — only the intentional historical mention in `tests/bats/README.md` remains
- [x] Full bats suite: `bats tests/bats/` — 57/57 passing (two pre-existing `gh`-not-installed warnings, unrelated to this change)

---
_Generated by [Claude Code](https://claude.ai/code/session_014mkpNM2ZMGG78bAiYM1osn)_