### PR TITLE
feat(rfc011): declare Fedora XFCE gap contract

### DIFF
--- a/.github/workflows/build-xfce-fedora.yml
+++ b/.github/workflows/build-xfce-fedora.yml
@@ -39,6 +39,10 @@ on:
   workflow_dispatch:
 
 env:
+  # Read by validate-package-factory.py. Keeping the target identity beside
+  # its real build prevents this native-spec gate from becoming invisible to
+  # the factory contract merely because it is not a Tideforge matrix cell.
+  FACTORY_TARGET: fedora
   R2_BUCKET: bluefin
   # Separate from the EL10 tree (xfce/10-stream-x86_64) — different dist tag,
   # different ABI, must not be mixed.

--- a/manifests/package-factory.yaml
+++ b/manifests/package-factory.yaml
@@ -120,6 +120,25 @@ targets:
     # build of yet; Fedora 44 supplies the Python namespace at the target's
     # own ABI (3.14, where Rawhide is 3.15).
     build_repositories: [fedora-rawhide, fedora-44-python]
+  fedora:
+    # RFC 011 Phase 1's smallest native-RPM conversion. This is the existing
+    # Fedora 44 XFCE Wayland build, made explicit so it can be measured and
+    # gated like every other factory target instead of living outside the
+    # factory contract. Fedora 44 remains the target itself; it is not the
+    # Hummingbird buildroot fallback.
+    status: supported
+    format: rpm
+    buildroot: fedora-44
+    architectures: [x86_64]
+    r2_path: xfce/44-x86_64
+    repository: rpm-md
+    probe_image: registry.fedoraproject.org/fedora:44
+    build_repositories: [fedora-44]
+    gap_measurement:
+      roots_manifest: manifests/xfce-fedora.yaml
+      target_index: https://dl.fedoraproject.org/pub/fedora/linux/releases/44/Everything/x86_64/os/
+      reference_index: https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/
+      source_reference_index: https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/source/tree/
   opensuse-tumbleweed:
     status: scaffold
     format: rpm

--- a/manifests/xfce-fedora.yaml
+++ b/manifests/xfce-fedora.yaml
@@ -1,0 +1,20 @@
+# RFC 011 Phase 1 input for the Fedora 44 XFWL4 build order.
+#
+# Shadow mode only: build-order-xfce-fedora.yml remains the executed,
+# evidence-backed three-package order until a measured run has reproduced it
+# exactly or its differences are explained in the conversion PR.
+schema: 1
+membership: runtime
+target:
+  id: fedora-44-x86_64
+  baseurl: https://dl.fedoraproject.org/pub/fedora/linux/releases/44/Everything/x86_64/os/
+  r2_path: xfce/44-x86_64
+  dist: .fc44
+  reference: fedora-rawhide
+
+desktops:
+  xfce:
+    release: "4.21"
+    sources: [{local: src/xfce-wayland}]
+    required_packages: [xfconf, libxfce4ui, xfwl4]
+    install_packages: [xfconf, libxfce4ui, xfwl4]

--- a/scripts/validate-package-factory.py
+++ b/scripts/validate-package-factory.py
@@ -34,7 +34,7 @@ def gate_targets(workflows: list[Path]) -> set[str]:
         # enter the set as a target literally called "matrix.target".
         for match in re.finditer(r"--target\s+\"?([a-z0-9-]+)\b", text):
             exercised.add(match.group(1))
-        for match in re.finditer(r"^\s*target:\s*([a-z0-9-]+)\s*$", text, re.MULTILINE):
+        for match in re.finditer(r"^\s*(?:target|FACTORY_TARGET):\s*([a-z0-9-]+)\s*$", text, re.MULTILINE):
             exercised.add(match.group(1))
         # A matrix axis exercises its targets just as much as an include list
         # does -- `target: [hummingbird]` or a block list under `target:`. Only
@@ -95,7 +95,7 @@ def main() -> None:
         seen_upstreams.add(upstream_id)
 
     targets = data.get("targets", {})
-    required = {"el10", "ubuntu", "debian", "hummingbird", "opensuse-tumbleweed", "arch"}
+    required = {"el10", "ubuntu", "debian", "hummingbird", "fedora", "opensuse-tumbleweed", "arch"}
     if set(targets) != required:
         fail(f"targets must be exactly {sorted(required)}")
     for target_id, target in targets.items():
@@ -110,7 +110,7 @@ def main() -> None:
         # else's distribution rather than a TunaOS repository, and its path is
         # already published with the desktop packages in it. Moving it under
         # rpm/ to satisfy this check would orphan them.
-        if not target["r2_path"].startswith(("rpm/", "apt/", "pacman/", "hummingbird/")):
+        if not target["r2_path"].startswith(("rpm/", "apt/", "pacman/", "hummingbird/", "xfce/")):
             fail(f"{target_id}: r2_path has an unsupported namespace")
         if not all(arch in {"x86_64", "aarch64", "amd64", "arm64"} for arch in target["architectures"]):
             fail(f"{target_id}: unsupported architecture")
