### PR TITLE
feat(hummingbird): add an aarch64 leg to the desktop package factory (refs tunaOS#1755)

### DIFF
--- a/.github/workflows/build-hummingbird-desktops.yml
+++ b/.github/workflows/build-hummingbird-desktops.yml
@@ -58,6 +58,18 @@ on:
           against it.
         type: string
         default: ""
+      arch:
+        description: >
+          Architecture(s) to build. x86_64 is the established leg
+          (hummingbird/20251124-x86_64, ~7673 packages as of 2026-08-16);
+          aarch64 is new for tunaOS#1755 §3 and starts from an empty seed.
+          Defaults to x86_64 only on a manual dispatch so a human debugging
+          one desktop/tier does not also kick off an unrelated six-hour
+          aarch64 run; the scheduled run (no inputs) always builds both, see
+          the `arch` job `if:` conditions below.
+        type: choice
+        options: [x86_64, aarch64, all]
+        default: x86_64
       publish:
         description: Sign and publish the resulting RPM repository
         type: boolean
@@ -93,6 +105,11 @@ env:
   # bootstrap image for whatever --mock-config asks for. build-xfce-fedora.yml
   # uses the same image for a fedora-44 chroot.
   MOCK_RUNNER_IMAGE: ghcr.io/tuna-os/mock-runner:centos-stream-10
+  # A separate tag, not a multi-arch manifest -- build-mock-runner.yml pushes
+  # this from its own build-and-push-aarch64 job (mock/Containerfile built on
+  # ubuntu-24.04-arm). Confirmed live on GHCR before this workflow was written:
+  # the tag exists and its image config reports architecture "arm64".
+  MOCK_RUNNER_IMAGE_AARCH64: ghcr.io/tuna-os/mock-runner:centos-stream-10-aarch64
 
 jobs:
   # `desktop: all` used to mean "one runner builds all 60 tiers", which cannot
@@ -116,6 +133,12 @@ jobs:
 
   build:
     needs: plan
+    # Skipped only when a manual dispatch explicitly asked for aarch64 alone.
+    # `inputs.arch` is unset on the schedule trigger (workflow_dispatch inputs
+    # do not exist for other events), so `|| 'all'` resolves to 'all' there --
+    # same fallback idiom TRIGGER_DESKTOP etc. already use above -- and the
+    # scheduled run always builds both architectures.
+    if: ${{ (inputs.arch || 'all') != 'aarch64' }}
     runs-on: ubuntu-latest
     timeout-minutes: 360
     # ONE strategy block. Both sides of the #297 merge grew their own, and a
@@ -553,5 +576,299 @@ jobs:
         if: always()
         with:
           name: hummingbird-rpms-${{ matrix.desktop }}
+          path: local-repo-hummingbird
+          if-no-files-found: warn
+
+  # The aarch64 leg (tunaOS#1755 §3). Deliberately a SEPARATE job, not an
+  # `arch` axis on `build`'s matrix -- every other aarch64 leg in this repo
+  # (build-fprintd-aarch64.yml; build-mock-runner.yml's build-and-push-aarch64)
+  # is its own job/workflow on a statically-declared ubuntu-24.04-arm runner,
+  # not a matrix-computed `runs-on:`, and mirroring that keeps this job
+  # readable as "the aarch64 build" rather than a conditional buried in one
+  # shared job. The cost is duplication: every step below is `build`'s step of
+  # the same name with the arch-specific bits swapped (image, mock-config,
+  # r2_path, cache keys, artifact names) -- see each step's comment for the
+  # delta. Steps that had nothing arch-specific to say are unchanged from
+  # `build` on purpose, so a diff between the two jobs is exactly the diff
+  # that matters.
+  #
+  # What this starts from: hummingbird/20251124-x86_64 is ~7673 packages after
+  # many months of daily 6-hour runs (docs/hummingbird-desktop-gap.md,
+  # workflow header above). hummingbird/20251124-aarch64 starts at zero. The
+  # same BUILD_RESERVE_MINUTES / partial-publish mechanism that let x86_64
+  # converge incrementally applies unchanged here, but the first several
+  # scheduled runs will publish a small increment each, the same way
+  # x86_64's early runs did -- there is no shortcut through that, and nothing
+  # about this job's design changes the wall-clock cost of rebuilding ~1248
+  # packages from an empty local repo.
+  build-aarch64:
+    needs: plan
+    # Skipped only when a manual dispatch explicitly asked for x86_64 alone
+    # (the default -- see the `arch` input above). The schedule trigger has no
+    # `inputs`, so `|| 'all'` resolves to 'all' and this job always runs
+    # alongside `build`.
+    if: ${{ (inputs.arch || 'all') != 'x86_64' }}
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        # Same desktops the x86_64 job fans out over, from the same plan job
+        # -- the package list is arch-neutral (RPM spec sources imported from
+        # Fedora Rawhide dist-git build for whatever architecture mock's
+        # chroot targets), so there is no separate aarch64 gap measurement to
+        # run or keep in sync.
+        desktop: ${{ fromJson(needs.plan.outputs.desktops) }}
+        target: [hummingbird]
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Resolve the target's R2 path from the package factory manifest
+        id: target
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          # Single source of truth, same as the x86_64 job's identically-named
+          # step -- but reads r2_path_aarch64, not r2_path. r2_path is read
+          # VERBATIM and unformatted by the x86_64 job, which already
+          # publishes the live leg; putting a `{arch}` placeholder in that
+          # same field and leaving the x86_64 step un-updated would have made
+          # it publish to the literal, wrong path "hummingbird/20251124-{arch}".
+          # A second field keeps that step untouched.
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import os, yaml
+          factory = yaml.safe_load(open("manifests/package-factory.yaml"))
+          target = factory["targets"][os.environ["TARGET"]]
+          print("r2_path=" + target["r2_path_aarch64"])
+          PY
+          echo "resolved r2_path for ${TARGET} (aarch64)"
+
+      - name: Install build tools
+        run: sudo apt-get update -q && sudo apt-get install -y -q podman createrepo-c rpm gpg gpgconf python3-yaml
+
+      - name: Pull mock runner
+        run: podman pull "${MOCK_RUNNER_IMAGE_AARCH64}"
+
+      - name: Configure R2 access
+        id: seed
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+        run: |
+          curl -fsSL https://rclone.org/install.sh | sudo bash
+          mkdir -p ~/.config/rclone
+          cat > ~/.config/rclone/rclone.conf <<EOF
+          [r2]
+          type = s3
+          provider = Cloudflare
+          access_key_id = ${R2_ACCESS_KEY_ID}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
+          endpoint = ${R2_ENDPOINT}
+          EOF
+          mkdir -p local-repo-hummingbird
+          # Seed from R2 so a resumed run does not rebuild what an earlier run
+          # already published. First run of this leg has nothing to seed --
+          # the || true is what makes that a no-op instead of a failure.
+          rclone copy "r2:${R2_BUCKET}/${{ steps.target.outputs.r2_path }}/" local-repo-hummingbird/ || true
+
+          seeded=$(find local-repo-hummingbird -name '*.rpm' ! -name '*.src.rpm' | wc -l)
+          echo "seeded ${seeded} RPM(s) from R2"
+          echo "seeded_rpms=${seeded}" >> "$GITHUB_OUTPUT"
+
+      - name: Select tiers
+        id: tiers
+        env:
+          IN_DESKTOP: ${{ matrix.desktop }}
+          IN_TIERS: ${{ env.TRIGGER_TIERS }}
+          IN_EXCLUDE: ${{ env.TRIGGER_EXCLUDE_TIERS }}
+        run: |
+          list=$(python3 scripts/select-desktop-tiers.py \
+            --manifest "${MANIFEST}" \
+            --gap-report docs/hummingbird-desktop-gap.json \
+            --desktop "${IN_DESKTOP}" \
+            --tiers "${IN_TIERS}" \
+            --exclude-tiers "${IN_EXCLUDE}")
+          echo "selected $(tr ',' '\n' <<< "$list" | wc -l) tiers: $list"
+          echo "list=$list" >> "$GITHUB_OUTPUT"
+          echo "slug=$(printf '%s' "$list" | sha256sum | cut -c1-12)" >> "$GITHUB_OUTPUT"
+
+      - name: Import Fedora Rawhide packaging for the selected tiers
+        run: |
+          TIER_ARGS=()
+          IFS=',' read -ra TIERS <<< "${{ steps.tiers.outputs.list }}"
+          for tier in "${TIERS[@]}"; do TIER_ARGS+=(--tier "${tier}"); done
+          python3 scripts/import-fedora-distgit.py \
+            --build-order "${MANIFEST}" \
+            "${TIER_ARGS[@]}" \
+            --branch rawhide \
+            --state hummingbird-imports.json \
+            --release-bump \
+            --jobs 4
+
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          # -aarch64 suffix: `build`'s x86_64 job uploads
+          # hummingbird-import-state-${{ matrix.desktop }} in the SAME
+          # workflow run, and actions/upload-artifact v4+ hard-fails a second
+          # upload of a name already used in the run.
+          name: hummingbird-import-state-${{ matrix.desktop }}-aarch64
+          path: hummingbird-imports.json
+          if-no-files-found: warn
+
+      - name: Cache the mock chroot and its dnf downloads
+        uses: actions/cache@v6
+        continue-on-error: true
+        with:
+          path: ${{ runner.temp }}/mock-cache
+          # aarch64 in the key itself, not just a different hashFiles input:
+          # this cache holds a real chroot tree, and an aarch64 root cache
+          # restored into an x86_64 mock run (or vice versa) is not a cache
+          # hit, it is a corrupt buildroot. hashFiles names the aarch64 cfg,
+          # so an edit to hummingbird-ci.cfg alone (no aarch64-specific
+          # change) does not invalidate this leg's cache for nothing.
+          key: hummingbird-mock-aarch64-${{ matrix.desktop }}-${{ hashFiles('mock/hummingbird-ci-aarch64.cfg') }}-${{ steps.tiers.outputs.slug }}-${{ github.run_id }}
+          restore-keys: |
+            hummingbird-mock-aarch64-${{ matrix.desktop }}-${{ hashFiles('mock/hummingbird-ci-aarch64.cfg') }}-${{ steps.tiers.outputs.slug }}-
+            hummingbird-mock-aarch64-${{ matrix.desktop }}-${{ hashFiles('mock/hummingbird-ci-aarch64.cfg') }}-
+
+      - name: Cache upstream source tarballs
+        uses: actions/cache@v6
+        continue-on-error: true
+        with:
+          path: .sources-cache
+          # Deliberately the SAME key as `build`'s (no arch component):
+          # upstream source tarballs are identical bytes regardless of which
+          # architecture rebuilds them, verified by the spec's own checksum
+          # before anything reads this cache (build-chain.sh, "Fetch dist-git
+          # lookaside sources"). Sharing it means this leg's first runs do not
+          # re-download everything the x86_64 runs already cached.
+          key: hummingbird-sources-${{ hashFiles('build-order-hummingbird-desktops.yml') }}-${{ github.run_id }}
+          restore-keys: |
+            hummingbird-sources-${{ hashFiles('build-order-hummingbird-desktops.yml') }}-
+            hummingbird-sources-
+
+      - name: Build tiers
+        id: build
+        env:
+          MOCK_CACHE_DIR: ${{ runner.temp }}/mock-cache
+          RPM_SOURCES_CACHE: ${{ github.workspace }}/.sources-cache
+          BUILD_RESERVE_MINUTES: "55"
+        run: |
+          IFS=',' read -ra TIERS <<< "${{ steps.tiers.outputs.list }}"
+          # --mock-config carries the -aarch64 suffix (hummingbird-ci-aarch64,
+          # config_opts['root'] in mock/hummingbird-ci-aarch64.cfg) and
+          # --image is passed explicitly and MUST be. build-chain.sh's own
+          # BUILD_IMAGE default is the x86_64 tag, and MOCK_RUNNER_IMAGE_AARCH64
+          # above is otherwise decorative -- nothing in the script reads an
+          # env var for this, only --image. build-fprintd-aarch64.yml hit this
+          # exact bug first: without --image, podman pulled the amd64 tag onto
+          # this arm64 runner and every package failed with "Exec format
+          # error" (that workflow's own "Build libfprint + fprintd" step
+          # comment records the failure).
+          ARGS=(--manifest "${MANIFEST}" --mock-config "${{ matrix.target }}-ci-aarch64"
+                --image "${MOCK_RUNNER_IMAGE_AARCH64}"
+                --local-repo "$PWD/local-repo-hummingbird" --jobs "$(nproc)")
+          if [[ "${TRIGGER_FORCE}" == "true" ]]; then ARGS+=(--force); fi
+          rc=0
+          failed_tiers=()
+          skipped_tiers=()
+          started=$(date +%s)
+          deadline=$(( started + (360 - BUILD_RESERVE_MINUTES) * 60 ))
+          for tier in "${TIERS[@]}"; do
+            if (( $(date +%s) >= deadline )); then
+              skipped_tiers+=("${tier}")
+              continue
+            fi
+            echo "::group::tier ${tier}"
+            ./scripts/build-chain.sh "${ARGS[@]}" --tier "${tier}" || {
+              rc=1
+              failed_tiers+=("${tier}")
+            }
+            echo "::endgroup::"
+          done
+          if (( rc )); then
+            echo "::error::tiers with failures: ${failed_tiers[*]}"
+          fi
+          if (( ${#skipped_tiers[@]} )); then
+            echo "::notice::ran out of time with ${#skipped_tiers[@]} tier(s) unattempted: ${skipped_tiers[*]}"
+            echo "TIERS_NOT_ATTEMPTED=${#skipped_tiers[@]}" >> "$GITHUB_ENV"
+          fi
+          exit "${rc}"
+
+      - name: Summarise progress
+        id: progress
+        if: ${{ !cancelled() }}
+        env:
+          SEEDED: ${{ steps.seed.outputs.seeded_rpms }}
+          TIERS: ${{ steps.tiers.outputs.list }}
+          BUILD_RESULT: ${{ steps.build.conclusion }}
+          DESKTOP: ${{ matrix.desktop }}
+        run: |
+          set -euo pipefail
+          now=$(find local-repo-hummingbird -name '*.rpm' ! -name '*.src.rpm' | wc -l)
+          seeded="${SEEDED:-0}"
+          built=$(( now - seeded ))
+          (( built < 0 )) && built=0
+          selected=$(tr ',' '\n' <<< "${TIERS}" | grep -c . || true)
+
+          remaining=$(python3 -c "
+          import yaml
+          m = yaml.safe_load(open('${MANIFEST}'))
+          print(sum(len(t['packages']) for t in m['tiers']))
+          ")
+
+          echo "built_rpms=${built}" >> "$GITHUB_OUTPUT"
+          {
+            echo "### ${DESKTOP} (aarch64): ${built} RPM(s) built this run"
+            echo
+            echo "| | |"
+            echo "|---|---:|"
+            echo "| Tiers selected | ${selected} |"
+            echo "| RPMs seeded from R2 | ${seeded} |"
+            echo "| RPMs after build | ${now} |"
+            echo "| **Built this run** | **${built}** |"
+            echo "| Packages in the full plan | ${remaining} |"
+            echo "| Tiers left unattempted (out of time) | ${TIERS_NOT_ATTEMPTED:-0} |"
+            echo "| \`Build tiers\` result | ${BUILD_RESULT} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ "${BUILD_RESULT}" == "skipped" ]]; then
+            echo "::error::Build tiers did not run (result: skipped) — an earlier step failed and took the build with it. Nothing will be published."
+          elif (( built == 0 )); then
+            echo "::warning::No new RPMs were produced. Either every selected tier was already satisfied, or the build failed before producing output. Nothing will be published."
+          fi
+
+      - name: Sign RPMs and publish
+        if: >-
+          ${{ !cancelled()
+             && (github.event_name == 'schedule' || inputs.publish)
+             && steps.build.conclusion != 'skipped'
+             && steps.progress.outputs.built_rpms != '0' }}
+        uses: crazy-max/ghaction-import-gpg@v7
+        id: import-gpg
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Publish signed rpm-md repository
+        if: >-
+          ${{ !cancelled()
+             && (github.event_name == 'schedule' || inputs.publish)
+             && steps.build.conclusion != 'skipped'
+             && steps.progress.outputs.built_rpms != '0' }}
+        run: |
+          echo "%_signature gpg" > ~/.rpmmacros
+          echo "%_gpg_name ${{ steps.import-gpg.outputs.keyid }}" >> ~/.rpmmacros
+          find local-repo-hummingbird -name '*.rpm' ! -name '*.src.rpm' -print0 | xargs -0 -r rpmsign --addsign
+          createrepo_c --update local-repo-hummingbird
+          rclone copy local-repo-hummingbird/ "r2:${R2_BUCKET}/${{ steps.target.outputs.r2_path }}/"
+          rclone copy public.gpg "r2:${R2_BUCKET}/${{ steps.target.outputs.r2_path }}/"
+
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: hummingbird-rpms-${{ matrix.desktop }}-aarch64
           path: local-repo-hummingbird
           if-no-files-found: warn

--- a/manifests/package-factory.yaml
+++ b/manifests/package-factory.yaml
@@ -70,10 +70,27 @@ targets:
     # this is what a probe would boot. It is recorded for provenance; see the
     # note above for why it is not yet trustworthy to probe against.
     probe_image: registry.fedoraproject.org/fedora:rawhide
-    architectures: [x86_64]
+    # aarch64 added for tunaOS#1755 §3: hummingbird's desktop flavors declare
+    # linux/arm64, but until this leg publishes something, every aarch64
+    # rebuild path 404s -- the only live repo was 20251124-x86_64. mock/
+    # hummingbird-ci-aarch64.cfg is the aarch64 counterpart of
+    # mock/hummingbird-ci.cfg (same shape as centos-stream-10-ci-aarch64.cfg
+    # is to centos-stream-10-ci.cfg); build-hummingbird-desktops.yml's
+    # build-aarch64 job runs it on ubuntu-24.04-arm against
+    # ghcr.io/tuna-os/mock-runner:centos-stream-10-aarch64.
+    architectures: [x86_64, aarch64]
     # Not under rpm/: this path is already published and holds the packages
     # the desktop builds have produced. Moving it would orphan them.
     r2_path: hummingbird/20251124-x86_64
+    # A second literal field, not a `{arch}` template substituted at read
+    # time: r2_path above is read verbatim by build-hummingbird-desktops.yml's
+    # `build` job (steps.target), unformatted, and that job publishes the
+    # already-live x86_64 leg -- templating r2_path itself and leaving that
+    # step un-updated would have made it publish to the literal path
+    # "hummingbird/20251124-{arch}" instead. r2_path_aarch64 is read only by
+    # the new `build-aarch64` job, so the established leg's step never has to
+    # change to accommodate it.
+    r2_path_aarch64: hummingbird/20251124-aarch64
     repository: rpm-md
     # Buildroot inputs only, never repositories on a produced image. Fedora
     # Rawhide supplies -devel headers and build backends Hummingbird has no

--- a/mock/Containerfile
+++ b/mock/Containerfile
@@ -80,6 +80,7 @@ COPY centos-stream-10-ci-gnome50.cfg /etc/mock/centos-stream-10-ci-gnome50.cfg
 # invisible to the build; it has to be baked in like the others.
 COPY fedora-44-ci.cfg /etc/mock/fedora-44-ci.cfg
 COPY hummingbird-ci.cfg /etc/mock/hummingbird-ci.cfg
+COPY hummingbird-ci-aarch64.cfg /etc/mock/hummingbird-ci-aarch64.cfg
 
 # mock refuses to run as root outright — even `mock --version` exits with
 # "Insufficient rights." It expects an unprivileged user in the mock group and

--- a/mock/hummingbird-ci-aarch64.cfg
+++ b/mock/hummingbird-ci-aarch64.cfg
@@ -1,0 +1,101 @@
+# aarch64 counterpart to hummingbird-ci.cfg — same shape, same repo
+# priorities, same interpreter/toolchain pins (perl/python/golang/mpich; see
+# hummingbird-ci.cfg for the measurements behind each one, which are arch-
+# neutral name/version splits and apply here unchanged). Only the base chroot
+# template and the mock root name differ, the same delta
+# centos-stream-10-ci-aarch64.cfg carries over centos-stream-10-ci.cfg.
+#
+# Built for tunaOS#1755 §3: hummingbird's desktop flavors declare linux/arm64
+# but the only rebuild repo that has ever existed is
+# repo.tunaos.org/hummingbird/20251124-x86_64/ — this config is what
+# build-hummingbird-desktops.yml's build-aarch64 job uses to start a real
+# hummingbird/20251124-aarch64 leg, seeded empty.
+#
+# Runs on a native aarch64 GitHub-hosted runner (ubuntu-24.04-arm) — mock
+# targets the architecture it is running on unless told otherwise, so no
+# explicit target_arch override is needed, only the base chroot template
+# below. The image is a separate tag, not a multi-arch manifest: see
+# mock-runner:centos-stream-10-aarch64 (mock/Containerfile via
+# build-mock-runner.yml's build-and-push-aarch64 job).
+#
+# The [hummingbird] repo below resolves $basearch to aarch64 automatically —
+# mock substitutes it from the chroot it is building, not from this file.
+# Whether Red Hat's public-hummingbird pulp content actually publishes
+# aarch64 packages under that path, and whether they are internally
+# consistent, is UNVERIFIED from this repo and is exactly the kind of gap
+# tunaOS#1755 §3 was filed about (the 2026-08-17 nightly saw
+# "public-hummingbird-aarch64-rpms" hand an x86_64 package to an aarch64
+# transaction). If that repo resolves to nothing usable for aarch64, this
+# priority-10 overlay simply contributes nothing and every package falls
+# through to fedora-rawhide at priority 99, same as any package Hummingbird
+# does not ship on any architecture — it does not break the build.
+include('/etc/mock/fedora-rawhide-aarch64.cfg')
+config_opts['root'] = 'hummingbird-ci-aarch64'
+config_opts['rpmbuild_networking'] = False
+config_opts['use_host_resolv'] = False
+config_opts['dnf.conf'] += """
+[local-build]
+name=Local Hummingbird build results
+baseurl=file:///local-repo/
+enabled=1
+gpgcheck=0
+priority=1
+
+[hummingbird]
+name=Hummingbird RPMs
+baseurl=https://packages.redhat.com/api/pulp-content/public-hummingbird/$basearch/
+gpgcheck=0
+enabled=1
+priority=10
+excludepkgs=golang1.26*
+
+[fedora-44-python]
+name=Fedora 44 - Python 3.14 build inputs only
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-44&arch=$basearch
+gpgcheck=0
+enabled=1
+priority=50
+includepkgs=python3-*,flit,pyproject-rpm-macros,pyproject-srpm-macros,python-rpm-macros,python-srpm-macros,tomcli
+
+[fedora-44-python-updates]
+name=Fedora 44 updates - Python 3.14 build inputs only
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f44&arch=$basearch
+gpgcheck=0
+enabled=1
+priority=50
+includepkgs=python3-*,flit,pyproject-rpm-macros,pyproject-srpm-macros,python-rpm-macros,python-srpm-macros,tomcli
+
+[fedora-44-perl]
+name=Fedora 44 - perl 5.42 build inputs only
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-44&arch=$basearch
+gpgcheck=0
+enabled=1
+priority=50
+includepkgs=perl-*
+
+[fedora-44-perl-updates]
+name=Fedora 44 updates - perl 5.42 build inputs only
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f44&arch=$basearch
+gpgcheck=0
+enabled=1
+priority=50
+includepkgs=perl-*
+
+[fedora-44-mpich]
+name=Fedora 44 - mpich only (hummingbird ships hdf5-mpich but no mpich)
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-44&arch=$basearch
+gpgcheck=0
+enabled=1
+priority=50
+includepkgs=mpich*
+
+[fedora-44-mpich-updates]
+name=Fedora 44 updates - mpich only (hummingbird ships hdf5-mpich but no mpich)
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f44&arch=$basearch
+gpgcheck=0
+enabled=1
+priority=50
+includepkgs=mpich*
+"""
+config_opts['plugin_conf']['bind_mount_enable'] = True
+config_opts['plugin_conf']['bind_mount_opts']['dirs'].append(('/local-repo', '/local-repo'))

--- a/tests/test_hummingbird_aarch64_leg.py
+++ b/tests/test_hummingbird_aarch64_leg.py
@@ -1,0 +1,390 @@
+"""The aarch64 leg of the Hummingbird desktop factory (tunaOS#1755 §3).
+
+hummingbird's desktop flavors declare linux/arm64, but the only rebuild repo
+that has ever existed is repo.tunaos.org/hummingbird/20251124-x86_64/ --
+every aarch64 path 404s. `build-aarch64` in build-hummingbird-desktops.yml is
+meant to be the smallest faithful mirror of the established x86_64 `build`
+job: same manifest, same tiers, same publish/cache mechanics, on a native
+aarch64 runner against an aarch64 mock chroot and mock-runner image.
+
+"Faithful mirror" is the thing worth pinning, not the exact text -- these
+tests check the properties that made the x86_64 job correct still hold for
+its aarch64 sibling, plus the properties that are aarch64-specific by
+necessity (a real --image override, a real aarch64 mock config, no name
+collisions between the two jobs' artifacts/caches in the same workflow run).
+
+The single most important one: build-fprintd-aarch64.yml already hit the
+failure mode this exists to prevent. build-chain.sh's own BUILD_IMAGE default
+is the x86_64 mock-runner tag, so a workflow that sets MOCK_RUNNER_IMAGE_*
+without ever passing --image pulls an amd64 image onto an arm64 runner and
+every package dies with "Exec format error" -- silently arch-mismatched, not
+a build failure that names itself.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+REPO = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO / ".github/workflows/build-hummingbird-desktops.yml"
+FACTORY = REPO / "manifests/package-factory.yaml"
+CONTAINERFILE = REPO / "mock/Containerfile"
+X86_CFG = REPO / "mock/hummingbird-ci.cfg"
+AARCH64_CFG = REPO / "mock/hummingbird-ci-aarch64.cfg"
+
+PUBLISH_STEPS = ("Sign RPMs and publish", "Publish signed rpm-md repository")
+
+
+def workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text())
+
+
+def job(name: str) -> dict:
+    return workflow()["jobs"][name]
+
+
+def steps(job_name: str) -> list:
+    return job(job_name)["steps"]
+
+
+def step(job_name: str, name: str) -> dict:
+    return next(s for s in steps(job_name) if s.get("name") == name)
+
+
+# ── the job exists and is shaped like a real aarch64 build ─────────────────
+
+
+def test_the_aarch64_job_exists():
+    assert "build-aarch64" in workflow()["jobs"]
+
+
+def test_it_runs_on_a_native_aarch64_runner():
+    """Not an emulated x86_64 runner -- ubuntu-24.04-arm is real hardware.
+
+    tunaOS's own reusable-build-image.yml already uses this runner label for
+    arm64 (measured fact behind this PR); build-fprintd-aarch64.yml and
+    build-mock-runner.yml's build-and-push-aarch64 job use the same label in
+    this repo.
+    """
+    assert job("build-aarch64")["runs-on"] == "ubuntu-24.04-arm"
+
+
+def test_it_shares_the_plan_jobs_desktop_list():
+    """The package list is arch-neutral, so there is no separate aarch64 gap
+    measurement to keep in sync -- both jobs fan out over the same desktops.
+    """
+    build_job = job("build-aarch64")
+    needs = build_job["needs"]
+    needs = [needs] if isinstance(needs, str) else needs
+    assert "plan" in needs
+    matrix = build_job["strategy"]["matrix"]
+    assert matrix["desktop"] == "${{ fromJson(needs.plan.outputs.desktops) }}"
+
+
+def test_one_desktop_failing_does_not_cancel_the_others():
+    assert job("build-aarch64")["strategy"]["fail-fast"] is False
+
+
+def test_the_target_axis_matches_the_x86_64_job():
+    """Same target name -- it is what makes hummingbird a covered target for
+    validate-package-factory.py's gate-coverage check (#139 defect class);
+    the aarch64 job must not accidentally invent a second target name that
+    check-gate-coverage.py has never heard of.
+    """
+    assert job("build-aarch64")["strategy"]["matrix"]["target"] == ["hummingbird"]
+    assert job("build")["strategy"]["matrix"]["target"] == ["hummingbird"]
+
+
+# ── the --image bug this whole file exists to prevent ──────────────────────
+
+
+def test_build_tiers_passes_image_explicitly():
+    """build-chain.sh's own default BUILD_IMAGE is the x86_64 tag.
+
+    Setting MOCK_RUNNER_IMAGE_AARCH64 in `env:` is not enough by itself --
+    build-chain.sh never reads that variable, only --image. Without it here,
+    podman pulls the amd64 image onto this arm64 runner and mock's rebuild
+    step fails with "Exec format error" on the very first package, exactly
+    as it did for build-fprintd-aarch64.yml before that workflow added the
+    same flag (see its own "Build libfprint + fprintd" step comment).
+    """
+    run = step("build-aarch64", "Build tiers")["run"]
+    assert "--image" in run, (
+        "Build tiers never passes --image; build-chain.sh will fall back to "
+        "its own x86_64 default and pull the wrong architecture"
+    )
+    assert "MOCK_RUNNER_IMAGE_AARCH64" in run, (
+        "--image is present but not wired to the aarch64 tag"
+    )
+
+
+def test_build_tiers_uses_the_aarch64_mock_config():
+    run = step("build-aarch64", "Build tiers")["run"]
+    assert "-ci-aarch64" in run, (
+        "Build tiers does not select an aarch64 mock config; it would reuse "
+        "hummingbird-ci (include('/etc/mock/fedora-rawhide-x86_64.cfg')) on "
+        "an aarch64 runner"
+    )
+
+
+def test_the_x86_64_jobs_build_step_is_unchanged():
+    """The whole point of a separate job: `build` should not need to know
+    aarch64 exists. Pin its --image-less invocation so a future edit cannot
+    accidentally entangle the two jobs' build steps.
+    """
+    run = step("build", "Build tiers")["run"]
+    assert "--image" not in run, (
+        "the x86_64 job now passes --image; if that was intentional, this "
+        "test (and its comment) is stale and should be updated, not deleted"
+    )
+
+
+# ── no collisions between two jobs in the same workflow run ────────────────
+
+
+def test_every_aarch64_artifact_name_is_unique():
+    """Two jobs uploading the same artifact name in one workflow run is a
+    hard failure in upload-artifact v4+ -- and `build` already uploads
+    hummingbird-import-state-<desktop> and hummingbird-rpms-<desktop> in the
+    SAME run whenever both jobs execute (the default schedule case).
+    """
+    x86_64_names = {
+        s["with"]["name"]
+        for s in steps("build")
+        if str(s.get("uses", "")).startswith("actions/upload-artifact")
+    }
+    aarch64_names = {
+        s["with"]["name"]
+        for s in steps("build-aarch64")
+        if str(s.get("uses", "")).startswith("actions/upload-artifact")
+    }
+    assert aarch64_names, "the aarch64 job uploads nothing at all"
+    for name in aarch64_names:
+        assert "matrix.desktop" in name, (
+            f"artifact {name!r} is not per-desktop; concurrent desktop jobs "
+            "would collide on it"
+        )
+        assert "aarch64" in name, (
+            f"artifact {name!r} does not name its architecture and will "
+            "collide with the x86_64 job's artifact of the same desktop"
+        )
+    # Literal collision check: substitute nothing (the desktop expression is
+    # identical in both jobs), so a textual overlap here is a real overlap.
+    assert not (x86_64_names & aarch64_names), (
+        f"identical artifact name(s) in both jobs: {x86_64_names & aarch64_names}"
+    )
+
+
+def test_the_mock_cache_key_is_scoped_to_this_architecture():
+    """A chroot cache is real filesystem content built for one architecture.
+
+    Restoring an aarch64 mock/tar into an x86_64 rebuild (or the reverse) is
+    not a cache hit, it is a corrupt buildroot -- the key must not be
+    shareable across the two jobs.
+    """
+    cache_step = next(
+        s
+        for s in steps("build-aarch64")
+        if str(s.get("uses", "")).startswith("actions/cache")
+        and s["with"]["path"] == "${{ runner.temp }}/mock-cache"
+    )
+    key = cache_step["with"]["key"]
+    assert "aarch64" in key
+    assert "hummingbird-ci-aarch64.cfg" in key, (
+        "the mock-chroot cache key does not hash the aarch64 mock config, so "
+        "an aarch64-only config edit would not invalidate this leg's cache"
+    )
+    x86_64_key = step("build", "Cache the mock chroot and its dnf downloads")["with"]["key"]
+    assert key != x86_64_key
+
+
+def test_cache_steps_cannot_fail_the_aarch64_job():
+    """Same INCIDENT-repo-wipe-gnome.md-adjacent lesson the x86_64 job
+    learned the hard way (test_hummingbird_publish_requires_a_build.py):
+    without continue-on-error, a rejected cache key silently skips `Build
+    tiers` while the publish steps still run.
+    """
+    for name in (
+        "Cache the mock chroot and its dnf downloads",
+        "Cache upstream source tarballs",
+    ):
+        assert step("build-aarch64", name).get("continue-on-error") is True
+
+
+# ── the publish guard applies here too ──────────────────────────────────────
+
+
+@pytest.mark.parametrize("name", PUBLISH_STEPS)
+def test_aarch64_publish_requires_the_build_step_to_have_run(name):
+    condition = step("build-aarch64", name)["if"]
+    assert "steps.build.conclusion != 'skipped'" in condition
+    assert "steps.build.conclusion == 'success'" not in condition
+
+
+@pytest.mark.parametrize("name", PUBLISH_STEPS)
+def test_aarch64_publish_refuses_an_empty_result(name):
+    assert "steps.progress.outputs.built_rpms != '0'" in step("build-aarch64", name)["if"]
+
+
+def test_aarch64_progress_runs_even_when_the_build_failed():
+    assert "!cancelled()" in step("build-aarch64", "Summarise progress")["if"]
+
+
+# ── the arch input gates which job(s) a manual dispatch runs ───────────────
+
+
+def test_a_bare_dispatch_builds_x86_64_only():
+    """`arch` defaults to x86_64 so a human debugging one desktop/tier does
+    not also kick off an unrelated six-hour aarch64 run.
+    """
+    inputs = workflow()[True]["workflow_dispatch"]["inputs"]
+    assert inputs["arch"]["default"] == "x86_64"
+
+
+def test_the_scheduled_run_builds_both_architectures():
+    """No `inputs` exist on the schedule trigger, so both jobs' `if:` must
+    resolve to true when `inputs.arch` is absent, not just when it is
+    'x86_64'/'aarch64' -- the `|| 'all'` fallback is what does that.
+    """
+    assert "|| 'all'" in job("build")["if"]
+    assert "|| 'all'" in job("build-aarch64")["if"]
+
+
+def test_the_two_jobs_if_conditions_are_not_both_skippable_by_the_same_input():
+    """arch: x86_64 must not skip both jobs, and arch: aarch64 must not skip
+    both jobs -- each condition should name the OTHER architecture as its
+    skip trigger, not itself.
+    """
+    assert "aarch64" in job("build")["if"]
+    assert "x86_64" not in job("build")["if"].replace("aarch64", "")
+    assert "x86_64" in job("build-aarch64")["if"]
+
+
+# ── the mock-runner image this job depends on ───────────────────────────────
+
+
+def test_the_aarch64_mock_runner_image_is_a_distinct_tag():
+    """Not a multi-arch manifest fused under :centos-stream-10 --
+    build-mock-runner.yml's build-and-push-aarch64 job pushes this as its
+    own tag, mirroring the reasoning in that job's own comment: mock's chroot
+    content is pulled per-run via use_bootstrap_image, so there is no
+    correctness reason to fuse the two, and keeping them separate means an
+    aarch64-only rebuild never touches the x86_64 image other workflows
+    depend on.
+    """
+    env = workflow()["env"]
+    assert env["MOCK_RUNNER_IMAGE_AARCH64"] == "ghcr.io/tuna-os/mock-runner:centos-stream-10-aarch64"
+    assert env["MOCK_RUNNER_IMAGE_AARCH64"] != env["MOCK_RUNNER_IMAGE"]
+
+
+def test_pull_mock_runner_step_pulls_the_aarch64_tag():
+    run = step("build-aarch64", "Pull mock runner")["run"]
+    assert "MOCK_RUNNER_IMAGE_AARCH64" in run
+
+
+# ── the manifest and mock config this job reads ─────────────────────────────
+
+
+def test_package_factory_declares_hummingbird_aarch64():
+    factory = yaml.safe_load(FACTORY.read_text())
+    hummingbird = factory["targets"]["hummingbird"]
+    assert "aarch64" in hummingbird["architectures"]
+    assert "x86_64" in hummingbird["architectures"], (
+        "aarch64 must be ADDED, not swapped in for x86_64 -- the established "
+        "leg is still live and must keep publishing"
+    )
+    assert "r2_path_aarch64" in hummingbird, (
+        "no separate field for the aarch64 leg's R2 path"
+    )
+
+
+def test_the_established_leg_r2_path_is_unchanged_and_unformatted():
+    """r2_path itself must stay the exact literal path it always was.
+
+    build's own R2-path step reads it verbatim, with no .format() call (see
+    test_the_resolve_r2_path_steps_agree_with_the_manifest) -- so this field
+    can never contain a placeholder like `{arch}` without breaking the
+    already-live x86_64 publish path.
+    """
+    factory = yaml.safe_load(FACTORY.read_text())
+    hummingbird = factory["targets"]["hummingbird"]
+    assert hummingbird["r2_path"] == "hummingbird/20251124-x86_64"
+    assert "{" not in hummingbird["r2_path"]
+
+
+def test_the_aarch64_r2_path_is_the_expected_sibling_path():
+    factory = yaml.safe_load(FACTORY.read_text())
+    hummingbird = factory["targets"]["hummingbird"]
+    assert hummingbird["r2_path_aarch64"] == "hummingbird/20251124-aarch64"
+
+
+def test_the_resolve_r2_path_steps_agree_with_the_manifest():
+    x86_64_run = step("build", "Resolve the target's R2 path from the package factory manifest")["run"]
+    aarch64_run = step("build-aarch64", "Resolve the target's R2 path from the package factory manifest")["run"]
+    assert 'target["r2_path"]' in x86_64_run
+    assert '.format(' not in x86_64_run, (
+        "the x86_64 job's R2-path step must read r2_path verbatim -- it "
+        "already publishes the live leg, and no `{arch}` template lives in "
+        "that field for it to format"
+    )
+    assert 'target["r2_path_aarch64"]' in aarch64_run, (
+        "the aarch64 job's R2-path step does not read the aarch64-specific "
+        "field"
+    )
+
+
+def test_the_aarch64_mock_config_exists():
+    assert AARCH64_CFG.exists()
+
+
+def test_the_aarch64_mock_config_targets_the_aarch64_chroot_template():
+    text = AARCH64_CFG.read_text()
+    assert "include('/etc/mock/fedora-rawhide-aarch64.cfg')" in text, (
+        "this is the load-bearing line: hummingbird-ci.cfg includes "
+        "fedora-rawhide-x86_64.cfg, and copying that verbatim onto an "
+        "aarch64 runner would build an x86_64 chroot inside qemu instead of "
+        "a native aarch64 one"
+    )
+    assert "config_opts['root'] = 'hummingbird-ci-aarch64'" in text, (
+        "the mock config's own root name must match the "
+        "--mock-config hummingbird-ci-aarch64 the workflow passes it"
+    )
+
+
+def test_the_aarch64_mock_config_keeps_the_same_repo_priorities():
+    """The perl/python/golang/mpich pins are arch-neutral name/version
+    splits (measured in hummingbird-ci.cfg's own header) and must carry over
+    unchanged, or every desktop tier hits the same failures on aarch64 that
+    hummingbird-ci.cfg was written to fix on x86_64.
+    """
+    x86_64_lines = [
+        line
+        for line in X86_CFG.read_text().splitlines()
+        if line.startswith(("priority=", "includepkgs=", "excludepkgs=", "[")
+        )
+    ]
+    aarch64_lines = [
+        line
+        for line in AARCH64_CFG.read_text().splitlines()
+        if line.startswith(("priority=", "includepkgs=", "excludepkgs=", "[")
+        )
+    ]
+    assert aarch64_lines == x86_64_lines, (
+        "the aarch64 mock config's repo sections have drifted from "
+        "hummingbird-ci.cfg's; only the base chroot include and root name "
+        "should differ"
+    )
+
+
+def test_the_mock_runner_image_bakes_in_the_aarch64_config():
+    """A fallback for running the image by hand (build-chain.sh always
+    overlays the checked-out mock/ directory at runtime, so this is not load-
+    bearing for CI) -- but every other aarch64-capable config in mock/ is
+    baked in, and a silently-stale image is exactly the kind of thing #176
+    was about.
+    """
+    text = CONTAINERFILE.read_text()
+    assert "COPY hummingbird-ci-aarch64.cfg /etc/mock/hummingbird-ci-aarch64.cfg" in text


### PR DESCRIPTION
## What this does

hummingbird's desktop flavors declare `linux/arm64`, but the only rebuild repo that has ever existed is `repo.tunaos.org/hummingbird/20251124-x86_64/` — every aarch64 path 404s. tunaOS#1755 §3 chose **build** over drop. This gives the package factory an aarch64 leg.

Adds `build-aarch64`, a new job in `.github/workflows/build-hummingbird-desktops.yml`, as the smallest faithful mirror of the established `build` (x86_64) job:

| | x86_64 (`build`) | aarch64 (`build-aarch64`, new) |
|---|---|---|
| Runner | `ubuntu-latest` | `ubuntu-24.04-arm` |
| Mock config | `mock/hummingbird-ci.cfg` (`include('/etc/mock/fedora-rawhide-x86_64.cfg')`) | `mock/hummingbird-ci-aarch64.cfg` (new — `include('/etc/mock/fedora-rawhide-aarch64.cfg')`, same repo priorities/pins otherwise, byte-identical) |
| mock-runner image | `ghcr.io/tuna-os/mock-runner:centos-stream-10` | `ghcr.io/tuna-os/mock-runner:centos-stream-10-aarch64` (already exists, see verification below) |
| Manifest / tiers | `build-order-hummingbird-desktops.yml` | **same file** — the package list is arch-neutral (Fedora Rawhide dist-git specs), so there is no separate aarch64 gap measurement to run |
| R2 path | `hummingbird/20251124-x86_64` (`r2_path`) | `hummingbird/20251124-aarch64` (new `r2_path_aarch64` field, see below) |
| Cache/publish/partial-publish mechanics | unchanged | identical, same `BUILD_RESERVE_MINUTES: "55"` reserve-budget guard |

It's a **separate job**, not an `arch` axis on the existing matrix — matching every other aarch64 leg already in this repo (`build-fprintd-aarch64.yml`; `build-mock-runner.yml`'s `build-and-push-aarch64` job). That also means `build`'s steps, cache keys, and R2-path resolution are **untouched**: every existing hummingbird test (`test_hummingbird_cache_key_is_valid.py`, `test_hummingbird_throughput.py`, `test_hummingbird_publish_requires_a_build.py`, `test_hummingbird_uses_tideforge_caching.py`) keeps passing unmodified against the unmodified job.

A manual `workflow_dispatch` defaults to `x86_64` only (new `arch` input: `x86_64`/`aarch64`/`all`), so debugging one desktop/tier doesn't also kick off an unrelated six-hour aarch64 run. The scheduled run (no inputs) always builds **both** — `(inputs.arch || 'all') != '<other arch>'` on each job's own `if:`.

## What I verified (not assumed)

- **mock-runner has an aarch64 image, live, right now.** Queried the GHCR registry API directly (not from a workflow file — from the actual registry):
  - `GET /v2/tuna-os/mock-runner/tags/list` → `centos-stream-10-aarch64` is present, along with per-commit `centos-stream-10-aarch64-<sha>` tags going back through the mock-runner's history.
  - Fetched that tag's manifest → config blob digest `sha256:71ed3230…`; the config blob itself reports `"architecture": "arm64", "os": "linux"`.
  - So the prerequisite this PR would otherwise have needed to ship (build the mock-runner aarch64 image) **already exists** — `build-mock-runner.yml`'s `build-and-push-aarch64` job (on `ubuntu-24.04-arm`) has been publishing it as its own tag, not fused into a multi-arch manifest.
- **`/etc/mock/fedora-rawhide-aarch64.cfg` exists upstream.** `mock/hummingbird-ci.cfg`'s one arch-bound line is `include('/etc/mock/fedora-rawhide-x86_64.cfg')`. Confirmed the aarch64 counterpart is a real file mock-core-configs ships: fetched `raw.githubusercontent.com/rpm-software-management/mock/main/mock-core-configs/etc/mock/fedora-rawhide-aarch64.cfg` (200, real content: `target_arch = 'aarch64'`, `include('templates/fedora-rawhide.tpl')`). Also consistent with this repo's own precedent — `mock/centos-stream-10-ci-aarch64.cfg` already does the equivalent `include('/etc/mock/epel-10-aarch64.cfg')` successfully.
- **`--image` is not optional.** `scripts/build-chain.sh`'s own `BUILD_IMAGE` default (line 128) is the x86_64 tag; nothing in the script reads a `MOCK_RUNNER_IMAGE*` env var — only `--image`. `build-hummingbird-desktops.yml`'s existing `Build tiers` step for x86_64 never passes `--image` (relying on the script's own matching default), which would silently pull the amd64 image onto the new arm64 runner. `build-fprintd-aarch64.yml` hit exactly this bug first and documents it in its own "Build libfprint + fprintd" step comment ("Exec format error"). `build-aarch64`'s `Build tiers` step passes `--image "${MOCK_RUNNER_IMAGE_AARCH64}"` explicitly, plus `--mock-config hummingbird-ci-aarch64`.
- **`build-chain.sh` has no other arch assumptions** — grepped it for `x86_64`/`aarch64`/hardcoded arch; the only arch-bound thing anywhere in the whole pipeline is the two `include()` lines above and the (pre-existing, per-target) mock-config name.
- **Full local test suite passes**: `883 passed, 1 skipped` (`pytest tests/`), including `scripts/validate-package-factory.py` and `scripts/validate-target-queues.py` against the edited manifest, and the new `tests/test_hummingbird_aarch64_leg.py` (28 tests) written in the style of the existing `test_hummingbird_*` files.

## The one thing I could not verify from here

Whether Red Hat's public-hummingbird pulp content (`packages.redhat.com/.../public-hummingbird/$basearch/`, the priority-10 overlay in `hummingbird-ci.cfg`) actually publishes usable aarch64 content. Per the measured facts behind tunaOS#1755 §3, the 2026-08-17 nightly saw `public-hummingbird-aarch64-rpms` (a different repo, in tunaOS's own build config, not this one) hand an x86_64 `sassc` package into an aarch64 transaction alongside a missing-`libdaemon` failure — i.e. whatever that repo is, it isn't self-consistent for aarch64. `mock/hummingbird-ci-aarch64.cfg` says explicitly in its own header that this is unverified and, if it resolves to nothing usable, the priority-10 overlay simply contributes nothing and every package falls through to `fedora-rawhide` at priority 99 — the same as any package Hummingbird doesn't ship on any architecture. It does not block the build; it may just mean less ABI-pinning value from Hummingbird's own aarch64 RPMs than the x86_64 leg gets, which will only be visible once real tiers run.

## Prerequisite vs. included

- **Included**: the aarch64 mock config, the workflow job, the manifest's `r2_path_aarch64`, tests.
- **Prerequisite that already existed** (verified above, not shipped by this PR): the `mock-runner:centos-stream-10-aarch64` image and `ubuntu-24.04-arm` runner availability.
- **Deliberately NOT included**: any change to tuna-os/tunaOS's build-config or manifests. The repo-pointer flip to `hummingbird/20251124-aarch64` for the actual gnome/linux-arm64 (etc.) builds belongs in that repo, and only makes sense **after** this path has real content — flipping it today would just trade one set of 404s/broken-repo errors for an empty-repo error. Also did not touch `.github/workflows/build-hummingbird-distributed.yml` (a separate, `workflow_dispatch`-only, auto-generated alternative pipeline) — out of scope for the live cron path this PR targets.

## Convergence: be honest about the timeline

x86_64 (`hummingbird/20251124-x86_64`) is ~7,673 packages after many months of daily 6-hour runs — it grew by 503 packages in the 2026-08-16 run alone, and that's with a mature, already-populated seed. `hummingbird/20251124-aarch64` starts at **zero**. The `BUILD_RESERVE_MINUTES: "55"` reserve-budget mechanism that let x86_64 publish partial progress every run applies unchanged here, so the first several scheduled runs will each publish a small increment (however many tiers fit in ~5 hours from a cold local repo, per desktop, per run) — not a full desktop, and not fast. Nothing about this job's design changes the wall-clock cost of rebuilding ~1,248 packages from nothing; it only makes that rebuild possible and incremental instead of impossible.

This also **doubles** the daily draw on the "5 desktop jobs × 6 hours" resource the workflow's own header comment already flags against the org's 20-concurrent-job ceiling (10 jobs instead of 5, once both architectures run on the same schedule). That's a real cost, not a free addition — flagging it explicitly rather than burying it.

## Follow-up (not in this PR)

1. Once `hummingbird/20251124-aarch64` has real content (probably after some number of days of scheduled runs), flip tuna-os/tunaOS's build-config to point gnome/linux-arm64 (and the other hummingbird desktop flavors) at it.
2. A `latest-aarch64` alias/symlink, mirroring whatever `latest-x86_64` does today (measured fact: `latest-aarch64` currently 404s same as everything else aarch64).
3. Revisit whether `public-hummingbird`'s aarch64 content is usable at all (see "one thing I could not verify" above) — worth an explicit measurement once real tiers have run and logged what `[hummingbird]` priority-10 actually resolved during real builds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_