### PR TITLE
fix(build): published index must fill gaps, never upgrade the buildroot

### DIFF
--- a/scripts/run-package-factory-cell.sh
+++ b/scripts/run-package-factory-cell.sh
@@ -83,8 +83,19 @@ PY
             dnf -y install epel-release
             dnf config-manager --set-enabled crb
           fi
+          # priority=999, WORSE than the system repos'\''s default 99: dnf
+          # priority excludes lower-priority repos for any name a
+          # higher-priority repo carries, so the published index fills only
+          # the names the system repos lack (gtk-layer-shell-devel,
+          # cpptrace-devel) and can never upgrade base packages into the
+          # buildroot. At 50 it BEAT the system repos and pulled the
+          # GNOME-50 glib2 stack into a generic buildroot, where the
+          # rearranged gir layout broke g-ir-scanner ("Couldn'\''t find
+          # include GObject-2.0.gir" — publish run 32396660104,
+          # gtk-layer-shell) — the exact repo-poisoning hazard AGENTS.md
+          # documents for ICU. System repos first; the factory fills gaps.
           dnf -y builddep \
-            ${PUBLISHED_INDEX:+--repofrompath tunaos,"$PUBLISHED_INDEX" --setopt=tunaos.priority=50 --setopt=tunaos.gpgcheck=0 --enablerepo=tunaos} \
+            ${PUBLISHED_INDEX:+--repofrompath tunaos,"$PUBLISHED_INDEX" --setopt=tunaos.priority=999 --setopt=tunaos.gpgcheck=0 --enablerepo=tunaos} \
             /work/rpmbuild/SPECS/*.spec
           rpmbuild -ba --define "_topdir /work/rpmbuild" /work/rpmbuild/SPECS/*.spec
         '


### PR DESCRIPTION
Publish run [32396660104](https://github.com/tuna-os/tunaos-packages/actions/runs/32396660104) — the first wave-1 publish — failed on `gtk-layer-shell` x86_64 with

```
g-ir-scanner: Couldn't find include 'GObject-2.0.gir'
```

a cell that was green in factory run 32382594650. The regression is #450's builddep repo: `priority=50` **beats** the system repos' default 99, and dnf priority excludes lower-priority repos for any name a higher-priority repo carries — so builddep pulled the published GNOME-50 glib2 stack into a generic buildroot, where the rearranged gir layout starves g-ir-scanner. That's the exact repo-poisoning hazard `AGENTS.md` documents for ICU: the served repo carries a curated desktop stack that must never upgrade base packages by accident.

**Change:** `priority=999` — worse than every system repo, so the published index resolves only names the system repos lack (`gtk-layer-shell-devel`, `xfconf-devel`, `cpptrace-devel` — the cross-cell BuildRequires it exists for) and can never displace a base package. System repos first; the factory fills gaps — RFC 011's own words.

The verify's `priority=50` (#442) is left alone deliberately: the verify models the **image's** repo closure, and el10 images do prefer the tunaos repo over base.

## Verification

`bash -n` + `shellcheck -S error` clean. End-to-end proof: re-dispatch `publish-tideforge-rpms.yml` after merge — gtk-layer-shell should build again and the wave publish complete.

Refs #439, #450, #451.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_