### PR TITLE
fix(gap-drift): install zstandard; the Rawhide reference primary is .zst

### DIFF
--- a/.github/workflows/hummingbird-gap-drift.yml
+++ b/.github/workflows/hummingbird-gap-drift.yml
@@ -57,7 +57,10 @@ jobs:
           python-version: '3.14'
 
       - if: steps.drift.outputs.drifted == 'true'
-        run: pip install --disable-pip-version-check PyYAML
+        # zstandard: the Fedora Rawhide reference primary.xml is .zst; the
+        # measure script's decompress() imports it lazily. First scheduled run
+        # (32017727489) died on exactly this import.
+        run: pip install --disable-pip-version-check PyYAML zstandard
 
       - name: Re-measure the gap against live upstream
         if: steps.drift.outputs.drifted == 'true'

--- a/tests/test_gap_drift_workflow_installs_what_the_script_imports.py
+++ b/tests/test_gap_drift_workflow_installs_what_the_script_imports.py
@@ -1,0 +1,62 @@
+"""The drift workflow must install every module the measure script imports.
+
+measure-hummingbird-gap.py imports `zstandard` lazily, inside decompress(),
+and only when a repository's primary index is .zst — which the Fedora Rawhide
+reference always is.  A workflow that installs only PyYAML passes the drift
+gate, downloads repomd, and then dies on the import: run 32017727489, the
+detector's first scheduled firing, failed exactly there in 19 seconds.
+
+Lazy imports dodge module-level import scans, so this test reads the script
+for its full import surface (top-level and function-local) and asserts the
+workflow's pip install covers every non-stdlib name.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "measure-hummingbird-gap.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "hummingbird-gap-drift.yml"
+
+# import name -> pip distribution name
+NON_STDLIB = {"yaml": "PyYAML", "zstandard": "zstandard"}
+
+
+def script_imports() -> set[str]:
+    names = set()
+    for match in re.finditer(
+        r"^\s*(?:import\s+(\w+)|from\s+(\w+)\s+import)",
+        SCRIPT.read_text(encoding="utf-8"),
+        re.M,
+    ):
+        names.add(match.group(1) or match.group(2))
+    return names
+
+
+def test_script_import_surface_is_known() -> None:
+    """A new non-stdlib import must be added to NON_STDLIB (and the workflow)."""
+    unknown = {
+        name
+        for name in script_imports()
+        if name not in NON_STDLIB and name not in sys.stdlib_module_names
+    }
+    assert not unknown, (
+        f"measure-hummingbird-gap.py imports {sorted(unknown)} which this test "
+        "does not classify; add each to NON_STDLIB and to the drift workflow's "
+        "pip install"
+    )
+
+
+def test_workflow_installs_every_non_stdlib_import() -> None:
+    body = WORKFLOW.read_text(encoding="utf-8")
+    needed = {NON_STDLIB[n] for n in script_imports() if n in NON_STDLIB}
+    install_lines = [l for l in body.splitlines() if "pip install" in l]
+    assert install_lines, "drift workflow has no pip install step"
+    for dist in sorted(needed):
+        assert any(dist in line for line in install_lines), (
+            f"drift workflow's pip install is missing {dist}; the measure "
+            "script imports it (possibly lazily) and the run will die at that "
+            "import, as run 32017727489 did for zstandard"
+        )


### PR DESCRIPTION
## What

The Hummingbird Gap Drift detector's first scheduled run ([32017727489](https://github.com/tuna-os/tunaos-packages/actions/runs/32017727489)) passed the revision gate — upstream had genuinely published a new repomd revision since this morning's measurement — and then died in 19 seconds:

```
File "scripts/measure-hummingbird-gap.py", line 78, in decompress
  import zstandard
ModuleNotFoundError: No module named 'zstandard'
```

The import is lazy (inside `decompress()`, only reached for `.zst` indexes), which is exactly why installing only PyYAML looked sufficient: the Fedora Rawhide reference primary is always `.zst`, so every *real* re-measure hits it while the gate-only path never does.

## Fix

- Add `zstandard` to the workflow's pip install (one line).
- New test `test_gap_drift_workflow_installs_what_the_script_imports.py`: reads the measure script's **full** import surface — top-level and function-local, so lazy imports can't dodge it — and asserts the workflow's pip install covers every non-stdlib module. A future lazy import fails the suite instead of the 09:15 UTC cron.

Full suite: **890 passed, 1 skipped.**

Once merged, the next scheduled firing (or a manual dispatch) will complete the re-measure that upstream's new revision triggered and open the adds/drops PR — the detector's first real output.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_