### PR TITLE
fix(factory): verify against the target's runtime repos; resolve cross-cell BuildRequires

### DIFF
--- a/manifests/package-factory.yaml
+++ b/manifests/package-factory.yaml
@@ -36,9 +36,19 @@ targets:
     repository: rpm-md
     probe_image: quay.io/centos/centos:stream10
     # CRB is a signed, target-native CentOS repository.  It supplies selected
-    # development headers (for example Qt private API metadata) during builds;
-    # it is never added to a produced TunaOS image.
+    # development headers (for example Qt private API metadata) during builds.
     build_repositories: [crb, epel]
+    # Repos the produced el10 image ENABLES at runtime (tunaOS
+    # build_scripts/10-base-packages.sh runs `crb enable` / `dnf
+    # config-manager --set-enabled crb` and `--set-enabled epel` on every EL
+    # base), so the clean-install verify resolves against the same repo
+    # closure a real install has. Without these the verify is dishonestly
+    # NARROWER than the image: run 32382594650 failed 19 el10 cells on deps
+    # EPEL serves (gnome-icon-theme for pop-icon-theme, libdav1d.so.7 for
+    # cosmic-bg) that every shipped image resolves fine. Distinct from
+    # build_repositories — that is the buildroot's set — even though el10's
+    # two sets happen to match.
+    system_repositories: [crb, epel]
   ubuntu:
     status: supported
     format: deb

--- a/scripts/run-package-factory-cell.sh
+++ b/scripts/run-package-factory-cell.sh
@@ -43,6 +43,20 @@ python3 scripts/verify-tideforge-source.py "$recipe" --cache-dir "$HOME/.cache/t
 
 case ${FORMAT:?} in
   rpm)
+    # Cross-cell BUILD dependency resolution — the build-side twin of #440's
+    # verify fix: a package whose BuildRequires are themselves factory
+    # products (gtkgreet needs gtk-layer-shell-devel, xfwl4 needs
+    # xfconf-devel/libxfce4ui-devel, quickshell needs cpptrace-devel — run
+    # 32382594650) can only resolve them from the PUBLISHED factory repo,
+    # built by earlier waves. Same manifest field the verify reads; empty
+    # (e.g. el10/aarch64, which has no served index yet) adds nothing.
+    published_index="$(python3 - "$target" "${ARCHITECTURE:-}" <<'PY'
+import pathlib, sys, yaml
+d = yaml.safe_load(pathlib.Path("manifests/package-factory.yaml").read_text()) or {}
+t = d.get("targets", {}).get(sys.argv[1]) or {}
+print((t.get("published_index") or {}).get(sys.argv[2], ""))
+PY
+)"
     root="$out/rpm"
     python3 scripts/tideforge.py render "$recipe" --target "$target" --output "$root/rpmbuild/SPECS"
     mkdir -p "$root/rpmbuild"/{BUILD,BUILDROOT,RPMS,SOURCES,SRPMS}
@@ -61,7 +75,7 @@ case ${FORMAT:?} in
         '
     else
       docker run --rm --env SOURCE_DATE_EPOCH --env TZ --env LANG --env LC_ALL \
-        --env TARGET="$target" \
+        --env TARGET="$target" --env PUBLISHED_INDEX="$published_index" \
         --volume "$root:/work" "$image" bash -lc '
           set -euo pipefail
           dnf -y install dnf-plugins-core rpm-build
@@ -69,7 +83,9 @@ case ${FORMAT:?} in
             dnf -y install epel-release
             dnf config-manager --set-enabled crb
           fi
