### PR TITLE
fix(publish): rename '+' out of published rpm filenames — the worker serves raw paths

### DIFF
--- a/.github/workflows/publish-tideforge-rpms.yml
+++ b/.github/workflows/publish-tideforge-rpms.yml
@@ -220,6 +220,20 @@ jobs:
           find staged -name '*.rpm' ! -name '*.src.rpm' -exec rpmsign --addsign {} \;
           mkdir -p repo/tideforge
           find staged -name '*.rpm' ! -name '*.src.rpm' -exec cp -t repo/tideforge {} +
+          # librepo percent-encodes '+' when building download URLs, but the
+          # repo.tunaos.org worker looks up R2 keys with the raw request
+          # path, so any filename containing '+' 404s at install time: run
+          # 32411090239's verify failed on oversteer-udev-0.8.3+git74c7484
+          # (the literal-'+' URL serves 200, the %2b one 404s). Rename '+'
+          # to '.' across the whole tree — staged files and files re-synced
+          # from the bucket alike — so the sync below also replaces any
+          # '+'-named object already served. The version INSIDE the rpm
+          # metadata is untouched; only the file name (and therefore the
+          # repodata location href) changes. The worker-side decode fix is
+          # tracked separately.
+          find repo -name '*+*.rpm' -print0 | while IFS= read -r -d '' f; do
+            mv "$f" "$(dirname "$f")/$(basename "$f" | tr '+' '.')"
+          done
           createrepo_c --update repo 2>/dev/null || createrepo_c repo
       - name: Sync up
         run: |


### PR DESCRIPTION
## What

In the publisher's "Sign and index" step, rename `+` → `.` in every RPM filename across the synced-down tree (staged artifacts and files re-synced from the bucket alike) before `createrepo_c` runs.

## Why

Publisher run 32411090239 was the first to get through **build and publish fully green** — 32/32 cells, both arches signed and synced, and the aarch64 index created at `rpm/el10/aarch64` (now serving 200). It failed only in the final serve-side verify, on a new, shallower layer:

```
[MIRROR] oversteer-udev-0.8.3+git74c7484-1.el10.x86_64.rpm: Status code: 404
  for https://repo.tunaos.org/repo/10/x86_64/tideforge/oversteer-udev-0.8.3%2bgit74c7484-1.el10.x86_64.rpm
```

librepo percent-encodes `+` as `%2b` when constructing download URLs, and the repo.tunaos.org worker looks up R2 keys with the **raw** request path. Verified with curl:

| URL | Status |
|---|---|
| `.../oversteer-udev-0.8.3+git74c7484-...rpm` (literal `+`) | 200 |
| `.../oversteer-udev-0.8.3%2bgit74c7484-...rpm` (what dnf requests) | 404 |

So any published filename containing `+` is uninstallable from the served repo — for image builds and end users exactly as much as for the verify job.

Renaming covers the whole tree (not just staged files) so the `+`-named object already published by run 4 is replaced by the sync-up (`rclone sync` deletes what the local tree no longer has). The version inside the rpm metadata is untouched — only the filename and the repodata location href change.

The proper worker-side percent-decode fix is tracked separately (issue to follow); this keeps every published filename inside the URL-unreserved set regardless.

## Validation

YAML parses; `bash -n` passes on every embedded `run` script.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_