### PR TITLE
perf(build-chain): stop the already-built check re-resolving the image tag

### DIFF
--- a/scripts/build-chain.sh
+++ b/scripts/build-chain.sh
@@ -602,9 +602,22 @@ check_package_exists() {
 
     # Query the spec file inside the container to get the expected NVR
     # We do this inside the container to ensure macro expansion (%autorelease, %dist, etc.)
+    #
+    # --pull=missing, not --pull=always. BUILD_IMAGE is a fixed tag, and the
+    # workflow already pulls it once in its own "Pull mock runner" step, so
+    # --pull=always bought nothing but a GHCR round-trip -- and this function
+    # runs for EVERY package the tier considers, before the skip decision, so
+    # it was paid for packages that were about to be skipped too. That cost
+    # grows as the R2 seed grows, which is backwards: the further hummingbird
+    # converges, the more of each 6-hour run goes on confirming there is
+    # nothing to do (tunaos-packages#410, #401).
+    #
+    # It is also more correct. The NVR this computes is compared against RPMs
+    # an earlier run built; re-resolving the tag mid-run could answer from a
+    # different image than the one that produced them.
     local nvr
     nvr=$(podman run --rm \
-        --pull=always \
+        --pull=missing \
         -v "$(dirname "$spec"):/specdir:Z" \
         "${BUILD_IMAGE}" \
         rpmspec -q "/specdir/${spec_basename}" \

--- a/tests/test_skip_check_does_not_hit_the_registry.py
+++ b/tests/test_skip_check_does_not_hit_the_registry.py
@@ -1,0 +1,101 @@
+"""The already-built check must not cost a registry round-trip per package.
+
+`check_package_exists` is what makes hummingbird's incremental convergence
+work: each run seeds `local-repo-hummingbird/` from R2 and this function is
+what decides, per package, whether it is already there and can be skipped.
+
+The decision is cheap. Reaching it was not. It resolved the expected NVR by
+starting a container with `--pull=always` against a *fixed* tag
+(`ghcr.io/tuna-os/mock-runner:centos-stream-10`), which the workflow has
+already pulled once in its own "Pull mock runner" step. So every package paid
+a GHCR round-trip -- including every package that was about to be skipped.
+
+That scales the wrong way for tunaos-packages#401. Convergence assumes the
+per-run overhead stays flat while the useful work shrinks; here the share of
+the ~5h05m usable budget spent confirming "already built, skip" grows as the
+seed grows. In the limit -- everything built -- a run still round-trips the
+registry once per package to conclude it has nothing to do.
+
+`--pull=missing` keeps the image available without re-resolving the tag, and
+is also the more correct choice: the NVR is compared against RPMs an earlier
+run built, so answering from a freshly-resolved image is a way to get a
+different answer than the one that produced them.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts/build-chain.sh"
+
+
+def _function_body(name: str, *, code_only: bool = False) -> str:
+    """The text of a shell function, from `name() {` to the closing brace.
+
+    `code_only` strips comment lines. The comment above the invocation
+    explains the change by naming the flag it replaced, so a naive substring
+    check reads the rationale as the thing it forbids -- which is how the
+    first version of this test failed against a correct fix.
+    """
+    src = SCRIPT.read_text()
+    start = src.index(f"{name}() {{")
+    end = src.index("\n}\n", start)
+    body = src[start:end]
+    if code_only:
+        body = "\n".join(
+            line for line in body.splitlines() if not line.lstrip().startswith("#")
+        )
+    return body
+
+
+def test_the_skip_check_does_not_re_resolve_the_image_tag():
+    body = _function_body("check_package_exists", code_only=True)
+    assert "--pull=always" not in body, (
+        "check_package_exists re-resolves the image tag against GHCR on every "
+        "package, before the skip decision, so the cost is paid for packages "
+        "that are about to be skipped"
+    )
+    assert "--pull=missing" in body, (
+        "the skip check should still guarantee the image is present, just not "
+        "re-resolve a fixed tag every time"
+    )
+
+
+def test_the_skip_check_still_resolves_the_nvr_inside_the_container():
+    """The reason this is expensive is also the reason it is correct.
+
+    `%autorelease` and `%dist` must expand exactly as they will at build time,
+    which means asking the build image -- not the host. Making the check
+    cheaper must not turn it into a host-side guess.
+    """
+    body = _function_body("check_package_exists")
+    assert "rpmspec -q" in body
+    assert "${BUILD_IMAGE}" in body
+    assert '--define "dist ${DIST}"' in body
+
+
+def test_the_skip_is_still_opt_out_able():
+    """`--force` must keep rebuilding regardless, or a bad NVR match is unfixable."""
+    src = SCRIPT.read_text()
+    guards = re.findall(r"if ! \$FORCE && check_package_exists", src)
+    assert len(guards) >= 2, (
+        f"expected every build backend to guard on FORCE, found {len(guards)}"
+    )
+
+
+def test_the_build_paths_are_left_alone():
+    """Deliberately not a blanket sweep of --pull=always.
+
+    The other call sites run once per package that is actually BUILT, so a
+    single tag resolution is amortised against minutes of compilation. This
+    change targets the one call paid per package *considered*. Pinned so the
+    narrow scope is a decision on record rather than something to 'tidy up'
+    without measuring.
+    """
+    src = SCRIPT.read_text()
+    assert src.count("--pull=always") >= 1, (
+        "the build paths were also changed -- that is a wider change than "
+        "tunaos-packages#410 argues for; measure it before widening"
+    )


### PR DESCRIPTION
Implements the cheapest fix from #410.

## What was costing

`check_package_exists` is what makes incremental convergence work — each run seeds `local-repo-hummingbird/` from R2 and this decides, per package, whether it's already there and can be skipped.

The decision is cheap. **Reaching** it wasn't:

```bash
nvr=$(podman run --rm \
    --pull=always \                    # ← fixed tag, re-resolved every call
    -v "$(dirname "$spec"):/specdir:Z" \
    "${BUILD_IMAGE}" \                 # ghcr.io/tuna-os/mock-runner:centos-stream-10
    rpmspec -q ...)
```

`BUILD_IMAGE` is a **fixed tag**, and the workflow already pulls it once in its own `Pull mock runner` step (11 seconds, at job start). So `--pull=always` bought nothing but a GHCR round-trip per package — and the cost lands **before** the skip decision, so it was paid for packages that were about to be skipped too.

## Why it matters for #401

Convergence assumes per-run overhead stays flat while useful work shrinks. This is the opposite: as the R2 seed grows, the share of the ~5h05m usable budget (after #407's reserve) spent confirming *"already built, skip"* grows with it. At the limit — everything built — a run still round-trips the registry once per package to conclude it has nothing to do.

## It's also more correct

The NVR computed here is compared against RPMs an **earlier run** built. Re-resolving a mutable tag mid-run is a way to answer from a different image than the one that produced them. `--pull=missing` still guarantees the image is present; it just stops re-asking.

## Deliberately narrow

The other four `--pull=always` sites in `build-chain.sh` run once per package **actually built**, where a single tag resolution is amortised against minutes of compilation. I've left them alone — widening this should follow a measurement, not a sweep. A test pins that scope so it reads as a decision rather than an oversight.

## Tests

`tests/test_skip_check_does_not_hit_the_registry.py` — 4 tests covering the change, what must *not* change with it (the NVR is still resolved **inside** the container, because `%autorelease`/`%dist` must expand as they will at build time — making the check cheaper must not turn it into a host-side guess), that `--force` still overrides, and the deliberate scope limit.

One note on the tests themselves: the first version failed against this correct fix, because the new comment *names* the flag it replaced and a naive substring check read the rationale as the thing it forbids. The helper now strips comments before asserting — worth knowing if you extend it.

Refs #410, #401.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_