-          dnf -y builddep /work/rpmbuild/SPECS/*.spec
+          dnf -y builddep \
+            ${PUBLISHED_INDEX:+--repofrompath tunaos,"$PUBLISHED_INDEX" --setopt=tunaos.priority=50 --setopt=tunaos.gpgcheck=0 --enablerepo=tunaos} \
+            /work/rpmbuild/SPECS/*.spec
           rpmbuild -ba --define "_topdir /work/rpmbuild" /work/rpmbuild/SPECS/*.spec
         '
     fi

--- a/scripts/verify-package-factory-cell.sh
+++ b/scripts/verify-package-factory-cell.sh
@@ -7,6 +7,20 @@ out=${OUT_DIR:-"$PWD/.factory/${CELL_ID:?}"}
 artifacts="$out/artifacts"
 test -d "$artifacts"
 
+# The target's runtime repo set (#446): the clean-install verify must resolve
+# against the same repos a produced image enables (for el10: crb + epel, per
+# tunaOS build_scripts/10-base-packages.sh), or real-world-installable
+# packages fail the gate on deps the image serves fine — run 32382594650
+# failed every cosmic el10 cell on EPEL-served gnome-icon-theme/libdav1d.so.7.
+# Empty for targets that declare none; only the dnf paths consume it today.
+system_repos="$(python3 - "${TARGET:-}" <<'PY'
+import pathlib, sys, yaml
+d = yaml.safe_load(pathlib.Path("manifests/package-factory.yaml").read_text()) or {}
+t = d.get("targets", {}).get(sys.argv[1]) or {}
+print(" ".join(t.get("system_repositories") or []))
+PY
+)"
+
 if [[ ${ENGINE:?} == build-chain ]]; then
   mapfile -d '' rpms < <(find "$artifacts" -type f -name '*.rpm' ! -name '*.src.rpm' -print0)
   ((${#rpms[@]} > 0)) || { echo "native queue produced no RPMs" >&2; exit 1; }
@@ -14,8 +28,16 @@ if [[ ${ENGINE:?} == build-chain ]]; then
     --volume "$PWD/scripts:/scripts:ro" "${IMAGE:?}" \
     /scripts/lint-generated-rpm.sh /artifacts
   docker run --rm --entrypoint /bin/bash \
-    --env TARGET="${TARGET:?}" --volume "$artifacts:/artifacts:ro" "${IMAGE:?}" -lc '
+    --env TARGET="${TARGET:?}" --env SYSTEM_REPOS="$system_repos" \
+    --volume "$artifacts:/artifacts:ro" "${IMAGE:?}" -lc '
     set -euo pipefail
+    for sysrepo in ${SYSTEM_REPOS:-}; do
+      case $sysrepo in
+        epel) dnf -y install epel-release ;;
+        *) dnf -y install "dnf-command(config-manager)"
+           dnf config-manager --set-enabled "$sysrepo" ;;
+      esac
+    done
     dnf -y install createrepo_c
     mkdir /factory-repo
     find /artifacts -maxdepth 1 -type f -name "*.rpm" ! -name "*.src.rpm" -exec cp -t /factory-repo {} +
@@ -67,7 +89,7 @@ PY
       --volume "$PWD/scripts:/scripts:ro" "${IMAGE:?}" \
       /scripts/lint-generated-rpm.sh /artifacts
     docker run --rm --entrypoint /bin/bash --env INSTALL_NAME="$install_name" \
-      --env PUBLISHED_INDEX="$published_index" \
+      --env PUBLISHED_INDEX="$published_index" --env SYSTEM_REPOS="$system_repos" \
       --volume "$artifacts:/artifacts:ro" --volume "$out/smoke.sh:/smoke.sh:ro" \
       --volume "$PWD/scripts:/scripts:ro" "${IMAGE:?}" -lc '
         set -euo pipefail
@@ -83,6 +105,13 @@ PY
           zypper --non-interactive --gpg-auto-import-keys refresh
           zypper --non-interactive --no-gpg-checks install "$INSTALL_NAME"
         else
+          for sysrepo in ${SYSTEM_REPOS:-}; do
+            case $sysrepo in
+              epel) dnf -y install epel-release ;;
+              *) dnf -y install "dnf-command(config-manager)"
+                 dnf config-manager --set-enabled "$sysrepo" ;;
+            esac
+          done
           dnf -y install createrepo_c
           createrepo_c /factory-repo
           dnf -y install --nogpgcheck --repofrompath tideforge,file:///factory-repo \

--- a/src/xfce-wayland/xfce4-panel/0001-drop-XfceTitledDialog-autoptr-shim.patch
+++ b/src/xfce-wayland/xfce4-panel/0001-drop-XfceTitledDialog-autoptr-shim.patch
@@ -1,0 +1,28 @@
+From: TunaOS packagers <packages@tunaos.org>
+Subject: [PATCH] panel: drop the XfceTitledDialog autoptr shim libxfce4ui now provides
+
+panel-tic-tac-toe.h carries a compat G_DEFINE_AUTOPTR_CLEANUP_FUNC for
+XfceTitledDialog, guarded by `#ifndef glib_autoptr_clear_XfceTitledDialog`.
+The guard is inert: G_DEFINE_AUTOPTR_CLEANUP_FUNC emits static inline
+FUNCTIONS, not preprocessor macros, so the #ifndef is always true. Against
+this stack's libxfce4ui 4.21.x — whose xfce-titled-dialog.h defines the
+same cleanup func at line 41 — every TU including this header fails with
+
+  error: redefinition of 'glib_autoptr_clear_XfceTitledDialog'
+
+(package-factory run 32382594650, the sole red package of the xfce chain).
+Drop the shim; G_DECLARE_FINAL_TYPE's parent chain-up resolves the
+libxfce4ui-provided definition.
+
+--- a/panel/panel-tic-tac-toe.h
++++ b/panel/panel-tic-tac-toe.h
+@@ -24,9 +24,6 @@
+ G_BEGIN_DECLS
+
+ #define PANEL_TYPE_TIC_TAC_TOE (panel_tic_tac_toe_get_type ())
+-#ifndef glib_autoptr_clear_XfceTitledDialog
+-G_DEFINE_AUTOPTR_CLEANUP_FUNC (XfceTitledDialog, g_object_unref)
+-#endif
+ G_DECLARE_FINAL_TYPE (PanelTicTacToe, panel_tic_tac_toe, PANEL, TIC_TAC_TOE, XfceTitledDialog)
+
+ void

--- a/src/xfce-wayland/xfce4-panel/xfce4-panel.spec
+++ b/src/xfce-wayland/xfce4-panel/xfce4-panel.spec
@@ -2,12 +2,16 @@
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 Name:           xfce4-panel
 Version:        4.21.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Panel for the Xfce desktop environment (Wayland-ready)
 
 License:        GPL-2.0-or-later AND LGPL-2.1-or-later
 URL:            https://gitlab.xfce.org/xfce/xfce4-panel
 Source0: https://gitlab.xfce.org/xfce/xfce4-panel/-/archive/%{commit}/xfce4-panel-%{commit}.tar.gz
+# The #ifndef guard around the shim is inert (autoptr cleanup funcs are
+# inline functions, not macros), so it collides with the definition our
+# libxfce4ui 4.21.x ships. See the patch header.
+Patch0: 0001-drop-XfceTitledDialog-autoptr-shim.patch
 
 BuildRequires: gcc
 BuildRequires:  gtk3-devel
@@ -43,7 +47,7 @@ Headers, pkgconfig, GObject-Introspection typelib, and Vala bindings for
 building xfce4-panel plugins.
 
 %prep
-%autosetup -n xfce4-panel-%{commit}
+%autosetup -n xfce4-panel-%{commit} -p1
 
 %build
 # Wayland-only build (matches thunar's -Dx11=disabled convention in this
@@ -78,5 +82,8 @@ building xfce4-panel plugins.
 %{_datadir}/vala/vapi/*
 
 %changelog
+* Thu Aug 20 2026 TunaOS Bot <bot@tunaos.org> - 4.21.0-2
+- Drop the XfceTitledDialog autoptr shim that collides with libxfce4ui 4.21
+
 * Thu Jul 03 2026 TunaOS Bot <bot@tunaos.org> - 4.21.0-1
 - Initial XFCE Wayland package for TunaOS EL10


### PR DESCRIPTION
Run 32382594650 left 20 of 28 el10 cells red. Every failure traces to one of three causes, fixed here as three commits.

## 1. The clean-install verify ran against a narrower repo set than any real image

Every verify failure was a dependency the verify container could not resolve:

```
nothing provides gnome-icon-theme needed by pop-icon-theme-3.5.0-1.el10
nothing provides libdav1d.so.7()(64bit) needed by cosmic-bg-1.4.0-1.el10
```

Both are served by EPEL 10 (`gnome-icon-theme-3.12.0-25.el10_1`, `dav1d-1.5.3-1.el10_3` — checked against dl.fedoraproject.org repodata), and every produced el10 image enables EPEL and CRB at runtime (tunaOS `build_scripts/10-base-packages.sh`: `crb enable` + `dnf config-manager --set-enabled crb`/`epel` on all EL bases). The verify ran against the bare probe image plus factory artifacts plus the published index — strictly narrower than any image these packages will be installed on. `pop-icon-theme` failing its own verify then cascaded through the whole COSMIC family: nothing published, so the #440 cross-cell resolution had nothing to fill dependents with, wave after wave.

**Change:** declare the image's runtime repo set as `system_repositories: [crb, epel]` on the el10 target (distinct from `build_repositories`, the buildroot's set) and enable it in both dnf verify paths. Targets declaring nothing see no change; zypper/apt/arch paths untouched. Also corrects the stale CRB comment claiming it is never added to a produced image.

## 2. Cross-cell BuildRequires could not resolve — the build-side twin of #440

Three cells died at `dnf builddep` on BuildRequires that are themselves factory products:

```
gtkgreet:   No matching package to install: 'gtk-layer-shell-devel'
xfwl4:      No matching package to install: 'libxfce4ui-devel' 'xfconf-devel'
quickshell: No matching package to install: 'cpptrace-devel' 'wayland-protocols'
```

Every named dep is a cell in this factory (gtk-layer-shell and wayland-protocols were green in the same run). The verify fills cross-cell **runtime** deps from `published_index`; the build container never got the same repo, so cross-cell **build** deps could not converge no matter how many waves ran.

**Change:** read `published_index` for the target/arch and hand it to `dnf builddep` as a low-priority `--repofrompath` with gpgcheck scoped off for just that repo. Empty index (el10/aarch64 has no served index yet) expands to nothing.

## 3. xfce4-panel: inert autoptr guard collides with libxfce4ui 4.21

The one red package in the otherwise-green xfce build chain (35/36 built). `panel-tic-tac-toe.h` carries a compat `G_DEFINE_AUTOPTR_CLEANUP_FUNC (XfceTitledDialog, …)` behind `#ifndef glib_autoptr_clear_XfceTitledDialog` — but the macro emits static inline **functions**, not preprocessor macros, so the guard is always true, and this stack's libxfce4ui 4.21.x defines the same cleanup func in `xfce-titled-dialog.h`:

```
error: redefinition of 'glib_autoptr_clear_XfceTitledDialog'
```

**Change:** patch the shim out (applies with fuzz 0 against the pinned commit; `G_DECLARE_FINAL_TYPE`'s parent chain-up resolves the libxfce4ui definition), Release 2.

## What remains after this

- COSMIC/XFCE dependents converge over subsequent publish waves (the #442 mechanism, which was starved rather than broken).
- el10/aarch64 cross-cell resolution stays blocked on a served aarch64 index (documented in the target contract).

## Verification

`bash -n` + `shellcheck -S error` clean on both scripts; `validate-package-factory.py` passes; manifest extractions return `crb epel` / the x86_64 index URL for el10 and empty elsewhere; the xfce4-panel patch applies with `patch -p1 --fuzz=0` against the pristine pinned source.

Refs #439 (gap convergence), #440/#442 (cross-cell deps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC