### PR TITLE
fix(build): exclude the glib2 family from the published gap-filler repo

### DIFF
--- a/scripts/run-package-factory-cell.sh
+++ b/scripts/run-package-factory-cell.sh
@@ -104,6 +104,20 @@ PY
               echo "enabled=1"
               echo "gpgcheck=0"
               echo "priority=999"
+              # priority cannot stop an OBSOLETER: the served repo retains
+              # stale gnome-50 bootstrap builds glib2-2.87.3-1.el10 and
+              # glib2-devel-2.87.3-1.el10 (a 6.4kB stub with no pkgconfig or
+              # gir payload) whose "Obsoletes: glib2 < 2.87.3" REPLACES the
+              # AppStream packages in any transaction regardless of repo
+              # priority — publish run 32405815822 failed on exactly this
+              # with the priority fix (#454) fully in effect. Later builds
+              # (-2, 2.88.0-*) dropped the self-obsolete; only the stale -1
+              # pair hijacks. Exclude the family here: a BUILDROOT must
+              # never take glib2 from the published repo — the system repos
+              # always carry it. Cleaning the stale pair out of the served
+              # repo itself is tracked separately (it affects image
+              # consumers too).
+              echo "excludepkgs=glib2 glib2-devel glib2-static"
             } > /etc/yum.repos.d/tunaos-published.repo
           fi
           dnf -y builddep /work/rpmbuild/SPECS/*.spec


### PR DESCRIPTION
## What

Adds `excludepkgs=glib2 glib2-devel glib2-static` to the `tunaos-published` repo file the rpm builddep path writes into the buildroot container.

## Why

Publisher runs 1–3 (latest: run 32405815822) all failed identically on gtk-layer-shell x86_64: `g-ir-scanner: Couldn't find include 'GObject-2.0.gir'` — and run 3 failed **with the #454 priority fix fully in effect** (a real `/etc/yum.repos.d` file, `priority=999`).

Root cause, from the served repo's `primary.xml`: the published index still carries the stale gnome-50 bootstrap pair **glib2-2.87.3-1.el10** and **glib2-devel-2.87.3-1.el10** (the -devel is a 6.4 kB stub with no pkgconfig or gir payload), and both carry a versioned self-Obsoletes:

```
Obsoletes: glib2 < 2.87.3        (flags=LT)
Obsoletes: glib2-devel < 2.87.3  (flags=LT)
```

dnf obsoletes processing trumps repo priority entirely — an obsoleter from *any* enabled repo replaces the obsoleted package regardless of priority. So the stub -devel displaced AppStream's full glib2-devel and starved g-ir-scanner of `GObject-2.0.gir`.

Later builds (`-2`, `2.88.0-*`) dropped the self-obsolete; only the stale `-1` pair hijacks. A buildroot must never take glib2 from the published repo — the system repos always carry it — so the family is excluded at the repo-file level.

Cleaning the stale pair out of the served repo itself is tracked separately (it affects image consumers too, not just buildroots).

## Validation

`bash -n` + `shellcheck -S error` pass on the edited script.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_