### PR TITLE
fix(factory): resolve cross-cell gap deps in the clean-install verify

### DIFF
--- a/.github/workflows/package-factory-cell.yml
+++ b/.github/workflows/package-factory-cell.yml
@@ -125,6 +125,7 @@ jobs:
           RECIPE: ${{ matrix.recipe }}
           TARGET: ${{ matrix.target }}
           FORMAT: ${{ matrix.format }}
+          ARCHITECTURE: ${{ matrix.architecture }}
           IMAGE: ${{ matrix.verify_image }}
         run: bash scripts/verify-package-factory-cell.sh
       - name: Write immutable artifact checksums

--- a/docs/adr/0001-rfc011-unified-gap-driven-factory.md
+++ b/docs/adr/0001-rfc011-unified-gap-driven-factory.md
@@ -26,8 +26,10 @@ hummingbird's actually executes as a query.
 package identity; a generalized, target-parameterized gap engine
 (`scripts/measure-target-gap.py`, the proven hummingbird machinery) computes
 per-target build orders against live repo indexes with revision-gated drift
-PRs; one reusable orchestrator per package format replaces the hand-copied
-families. Packaging payloads stay heterogeneous — Tideforge recipes where
+PRs; one unified format-agnostic factory (`package-factory.yml` planner +
+`package-factory-cell.yml` boundary, landed in #430) replaces the hand-copied
+families — amending the originally-proposed per-format orchestrators.
+Packaging payloads stay heterogeneous — Tideforge recipes where
 they are proven, native EL10 specs where the TIDEFORGE-READINESS verdict
 says there is nothing to switch.
 

--- a/docs/rfc/rfc011-unified-gap-driven-factory.md
+++ b/docs/rfc/rfc011-unified-gap-driven-factory.md
@@ -1,6 +1,10 @@
 # RFC 011: One gap-driven factory
 
 **Status:** Accepted — maintainer sign-off by hanthor, 2026-08-18
+**Amended:** 2026-08-19 (#430) — Design §3 and Phase 2 updated to the unified
+format-agnostic factory that #430 actually landed (one `package-factory.yml`
+planner + `package-factory-cell.yml` boundary), replacing the per-format
+reusable workflows originally proposed.
 **ADR:** [0001](../adr/0001-rfc011-unified-gap-driven-factory.md)
 **Tracking issue:** [#418](https://github.com/tuna-os/tunaos-packages/issues/418)
 **Owner:** hanthor
@@ -63,7 +67,9 @@ been composed:
 - **The catalog shape.** `manifests/hummingbird-desktops.yaml` already
   declares intent separately from execution.
 - **The target contract.** `manifests/package-factory.yaml` is the
-  authoritative list of targets, formats, and R2 paths.
+  authoritative list of targets, formats, and R2 paths; `manifests/package-builds.yaml`
+  records the legacy native-spec queues as data so they stay buildable
+  without owning a workflow (added by #430).
 - **The recipe layer.** Tideforge recipes cover 40 packages with proven
   source and build parity (per `docs/TIDEFORGE-READINESS.md`); native EL10
   specs cover the hard GNOME bootstrap that a generic recipe format cannot
@@ -145,16 +151,31 @@ measure-target-gap.py --catalog manifests/catalog.yaml --target el10
   obligation*: Phase 1 is complete for a family only when regeneration
   reproduces the curated order, with every difference explained in the PR.
 
-### 3. The orchestrator (one reusable workflow per package format)
+### 3. The orchestrator — one unified format-agnostic factory *(amended 2026-08-19)*
 
-`build-rpm-distributed.yml` (reusable, `workflow_call`) parameterized by
-`(target, build-order file, mock config)`; likewise `build-deb.yml`,
-`build-arch.yml`. The six hand-copied distributed families become thin
-callers. Shared once, not five times: tier scheduling, the already-built skip
-check (#410's cost problem gets one fix), `createrepo_c --update` handling
-(#358's class dies structurally), staged-install gating, publish gates,
-R2 paths from `manifests/package-factory.yaml`, and the step-summary
-reporting.
+The original design proposed one reusable workflow per package format
+(`build-rpm-distributed.yml`, `build-deb.yml`, `build-arch.yml`). #430
+implemented a *more* unified shape, and this RFC adopts it:
+
+- `package-factory.yml` is the single planner and required gate. It computes
+  the affected coordinates `(package | native queue, target, architecture,
+  release track, engine)` and emits only those cells.
+- `package-factory-cell.yml` is the single reusable build boundary. Every
+  coordinate derives an exact content-addressed action key, restores only an
+  exact cached result, verifies every restored byte, and skips compilation
+  only after the restored result passes the same package checks as a fresh
+  build.
+- `manifests/package-factory.yaml` remains the target contract (formats,
+  R2 paths); `manifests/package-builds.yaml` records the legacy native-spec
+  queues as data so they stay buildable without owning a workflow.
+
+The per-family workflows (`build-gnome*`, `build-xfce*`,
+`build-hummingbird*`, `build-tideforge-*`, `build-fprintd-*`) are removed.
+The shared mechanics this RFC wanted unified — tier scheduling, the
+already-built skip check (#410), `createrepo_c --update` handling (#358's
+class), staged-install gating, publish gates, and R2 paths from
+`manifests/package-factory.yaml` — now live once in the factory, not once
+per format.
 
 ### 4. What does NOT change
 
@@ -193,16 +214,14 @@ already works this way); then `build-order-xfce-fedora.yml` (smallest), then
 the conversion PR. The curated file is then deleted and the generated one
 committed with its provenance header.*
 
-**Phase 2 — orchestrator consolidation.**
-Extract the reusable `build-rpm-distributed.yml` from the *best* current copy
-(the xfce-package one, which carries the #358 fix). Convert callers
-lowest-risk-first: xfce-fedora → xfce → hummingbird → gnome49 → gnome50 →
-gnome51 → `build.yml`. Each conversion PR must show an unchanged (or
-improved) run on the same inputs before the old workflow file is deleted.
-DEB and Arch orchestrators follow the same pattern from the tideforge
-workflows.
-*Gate per family: one green run of the converted workflow producing the same
-artifact set as the last green run of the old one.*
+**Phase 2 — orchestrator consolidation.** ✅ **Landed via #430 (2026-08-19),
+amending the per-format design above to one format-agnostic factory.** The
+hand-copied families were removed in one merge and replaced by
+`package-factory.yml` + `package-factory-cell.yml` driven by
+`package-factory.yaml` + `package-builds.yaml`, with content-addressed exact
+reuse and SLSA attestation. Required contexts remained as zero-build aliases
+of the factory gate during the ruleset transition.
+*Gate satisfied: the merge queue ran the full package-factory matrix green.*
 
 **Phase 3 — runtime gates, then (separately) promotion.**
 Implement the 12 declared gate types from `docs/TIDEFORGE-READINESS.md`
@@ -214,9 +233,13 @@ factory-complete.
 each row's removal cites the run that covered it. Automated promotion remains
 out of scope and requires its own RFC with the incident safeguards.*
 
-**Cleanup.** When the last family converts, the factory is: one catalog,
-one gap engine + N drift detectors, one orchestrator per format,
-heterogeneous payloads. The per-family workflow count drops from ~20 to ~6.
+**Cleanup.** ✅ Achieved by #430. The factory is one catalog, one gap engine +
+N drift detectors, and one format-agnostic factory (`package-factory.yml` +
+`package-factory-cell.yml`) over heterogeneous payloads. The per-family
+workflow count dropped from ~20 to ~2 factory workflows plus the shared
+auxiliary workflows (`lint.yml`, `validate-package-factory.yml`, the legacy
+`build.yml`/`build-distributed.yml` dispatch, `publish-tideforge-debs.yml`,
+`r2-inventory.yml`, and the non-factory scheduled jobs).
 
 ## Risks
 

--- a/scripts/verify-package-factory-cell.sh
+++ b/scripts/verify-package-factory-cell.sh
@@ -50,10 +50,24 @@ fi
 
 case ${FORMAT:?} in
   rpm)
+    # Cross-cell dependency resolution (#440): a clean-install verify of a
+    # package whose runtime deps are themselves in the gap (e.g. niri needs
+    # libseat) can only resolve them from the PUBLISHED factory repo, built by
+    # earlier waves. The target contract's `published_index` (served read URL,
+    # distinct from `r2_path`) is added as a lower-priority dnf/zypper repo so
+    # the local cell artifacts win and the published repo only fills in deps.
+    published_index="$(python3 - "$TARGET" "${ARCHITECTURE:-}" <<'PY'
+import pathlib, sys, yaml
+d = yaml.safe_load(pathlib.Path("manifests/package-factory.yaml").read_text()) or {}
+t = d.get("targets", {}).get(sys.argv[1]) or {}
+print((t.get("published_index") or {}).get(sys.argv[2], ""))
+PY
+)"
     docker run --rm --entrypoint /bin/bash --volume "$artifacts:/artifacts:ro" \
       --volume "$PWD/scripts:/scripts:ro" "${IMAGE:?}" \
       /scripts/lint-generated-rpm.sh /artifacts
     docker run --rm --entrypoint /bin/bash --env INSTALL_NAME="$install_name" \
+      --env PUBLISHED_INDEX="$published_index" \
       --volume "$artifacts:/artifacts:ro" --volume "$out/smoke.sh:/smoke.sh:ro" \
       --volume "$PWD/scripts:/scripts:ro" "${IMAGE:?}" -lc '
         set -euo pipefail
@@ -63,13 +77,18 @@ case ${FORMAT:?} in
           zypper --non-interactive install createrepo_c
           createrepo_c /factory-repo
           zypper --non-interactive addrepo --no-gpgcheck --priority 1 file:///factory-repo tideforge
-          zypper --non-interactive --gpg-auto-import-keys refresh tideforge
+          if [ -n "$PUBLISHED_INDEX" ]; then
+            zypper --non-interactive addrepo --no-gpgcheck --priority 50 "$PUBLISHED_INDEX" tunaos-published
+          fi
+          zypper --non-interactive --gpg-auto-import-keys refresh
           zypper --non-interactive --no-gpg-checks install "$INSTALL_NAME"
         else
           dnf -y install createrepo_c
           createrepo_c /factory-repo
           dnf -y install --nogpgcheck --repofrompath tideforge,file:///factory-repo \
-            --setopt=tideforge.priority=1 --enablerepo=tideforge "$INSTALL_NAME"
+            --setopt=tideforge.priority=1 --enablerepo=tideforge \
+            ${PUBLISHED_INDEX:+--repofrompath tunaos,"$PUBLISHED_INDEX" --setopt=tunaos.priority=50 --enablerepo=tunaos} \
+            "$INSTALL_NAME"
         fi
         rpm -q "$INSTALL_NAME"
         bash /smoke.sh


### PR DESCRIPTION
Fixes #440.

## Problem

The clean-install verify only saw the local cell repo + the container system repos. A package whose runtime deps are themselves in the gap (niri needs libseat; the whole COSMIC stack depends on its siblings) failed with "nothing provides <dep>" even after the dep was built and published in an earlier wave — so the factory could never converge on dependents, and the first el10 wave showed 16/17 COSMIC cells failing exactly this way.

## Fix

1. `verify-package-factory-cell.sh` — read the target contract published_index (the SERVED read URL, distinct from r2_path) for (TARGET, ARCHITECTURE) and add it to the verify container as a lower-priority dnf/zypper repo (tunaos-published, priority 50 vs the local tideforge priority 1). The current cell artifacts win; the published repo only fills in deps the system repos cannot.
2. `package-factory-cell.yml` — pass ARCHITECTURE into the verify step (it was missing, so the per-arch published_index could not be looked up).

## Why this makes the factory converge

First wave: leaves + deps (libseat) build and publish. Dependents (niri, COSMIC stack) fail the verify (deps not yet published). Second wave: the dependents verify now resolves the published deps from repo.tunaos.org/repo/10/x86_64/ → they build + publish. Subsequent waves converge.

Tests: bash -n + YAML parse OK; pytest tests/ -k "factory or verify or gate or validate" — 106 passed.