@@ -133,6 +133,7 @@ def main() -> None:
             # would make hummingbird look uncovered when it is the busiest
             # target in the repository.
             workflow_directory / "build-hummingbird-desktops.yml",
+            workflow_directory / "build-xfce-fedora.yml",
         ]
     check_gate_coverage(set(targets), workflows)
 

--- a/tests/test_catalog_completeness.py
+++ b/tests/test_catalog_completeness.py
@@ -32,18 +32,6 @@ FACTORY = ROOT / "manifests" / "package-factory.yaml"
 # to prevent.
 KNOWN_ORPHAN_RECIPES = {"cpptrace-devel", "gtkgreet", "iio-niri"}
 
-# Targets a family builds for that manifests/package-factory.yaml does not
-# declare. The bootstrap found exactly one: the XFWL4 Fedora validation
-# family (build-order-xfce-fedora.yml) builds fedora-44-x86_64 and publishes
-# to xfce/44-x86_64 — but the factory contract cannot simply gain a `fedora`
-# entry, because scripts/validate-package-factory.py rightly requires every
-# declared target to have a Tideforge gate cell (#139), and this family is
-# native-spec with no Tideforge involvement. Resolving the mismatch —
-# a gate cell + declaration, or retiring the family — is Phase 1 work; until
-# then the gap stays visible here and may only shrink, never grow.
-KNOWN_UNDECLARED_TARGETS = {"fedora"}
-
-
 def _load_builder():
     spec = importlib.util.spec_from_file_location(
         "build_catalog", ROOT / "scripts" / "build-catalog.py")
@@ -78,25 +66,15 @@ def test_catalog_matches_regeneration() -> None:
 
 
 def test_targets_are_declared_in_the_factory_contract() -> None:
-    """A catalog entry may only name targets package-factory.yaml declares.
-    This is the rule that surfaced the fedora-44 gap at bootstrap: the XFWL4
-    Fedora family had been publishing to a target the contract never named.
-    """
+    """A catalog entry may only name targets package-factory.yaml declares."""
     declared = set(yaml.safe_load(
         FACTORY.read_text(encoding="utf-8"))["targets"])
-    seen_undeclared: set[str] = set()
     for p in _catalog()["packages"]:
         rogue = set(p["targets"]) - declared
-        seen_undeclared |= rogue & KNOWN_UNDECLARED_TARGETS
-        rogue -= KNOWN_UNDECLARED_TARGETS
         assert not rogue, (
             f"{p['name']} ({p['family']}) names undeclared target(s) "
             f"{sorted(rogue)}; declare them in manifests/package-factory.yaml "
             f"or fix the order/queue")
-    healed = KNOWN_UNDECLARED_TARGETS - seen_undeclared
-    assert not healed, (
-        f"{sorted(healed)} no longer appear as undeclared targets — remove "
-        f"them from KNOWN_UNDECLARED_TARGETS so the allowlist only shrinks")
 
 
 def test_executed_packages_have_recorded_provenance() -> None:

--- a/tests/test_measure_target_gap.py
+++ b/tests/test_measure_target_gap.py
@@ -28,6 +28,13 @@ def test_hummingbird_gap_contract_is_complete() -> None:
     assert measurement["reference_index"].startswith("https://")
 
 
+def test_fedora_xfce_gap_contract_is_complete() -> None:
+    measurement = gap.target_measurement(factory(), "fedora")
+    assert measurement["roots_manifest"] == "manifests/xfce-fedora.yaml"
+    assert "releases/44" in measurement["target_index"]
+    assert "rawhide" in measurement["reference_index"]
+
+
 def test_target_without_gap_contract_is_not_silently_measured() -> None:
     with pytest.raises(SystemExit, match="no gap_measurement contract"):
         gap.target_measurement(factory(), "el10")


### PR DESCRIPTION
## RFC 011 Phase 1 — next target conversion

Makes the existing Fedora 44 XFCE Wayland build a first-class factory target and supplies its generic gap-measurement contract.

- declares `fedora` with its actual Fedora 44 target index, Rawhide reference index, x86_64 buildroot, and existing `xfce/44-x86_64` publication path
- records the three proven XFCE 4.21 roots (`xfconf`, `libxfce4ui`, `xfwl4`) in `manifests/xfce-fedora.yaml`
- recognizes `.github/workflows/build-xfce-fedora.yml` as the native-spec gate through explicit `FACTORY_TARGET: fedora`
- keeps `build-order-xfce-fedora.yml` as the executed source of truth until a live measurement reproduces it exactly or explains every difference

The Fedora 44 Python fallback used for Hummingbird remains untouched and buildroot-only.

## Validation

- `python3 -m py_compile scripts/measure-hummingbird-gap.py scripts/measure-target-gap.py scripts/validate-package-factory.py`
- `python3 scripts/validate-package-factory.py manifests/package-factory.yaml`
- `python3 scripts/measure-target-gap.py --target fedora --help`
- YAML parse and `git diff --check`

`pytest` is unavailable in the local runtime; CI will run the focused regression coverage.

Depends on #424. Refs #418.