### PR TITLE
feat(status): declare the served el10 aarch64 index

### DIFF
--- a/manifests/package-factory.yaml
+++ b/manifests/package-factory.yaml
@@ -33,6 +33,10 @@ targets:
     # absent — the status page reports what it cannot measure.
     published_index:
       x86_64: https://repo.tunaos.org/repo/10/x86_64/
+      # Created by publish-tideforge-rpms.yml's first green aarch64 publish
+      # (the target contract's r2_path, served by the generic worker) —
+      # declared only once the index actually resolves, per the rule above.
+      aarch64: https://repo.tunaos.org/rpm/el10/aarch64/
     repository: rpm-md
     probe_image: quay.io/centos/centos:stream10
     # CRB is a signed, target-native CentOS repository.  It supplies selected


### PR DESCRIPTION
## What

Adds `published_index.aarch64: https://repo.tunaos.org/rpm/el10/aarch64/` to the el10 target contract.

## Why

The publisher (publish-tideforge-rpms.yml, #451) has now run **fully green end-to-end** — run 32413796958 attempt 2: 32/32 build cells, both publish jobs (signed, synced to R2), and the serve-side verify installing the whole wave-1 set from the served URLs on a clean el10 contract container, on **both arches**.

That run created the served aarch64 index this key names — exactly the flip the publisher's header comment and the contract's own note said to make "once this has run green":

```
$ curl -s -o /dev/null -w '%{http_code}' https://repo.tunaos.org/rpm/el10/aarch64/repodata/repomd.xml
200
```

With the key set, el10/aarch64 cells resolve cross-cell runtime deps (verify, #440) and cross-cell BuildRequires (builddep, #450) from the published index the same way x86_64 already does — closing the "aarch64 has no served index" asymmetry in the factory's convergence story.

This was held staged until the publisher proved the index; it now has.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_