### PR TITLE
fix(input-remapper): BuildRequires python3-pip and python3-gobject

### DIFF
--- a/src/input-remapper/input-remapper.spec
+++ b/src/input-remapper/input-remapper.spec
@@ -14,7 +14,7 @@
 
 Name:           input-remapper
 Version:        2.2.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Change the mapping of input device buttons
 
 License:        GPL-3.0-or-later
@@ -24,6 +24,21 @@ Source0:        https://github.com/sezanzeb/input-remapper/archive/refs/tags/%{v
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
 BuildRequires:  gettext
+# The bundled installer shells out to pip and imports gi, even though this
+# spec deliberately avoids pip as the INSTALL METHOD (see above).
+# install/module.py's build_input_remapper_module() runs
+#   python3 -m pip install . --target <buildroot>/.../site-packages --no-deps
+# to place the Python package, and install/__main__.py imports gi while
+# checking dependencies. Neither is in the mock buildroot by default, so
+# %install died at 'No module named pip' after logging 'Missing Python
+# module: No module named gi' (gnome50-el10-x86_64, run 32418295773 — one of
+# that chain's five failed packages).
+#
+# Requiring pip here is not a reversal of the no-pip decision above: pip is
+# an implementation detail of upstream's installer, which is still what
+# places the udev rules, polkit action, systemd unit and D-Bus policy.
+BuildRequires:  python3-pip
+BuildRequires:  python3-gobject
 
 # python3-evdev is built alongside this package in this repository.
 # All other runtime names were verified against CentOS Stream 10 repository
@@ -94,5 +109,9 @@ python3 -m install --root %{buildroot}
 %{python3_sitelib}/input_remapper-*.dist-info/
 
 %changelog
+* Fri Aug 21 2026 TunaOS Bot <bot@tunaos.org> - 2.2.1-2
+- Add python3-pip and python3-gobject BuildRequires: upstream's bundled
+  installer shells out to pip and imports gi, so %install failed in mock
+
 * Tue Aug 12 2025 TunaOS Bot <bot@tunaos.org> - 2.2.1-1
 - Initial package: input-remapper for EL10 (#122, #126)


### PR DESCRIPTION
## What

Adds `BuildRequires: python3-pip` and `BuildRequires: python3-gobject` to the input-remapper spec, with a release bump and changelog entry.

## Why

One of the **five packages the gnome50 build chain fails on** (run 32418295773 — a chain that otherwise built 55 packages across 19 tiers and produced a 497 MB artifact, so the chain itself is healthy). `%install` died in mock:

```
Missing Python module: No module named 'gi'
Running /usr/bin/python3 -m pip install . --target .../site-packages --no-deps
/usr/bin/python3: No module named pip
subprocess.CalledProcessError: ... returned non-zero exit status 1
error: Bad exit status from /var/tmp/rpm-tmp.xH0RCw (%install)
```

`root.log` confirms the buildroot had `python3-devel` and `python3-setuptools` and nothing else Python-side. Upstream's bundled installer needs both of the added packages:

- `install/module.py`'s `build_input_remapper_module()` runs pip to place the Python package
- `install/__main__.py` imports `gi` during its dependency check

## This is not a reversal of the spec's no-pip decision

The header documents, at length, why pip is the wrong **install method** — it misplaces udev rules, the polkit action, the systemd unit and the D-Bus policy into the Python module tree. That still stands: upstream's installer is still what installs. pip is an implementation detail *inside* that installer, and it has to exist in the buildroot for the installer to run at all. I've written that distinction into the spec next to the new lines so the next reader doesn't "fix" the apparent contradiction.

## Validation

Full Python suite passes (666 passed, 1 skipped). `rpmspec` isn't available in this environment, so the spec parse happens in CI.

## Context

The other four gnome50 failures (`malcontent`, `gnome-settings-daemon`, `gnome-control-center`, `gnome-initial-setup`) have not been read yet. Separately, the build-chain families still have **no publish path** — see tuna-os/tunaos-packages#459 for the consolidated analysis; that is the larger remaining workstream and this fix is independent of it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_