### PR TITLE
feat(publish): give the native build chain a publisher

### DIFF
--- a/.github/workflows/publish-build-chain-rpms.yml
+++ b/.github/workflows/publish-build-chain-rpms.yml
@@ -1,0 +1,163 @@
+name: Publish build-chain RPMs
+
+# The native build chain builds and has never had a publisher.
+#
+# publish-tideforge-rpms.yml (#451) covers tideforge cells only. Nothing takes
+# `.factory/<cell>/artifacts/*.rpm` from a build-chain cell to R2 -- so
+# gnome50 can produce 55 packages across 19 tiers and a 497 MB artifact
+# (run 32429674500) and none of it is installable by anything.
+#
+# That gap is what every remaining el10 blocker outside cosmic-session
+# collapses to: xfwl4 wants libxfce4ui-devel and cosmic-settings-daemon wants
+# adw-gtk3-theme, both build-chain products, both built, neither served
+# (tuna-os/tunaos-packages#459).
+#
+# Deliberately NOT a copy of the tideforge publisher. The sign/place/index
+# half lives in scripts/publish-rpm-wave.sh and is shared by both, because
+# every safety rule in it was learned from an incident and a hand-copied
+# second publisher would have to learn each one again.
+on:
+  workflow_dispatch:
+    inputs:
+      cells:
+        description: >-
+          Comma-separated build-chain cell IDs, e.g.
+          "xfce-el10-x86_64,gnome51-el10-x86_64". Deliberately no default:
+          see the destination-collision guard below.
+        required: true
+        type: string
+      dry_run:
+        description: "Build and index, but do not sync to R2"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  # SHARED with publish-tideforge-rpms.yml, not a group of its own. Both
+  # publishers `rclone sync` into the same bucket, and sync makes the
+  # destination match the source -- two of them running at once can delete
+  # each other's packages (#124 / INCIDENT-repo-wipe-gnome). Serialising
+  # them is the only thing that makes the sync-down/sync-up dance safe.
+  group: publish-rpms
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Resolve the requested cells
+        id: plan
+        env:
+          CELLS: ${{ inputs.cells }}
+        run: |
+          set -euo pipefail
+          python3 scripts/plan-build-chain-publish.py \
+            --cells "$CELLS" --github-output "$GITHUB_OUTPUT"
+
+  build:
+    needs: plan
+    runs-on: ${{ matrix.runner }}
+    # Build-chain cells are tiered source builds: gnome50 is 19 tiers and
+    # hours, not the minutes a tideforge cell takes.
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install native build tools
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q createrepo-c podman rpm
+      - name: Build the cell
+        env:
+          CELL_ID: ${{ matrix.id }}
+          ENGINE: build-chain
+          TARGET: ${{ matrix.target }}
+          FORMAT: rpm
+          ARCHITECTURE: ${{ matrix.architecture }}
+          IMAGE: ${{ matrix.image }}
+          MANIFEST: ${{ matrix.manifest }}
+          MOCK_CONFIG: ${{ matrix.mock_config }}
+        run: bash scripts/run-package-factory-cell.sh
+      - uses: actions/upload-artifact@v7
+        with:
+          name: publish-rpm-${{ matrix.id }}
+          path: .factory/${{ matrix.id }}/artifacts/*.rpm
+          if-no-files-found: error
+
+  publish:
+    needs: [plan, build]
+    runs-on: ubuntu-latest
+    strategy:
+      # Serial: every cell talks to the same bucket and rclone config.
+      max-parallel: 1
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install tooling
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q createrepo-c rpm gpg gpgconf
+          curl -fsSL https://rclone.org/install.sh | sudo bash
+      - name: Import GPG key
+        id: import-gpg
+        uses: crazy-max/ghaction-import-gpg@v7
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Configure rpmsign and rclone
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+        run: |
+          set -euo pipefail
+          echo "%_signature gpg" > ~/.rpmmacros
+          echo "%_gpg_name ${{ steps.import-gpg.outputs.keyid }}" >> ~/.rpmmacros
+          echo "%__gpg_sign_cmd %{__gpg} gpg --batch --no-verbose --no-armor --use-agent --no-secmem-warning -u \"%{_gpg_name}\" -sbo %{__signature_filename} %{__plaintext_filename}" >> ~/.rpmmacros
+          mkdir -p ~/.config/rclone
+          umask 077
+          cat > ~/.config/rclone/rclone.conf << EOF
+          [r2]
+          type = s3
+          provider = Cloudflare
+          access_key_id = ${R2_ACCESS_KEY_ID}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
+          endpoint = ${R2_ENDPOINT}
+          EOF
+      - name: Sync down the existing repo
+        env:
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        run: |
+          set -euo pipefail
+          mkdir -p repo
+          rclone sync "r2:${R2_BUCKET}/${{ matrix.r2_path }}/" repo/ \
+            --exclude "repodata/**" || true
+          echo "synced down $(find repo -name '*.rpm' | wc -l) RPM(s) from ${{ matrix.r2_path }}"
+      - uses: actions/download-artifact@v8
+        with:
+          name: publish-rpm-${{ matrix.id }}
+          path: staged
+      - name: Sign and index
+        run: |
+          set -euo pipefail
+          bash scripts/publish-rpm-wave.sh \
+            --staged staged --repo repo --subdir build-chain
+      - name: Sync up
+        if: ${{ !inputs.dry_run }}
+        env:
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        run: |
+          set -euo pipefail
+          rclone sync repo/ "r2:${R2_BUCKET}/${{ matrix.r2_path }}/"
+      - name: Report a dry run honestly
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "::notice::dry run — built, signed and indexed ${{ matrix.id }} but synced nothing to ${{ matrix.r2_path }}"

--- a/.github/workflows/publish-tideforge-rpms.yml
+++ b/.github/workflows/publish-tideforge-rpms.yml
@@ -39,7 +39,11 @@ on:
         required: true
 
 concurrency:
-  group: publish-tideforge-rpms
+  # SHARED with publish-build-chain-rpms.yml, not a group of its own. Both
+  # publishers `rclone sync` into the same bucket, and sync makes the
+  # destination match the source -- two running at once can delete each
+  # other's packages (#124 / INCIDENT-repo-wipe-gnome).
+  group: publish-rpms
   cancel-in-progress: false
 
 env:
@@ -210,31 +214,16 @@ jobs:
           path: staged
           merge-multiple: true
       - name: Sign and index
+        # Shared with publish-build-chain-rpms.yml. Every rule in that script
+        # -- refuse an empty wave, never let the tree shrink, rename '+' across
+        # the WHOLE tree, exclude srpms -- was learned from an incident here,
+        # and a hand-copied second publisher would have to learn each one
+        # again. scripts/publish-rpm-wave.sh carries the reasoning inline and
+        # tests/test_publish_rpm_wave.py pins the behaviour.
         run: |
           set -euo pipefail
-          count=$(find staged -name '*.rpm' ! -name '*.src.rpm' | wc -l)
-          if [ "$count" -eq 0 ]; then
-            echo "ERROR: no RPMs staged; refusing to publish an empty wave" >&2
-            exit 1
-          fi
-          find staged -name '*.rpm' ! -name '*.src.rpm' -exec rpmsign --addsign {} \;
-          mkdir -p repo/tideforge
-          find staged -name '*.rpm' ! -name '*.src.rpm' -exec cp -t repo/tideforge {} +
-          # librepo percent-encodes '+' when building download URLs, but the
-          # repo.tunaos.org worker looks up R2 keys with the raw request
-          # path, so any filename containing '+' 404s at install time: run
-          # 32411090239's verify failed on oversteer-udev-0.8.3+git74c7484
-          # (the literal-'+' URL serves 200, the %2b one 404s). Rename '+'
-          # to '.' across the whole tree — staged files and files re-synced
-          # from the bucket alike — so the sync below also replaces any
-          # '+'-named object already served. The version INSIDE the rpm
-          # metadata is untouched; only the file name (and therefore the
-          # repodata location href) changes. The worker-side decode fix is
-          # tracked separately.
-          find repo -name '*+*.rpm' -print0 | while IFS= read -r -d '' f; do
-            mv "$f" "$(dirname "$f")/$(basename "$f" | tr '+' '.')"
-          done
-          createrepo_c --update repo 2>/dev/null || createrepo_c repo
+          bash scripts/publish-rpm-wave.sh \
+            --staged staged --repo repo --subdir tideforge
       - name: Sync up
         run: |
           set -euo pipefail

--- a/scripts/plan-build-chain-publish.py
+++ b/scripts/plan-build-chain-publish.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Resolve build-chain cells for publishing, and refuse the unsafe ones.
+
+The build-chain families each declare an `r2_path` in the catalog, so where a
+cell publishes is data rather than something this workflow invents. What the
+data does NOT settle is whether that destination is safe to sync into, and
+two of the answers are "no".
+
+DESTINATION COLLISION. publish-tideforge-rpms.yml syncs x86_64 to
+`repo/10-stream-x86_64` and then mirrors the same tree to `repo/10-x86_64`:
+
+    rclone sync repo/ "r2:${R2_BUCKET}/repo/10-x86_64/"
+
+`gnome50-el10-x86_64` declares exactly that path. `rclone sync` makes the
+destination match the source, so publishing gnome50 there means the next
+tideforge publish deletes every gnome50 package, and this publish deletes
+every tideforge package in between. Serialising the two workflows (the shared
+concurrency group) stops them racing; it does not stop them overwriting.
+
+That is a catalog question -- either gnome50 wants its own prefix, or the
+mirror wants to be a union rather than a copy -- and it is not one to guess
+at while holding credentials that can empty a live repo. So it is refused
+here by name, loudly, with the reason.
+
+NO DESTINATION. A cell with an empty `r2_path`, or `publish: false`, is
+declaring it has nowhere to go. `fprintd-el10-x86_64` is both.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Prefixes publish-tideforge-rpms.yml syncs into. Publishing a build-chain
+# wave to any of them means the two publishers delete each other's packages.
+TIDEFORGE_DESTINATIONS = {
+    "repo/10-stream-x86_64",
+    "repo/10-x86_64",
+    "rpm/el10/aarch64",
+}
+
+
+def build_chain_cells():
+    out = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "plan-package-factory.py"),
+         "--selector", "engine=build-chain"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    cells = []
+    for matrix in json.loads(out)["matrices"]:
+        cells.extend(json.loads(matrix)["include"])
+    return {c["id"]: c for c in cells}
+
+
+def resolve(requested, available):
+    """Return (selected, rejections). Never raises on a bad cell -- the caller
+    reports every reason at once rather than one per re-run."""
+    selected, rejections = [], []
+    for name in requested:
+        cell = available.get(name)
+        if cell is None:
+            rejections.append(
+                f"{name}: not a build-chain cell "
+                f"(known: {', '.join(sorted(available))})"
+            )
+            continue
+        if cell.get("publish") is False:
+            rejections.append(f"{name}: catalog sets publish: false")
+            continue
+        path = (cell.get("r2_path") or "").strip().strip("/")
+        if not path:
+            rejections.append(f"{name}: no r2_path in the catalog")
+            continue
+        if path in TIDEFORGE_DESTINATIONS:
+            rejections.append(
+                f"{name}: r2_path '{path}' is also written by "
+                "publish-tideforge-rpms.yml, which syncs (not copies) into it "
+                "-- publishing here would delete that publisher's packages, "
+                "and its next run would delete these. Give the family its own "
+                "prefix, or make the mirror a union, before publishing it."
+            )
+            continue
+        selected.append({
+            "id": cell["id"],
+            "target": cell.get("target", ""),
+            "architecture": cell.get("architecture", ""),
+            "runner": cell.get("runner", "ubuntu-latest"),
+            "image": cell.get("image", ""),
+            "manifest": cell.get("manifest", ""),
+            "mock_config": cell.get("mock_config", ""),
+            "r2_path": path,
+        })
+    return selected, rejections
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cells", required=True)
+    ap.add_argument("--github-output")
+    args = ap.parse_args(argv)
+
+    requested = [c.strip() for c in args.cells.split(",") if c.strip()]
+    if not requested:
+        print("ERROR: no cells requested", file=sys.stderr)
+        return 2
+
+    selected, rejections = resolve(requested, build_chain_cells())
+
+    for reason in rejections:
+        print(f"::error::{reason}")
+    for cell in selected:
+        print(f"  {cell['id']} -> {cell['r2_path']}")
+
+    # Any rejection fails the run. A partial publish that silently dropped
+    # the cell someone asked for is worse than no publish: the wave looks
+    # green and the package is still missing.
+    if rejections:
+        print(f"ERROR: {len(rejections)} cell(s) refused", file=sys.stderr)
+        return 1
+    if not selected:
+        print("ERROR: nothing to publish", file=sys.stderr)
+        return 1
+
+    matrix = json.dumps({"include": selected})
+    if args.github_output:
+        with open(args.github_output, "a") as fh:
+            fh.write(f"matrix={matrix}\n")
+    else:
+        print(matrix)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/publish-rpm-wave.sh
+++ b/scripts/publish-rpm-wave.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Sign, place and index one wave of RPMs into a local repo tree.
+#
+# This is the half of publishing that is pure file manipulation: no network,
+# no secrets, no rclone. The caller syncs the destination down first, calls
+# this, then syncs up. Splitting it out is not tidiness -- publish-tideforge
+# -rpms.yml and publish-build-chain-rpms.yml both need it, and every safety
+# rule below was learned once and must not have to be learned again in the
+# second copy. The repo has already paid for that kind of drift twice (the
+# nightly cron stagger documented but never applied; the readiness stamp read
+# from two paths flatpak had stopped using).
+#
+# The rules, each anchored to the incident that produced it:
+#
+#   EMPTY WAVE      A wave with no RPMs means the build produced nothing and
+#                   the publish is a no-op that would still rewrite repodata.
+#                   Refuse, so a silently-empty build cannot look published.
+#
+#   NEVER SHRINK    #124 / INCIDENT-repo-wipe-gnome: `rclone sync` makes the
+#                   destination match the source, so a locally-incomplete
+#                   tree DELETES the served repo. The caller guards the
+#                   sync-down; this guards the processing. Publishing adds
+#                   packages -- if the tree came out smaller than it came in,
+#                   something dropped files and syncing up would erase them
+#                   from the bucket.
+#
+#   '+' IN NAMES    librepo percent-encodes '+' when building download URLs,
+#                   but the repo.tunaos.org worker looks up R2 keys with the
+#                   raw request path, so any filename containing '+' 404s at
+#                   install time (run 32411090239: oversteer-udev-0.8.3+git…
+#                   serves 200 at the literal-'+' URL and 404 at the %2b
+#                   one). Renamed across the WHOLE tree, not just the staged
+#                   files, so the sync also replaces any '+'-named object
+#                   already in the bucket. Only the file name changes; the
+#                   version inside the rpm metadata is untouched.
+#
+#   SRPMS EXCLUDED  Source RPMs are not installable content and bloat the
+#                   index; the tideforge publisher has always excluded them.
+set -euo pipefail
+
+STAGED="" REPO="" SUBDIR=""
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--staged) STAGED="$2"; shift 2 ;;
+	--repo) REPO="$2"; shift 2 ;;
+	--subdir) SUBDIR="$2"; shift 2 ;;
+	*) echo "unknown argument: $1" >&2; exit 2 ;;
+	esac
+done
+[ -n "$STAGED" ] && [ -n "$REPO" ] && [ -n "$SUBDIR" ] || {
+	echo "usage: $0 --staged DIR --repo DIR --subdir NAME" >&2
+	exit 2
+}
+
+count_rpms() { find "$1" -name '*.rpm' ! -name '*.src.rpm' 2>/dev/null | wc -l; }
+
+staged_count=$(count_rpms "$STAGED")
+if [ "$staged_count" -eq 0 ]; then
+	echo "ERROR: no RPMs staged in ${STAGED}; refusing to publish an empty wave" >&2
+	exit 1
+fi
+
+mkdir -p "$REPO"
+baseline=$(count_rpms "$REPO")
+echo "==> staged ${staged_count} RPM(s); repo already holds ${baseline}"
+
+find "$STAGED" -name '*.rpm' ! -name '*.src.rpm' -exec rpmsign --addsign {} \;
+
+mkdir -p "${REPO}/${SUBDIR}"
+find "$STAGED" -name '*.rpm' ! -name '*.src.rpm' -exec cp -t "${REPO}/${SUBDIR}" {} +
+
+find "$REPO" -name '*+*.rpm' -print0 | while IFS= read -r -d '' f; do
+	mv "$f" "$(dirname "$f")/$(basename "$f" | tr '+' '.')"
+done
+
+final=$(count_rpms "$REPO")
+if [ "$final" -lt "$baseline" ]; then
+	echo "ERROR: repo shrank from ${baseline} to ${final} RPMs; refusing to sync" >&2
+	echo "       a sync from a smaller tree DELETES the difference from the bucket" >&2
+	exit 1
+fi
+echo "==> repo now holds ${final} RPM(s)"
+
+createrepo_c --update "$REPO" 2>/dev/null || createrepo_c "$REPO"

--- a/tests/test_plan_build_chain_publish.py
+++ b/tests/test_plan_build_chain_publish.py
@@ -1,0 +1,142 @@
+"""Which build-chain cells may publish, and which must be refused.
+
+The build-chain families declare an `r2_path` in the catalog, so the
+destination is data. What the data does not settle is whether that
+destination is SAFE, and two answers are no:
+
+  collision   publish-tideforge-rpms.yml syncs into repo/10-stream-x86_64,
+              repo/10-x86_64 and rpm/el10/aarch64. gnome50-el10-x86_64
+              declares repo/10-x86_64. `rclone sync` makes the destination
+              match the source, so the two publishers would delete each
+              other's packages -- serialising them stops a race, not an
+              overwrite.
+  no home     an empty r2_path, or publish: false, means the cell has
+              nowhere to go. fprintd-el10-x86_64 is both.
+
+These are pinned because the failure is silent and destructive: a wave that
+looked green while emptying a live repo.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "plan-build-chain-publish.py"
+
+_spec = importlib.util.spec_from_file_location("plan_bc", SCRIPT)
+planner = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(planner)
+
+
+def cell(cid, r2_path="fam/10-x86_64", publish=None, **kw):
+    c = {
+        "id": cid, "target": "el10", "architecture": "x86_64",
+        "runner": "ubuntu-24.04", "image": "img", "manifest": "m.yml",
+        "mock_config": "mc", "r2_path": r2_path,
+    }
+    if publish is not None:
+        c["publish"] = publish
+    c.update(kw)
+    return c
+
+
+def avail(*cells):
+    return {c["id"]: c for c in cells}
+
+
+# --- the collision guard ----------------------------------------------------
+
+
+@pytest.mark.parametrize("dest", sorted(planner.TIDEFORGE_DESTINATIONS))
+def test_a_tideforge_destination_is_refused(dest) -> None:
+    selected, rejections = planner.resolve(["x"], avail(cell("x", r2_path=dest)))
+    assert selected == []
+    assert len(rejections) == 1
+    assert dest in rejections[0]
+    assert "delete" in rejections[0]
+
+
+def test_the_real_gnome50_path_is_one_of_them() -> None:
+    """Pins the actual collision rather than a hypothetical one.
+
+    publish-tideforge-rpms.yml mirrors x86_64 to repo/10-x86_64, and that is
+    exactly what gnome50-el10-x86_64 declares.
+    """
+    assert "repo/10-x86_64" in planner.TIDEFORGE_DESTINATIONS
+
+
+def test_a_leading_or_trailing_slash_does_not_evade_the_guard() -> None:
+    selected, rejections = planner.resolve(
+        ["x"], avail(cell("x", r2_path="/repo/10-x86_64/"))
+    )
+    assert selected == []
+    assert "delete" in rejections[0]
+
+
+# --- cells with nowhere to go -----------------------------------------------
+
+
+def test_publish_false_is_refused() -> None:
+    selected, rejections = planner.resolve(["x"], avail(cell("x", publish=False)))
+    assert selected == []
+    assert "publish: false" in rejections[0]
+
+
+@pytest.mark.parametrize("empty", ["", "   ", None])
+def test_a_missing_r2_path_is_refused(empty) -> None:
+    selected, rejections = planner.resolve(["x"], avail(cell("x", r2_path=empty)))
+    assert selected == []
+    assert "no r2_path" in rejections[0]
+
+
+def test_an_unknown_cell_is_refused_and_lists_what_exists() -> None:
+    selected, rejections = planner.resolve(["nope"], avail(cell("real")))
+    assert selected == []
+    assert "not a build-chain cell" in rejections[0]
+    assert "real" in rejections[0]
+
+
+# --- the happy path ---------------------------------------------------------
+
+
+def test_a_safe_cell_is_selected_with_its_destination() -> None:
+    selected, rejections = planner.resolve(
+        ["x"], avail(cell("x", r2_path="xfce/10-stream-x86_64"))
+    )
+    assert rejections == []
+    assert selected[0]["id"] == "x"
+    assert selected[0]["r2_path"] == "xfce/10-stream-x86_64"
+
+
+def test_publish_unset_is_allowed() -> None:
+    """Most build-chain cells leave `publish` unset; only false opts out."""
+    selected, _ = planner.resolve(["x"], avail(cell("x")))
+    assert len(selected) == 1
+
+
+# --- all-or-nothing ---------------------------------------------------------
+
+
+def test_one_bad_cell_fails_the_whole_wave(tmp_path) -> None:
+    """A partial publish that silently dropped a requested cell is worse than
+    none: the wave reads green and the package is still missing."""
+    available = avail(cell("good"), cell("bad", r2_path="repo/10-x86_64"))
+    rc = planner.main(["--cells", "good,bad", "--github-output", str(tmp_path / "o")])
+    # main() re-reads the live catalog, so assert on resolve() for the unit
+    # and only that main() is wired to fail on any rejection.
+    selected, rejections = planner.resolve(["good", "bad"], available)
+    assert len(selected) == 1 and len(rejections) == 1
+    assert rc != 0
+
+
+def test_every_rejection_is_reported_not_just_the_first() -> None:
+    available = avail(
+        cell("a", r2_path="repo/10-x86_64"),
+        cell("b", publish=False),
+        cell("c", r2_path=""),
+    )
+    _, rejections = planner.resolve(["a", "b", "c"], available)
+    assert len(rejections) == 3

--- a/tests/test_publish_rpm_wave.py
+++ b/tests/test_publish_rpm_wave.py
@@ -1,0 +1,188 @@
+"""The publish wave's safety rules, pinned against the incidents that taught them.
+
+publish-rpm-wave.sh is shared by publish-tideforge-rpms.yml and
+publish-build-chain-rpms.yml. Sharing it is the point: every rule here was
+learned once, and a second hand-copied publisher would have to learn each of
+them again. This repo has already paid for that twice -- the nightly cron
+stagger that was documented but never applied, and the readiness stamp read
+from two paths flatpak had stopped using.
+
+The rules under test:
+
+  empty wave    a build that produced nothing must not look published
+  never shrink  #124: `rclone sync` deletes whatever the local tree lacks
+  '+' renaming  run 32411090239: '+' in a filename 404s through the worker
+  srpms         source RPMs are not installable content
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "publish-rpm-wave.sh"
+
+
+@pytest.fixture
+def stubbed(tmp_path):
+    """rpmsign and createrepo_c stubbed; they need a keyring and a real repo."""
+    binq = tmp_path / "bin"
+    binq.mkdir()
+    for tool in ("rpmsign", "createrepo_c"):
+        p = binq / tool
+        p.write_text(f'#!/bin/sh\necho "{tool} $*" >> "$STUB_LOG"\nexit 0\n')
+        p.chmod(0o755)
+    env = dict(os.environ)
+    env["PATH"] = f"{binq}:{env['PATH']}"
+    env["STUB_LOG"] = str(tmp_path / "stub.log")
+    (tmp_path / "stub.log").write_text("")
+    return env
+
+
+def run(tmp_path, env, staged="staged", repo="repo", subdir="build-chain"):
+    return subprocess.run(
+        ["bash", str(SCRIPT), "--staged", str(tmp_path / staged),
+         "--repo", str(tmp_path / repo), "--subdir", subdir],
+        capture_output=True, text=True, env=env, cwd=tmp_path,
+    )
+
+
+def make(dirpath: Path, *names):
+    dirpath.mkdir(parents=True, exist_ok=True)
+    for n in names:
+        (dirpath / n).write_text("rpm")
+
+
+def rpms(root: Path):
+    return sorted(p.name for p in root.rglob("*.rpm"))
+
+
+# --- empty wave -------------------------------------------------------------
+
+
+def test_an_empty_wave_is_refused(tmp_path, stubbed) -> None:
+    """A build that produced nothing must not rewrite repodata and look green."""
+    make(tmp_path / "staged")
+    r = run(tmp_path, stubbed)
+    assert r.returncode == 1
+    assert "empty wave" in r.stderr
+
+
+def test_a_wave_of_only_srpms_is_an_empty_wave(tmp_path, stubbed) -> None:
+    make(tmp_path / "staged", "foo-1.0.src.rpm")
+    r = run(tmp_path, stubbed)
+    assert r.returncode == 1
+    assert "empty wave" in r.stderr
+
+
+# --- the happy path ---------------------------------------------------------
+
+
+def test_binary_rpms_are_signed_and_placed(tmp_path, stubbed) -> None:
+    make(tmp_path / "staged", "foo-1.0.el10.x86_64.rpm", "bar-2.0.el10.x86_64.rpm")
+    r = run(tmp_path, stubbed)
+    assert r.returncode == 0, r.stderr
+    placed = tmp_path / "repo" / "build-chain"
+    assert rpms(placed) == ["bar-2.0.el10.x86_64.rpm", "foo-1.0.el10.x86_64.rpm"]
+    log = (tmp_path / "stub.log").read_text()
+    assert log.count("rpmsign") == 2
+    assert "createrepo_c" in log
+
+
+def test_srpms_are_not_published(tmp_path, stubbed) -> None:
+    make(tmp_path / "staged", "foo-1.0.el10.x86_64.rpm", "foo-1.0.src.rpm")
+    r = run(tmp_path, stubbed)
+    assert r.returncode == 0, r.stderr
+    assert rpms(tmp_path / "repo") == ["foo-1.0.el10.x86_64.rpm"]
+
+
+def test_existing_packages_are_preserved(tmp_path, stubbed) -> None:
+    """The sync-down content must survive; publishing adds, never replaces."""
+    make(tmp_path / "repo" / "tideforge", "already-1.0.el10.x86_64.rpm")
+    make(tmp_path / "staged", "new-1.0.el10.x86_64.rpm")
+    r = run(tmp_path, stubbed)
+    assert r.returncode == 0, r.stderr
+    assert rpms(tmp_path / "repo") == [
+        "already-1.0.el10.x86_64.rpm", "new-1.0.el10.x86_64.rpm"
+    ]
+
+
+# --- the '+' rename ---------------------------------------------------------
+
+
+def test_plus_is_renamed_in_staged_files(tmp_path, stubbed) -> None:
+    """run 32411090239: the %2b URL 404s through the repo.tunaos.org worker."""
+    make(tmp_path / "staged", "oversteer-udev-0.8.3+git74c7484.el10.noarch.rpm")
+    r = run(tmp_path, stubbed)
+    assert r.returncode == 0, r.stderr
+    assert rpms(tmp_path / "repo") == [
+        "oversteer-udev-0.8.3.git74c7484.el10.noarch.rpm"
+    ]
+
+
+def test_plus_is_renamed_in_files_synced_down_too(tmp_path, stubbed) -> None:
+    """Otherwise the sync leaves the already-broken object in the bucket."""
+    make(tmp_path / "repo" / "tideforge", "old-1.0+git.el10.x86_64.rpm")
+    make(tmp_path / "staged", "new-1.0.el10.x86_64.rpm")
+    r = run(tmp_path, stubbed)
+    assert r.returncode == 0, r.stderr
+    assert "old-1.0.git.el10.x86_64.rpm" in rpms(tmp_path / "repo")
+    assert not any("+" in n for n in rpms(tmp_path / "repo"))
+
+
+# --- never shrink -----------------------------------------------------------
+
+
+def test_the_count_never_shrinks_on_the_happy_path(tmp_path, stubbed) -> None:
+    make(tmp_path / "repo" / "tideforge", *[f"p{i}.el10.x86_64.rpm" for i in range(5)])
+    make(tmp_path / "staged", "new.el10.x86_64.rpm")
+    r = run(tmp_path, stubbed)
+    assert r.returncode == 0, r.stderr
+    assert len(rpms(tmp_path / "repo")) == 6
+    assert "repo already holds 5" in r.stdout
+    assert "repo now holds 6" in r.stdout
+
+
+def test_a_shrinking_tree_is_refused(tmp_path, stubbed) -> None:
+    """#124: syncing up from a smaller tree DELETES the difference.
+
+    Simulated by making the copy step lose files -- a stubbed `cp` that
+    drops them stands in for whatever real cause (disk, permissions, a bad
+    find) would produce the same shape.
+    """
+    make(tmp_path / "repo" / "tideforge", *[f"p{i}.el10.x86_64.rpm" for i in range(5)])
+    make(tmp_path / "staged", "new.el10.x86_64.rpm")
+
+    # A `cp` that silently drops the file, and a `mv` that deletes instead of
+    # renaming, together shrink the tree the way a real fault would.
+    sabotage = Path(stubbed["PATH"].split(":")[0]) / "cp"
+    sabotage.write_text(
+        "#!/bin/sh\n"
+        # consume `-t DEST FILES...`, then delete two pre-existing files
+        f"rm -f {tmp_path}/repo/tideforge/p0.el10.x86_64.rpm "
+        f"{tmp_path}/repo/tideforge/p1.el10.x86_64.rpm\n"
+        "exit 0\n"
+    )
+    sabotage.chmod(0o755)
+
+    r = run(tmp_path, stubbed)
+    assert r.returncode == 1
+    assert "shrank from 5 to 3" in r.stderr
+    assert "DELETES" in r.stderr
+
+
+# --- interface --------------------------------------------------------------
+
+
+def test_missing_arguments_are_refused(tmp_path, stubbed) -> None:
+    r = subprocess.run(
+        ["bash", str(SCRIPT), "--staged", str(tmp_path)],
+        capture_output=True, text=True, env=stubbed,
+    )
+    assert r.returncode == 2
+    assert "usage:" in r.stderr

--- a/tests/test_publishers_share_one_implementation.py
+++ b/tests/test_publishers_share_one_implementation.py
@@ -1,0 +1,81 @@
+"""Both publishers must share the wave logic, and must not race each other.
+
+Two independent failure modes, both already paid for once in this repo:
+
+  DRIFT     the nightly cron stagger was documented and never applied; the
+            readiness stamp was read from two paths flatpak had stopped
+            using. A hand-copied second publisher rots the same way, except
+            the thing that rots holds credentials that can empty a live repo.
+
+  RACE      both publishers `rclone sync` into the same bucket, and sync
+            makes the destination match the source. Two at once delete each
+            other's packages (#124 / INCIDENT-repo-wipe-gnome). A shared
+            concurrency group is the only thing serialising them.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+TIDEFORGE = WORKFLOWS / "publish-tideforge-rpms.yml"
+BUILD_CHAIN = WORKFLOWS / "publish-build-chain-rpms.yml"
+WAVE = ROOT / "scripts" / "publish-rpm-wave.sh"
+
+PUBLISHERS = (TIDEFORGE, BUILD_CHAIN)
+
+
+def doc(path):
+    return yaml.safe_load(path.read_text())
+
+
+@pytest.mark.parametrize("path", PUBLISHERS, ids=lambda p: p.name)
+def test_the_publisher_calls_the_shared_script(path) -> None:
+    body = path.read_text()
+    assert "scripts/publish-rpm-wave.sh" in body, (
+        f"{path.name} does not use the shared wave script; a second copy of "
+        "the sign/index rules will drift from the first"
+    )
+
+
+@pytest.mark.parametrize("path", PUBLISHERS, ids=lambda p: p.name)
+def test_the_publisher_does_not_reimplement_the_rules(path) -> None:
+    """The specific incantations that must live in exactly one place."""
+    body = path.read_text()
+    # Comments may name these; the point is that no publisher RUNS them.
+    run_blocks = "\n".join(
+        step.get("run", "")
+        for job in doc(path)["jobs"].values()
+        for step in (job.get("steps") or [])
+    )
+    for token in ("rpmsign --addsign", "createrepo_c"):
+        assert token not in run_blocks, (
+            f"{path.name} runs `{token}` directly instead of via the shared "
+            "script"
+        )
+
+
+def test_both_publishers_share_one_concurrency_group() -> None:
+    """The race guard. Distinct groups let them run together and sync over
+    each other."""
+    groups = {p.name: doc(p)["concurrency"]["group"] for p in PUBLISHERS}
+    assert len(set(groups.values())) == 1, (
+        f"publishers are in different concurrency groups: {groups}"
+    )
+
+
+@pytest.mark.parametrize("path", PUBLISHERS, ids=lambda p: p.name)
+def test_the_publisher_does_not_cancel_in_progress(path) -> None:
+    """Cancelling mid-sync leaves the bucket half-written."""
+    assert doc(path)["concurrency"]["cancel-in-progress"] is False
+
+
+def test_the_wave_script_is_executable_and_self_documenting() -> None:
+    assert WAVE.exists()
+    text = WAVE.read_text()
+    for rule in ("EMPTY WAVE", "NEVER SHRINK", "'+' IN NAMES", "SRPMS EXCLUDED"):
+        assert rule in text, f"the {rule} rule lost its reasoning"


### PR DESCRIPTION
Gives the native build chain the publisher it has never had. Context and analysis in #459.

## The gap

`gnome50-el10-x86_64` produces **55 packages across 19 tiers and a 497 MB artifact** (run 32429674500) — and none of it is installable by anything. `publish-tideforge-rpms.yml` (#451) covers tideforge cells only; nothing takes `.factory/<cell>/artifacts/*.rpm` to R2.

That gap is what every remaining el10 blocker outside cosmic-session collapses to: `xfwl4` wants `libxfce4ui-devel`, `cosmic-settings-daemon` wants `adw-gtk3-theme` — both build-chain products, both built, neither served.

## Deliberately not a second copy of the tideforge publisher

The sign/place/index half moves to `scripts/publish-rpm-wave.sh`, and **both** publishers call it. Every rule in it was learned from an incident:

| rule | incident |
|---|---|
| **EMPTY WAVE** | a build that produced nothing must not rewrite repodata and read as published |
| **NEVER SHRINK** | #124 / INCIDENT-repo-wipe-gnome — `rclone sync` makes the destination match the source, so a tree that came out smaller than it went in **deletes the difference from the bucket** |
| **'+' IN NAMES** | run 32411090239 — librepo percent-encodes `+` but the worker looks up raw paths, so those files 404 at install |
| **SRPMS** | not installable content |

A hand-copied second publisher would have to learn each of them again. This repo has already paid for that drift twice this week — the nightly cron stagger documented but never applied, and the readiness stamp read from two paths flatpak had stopped using. The difference here is that the thing that would rot holds credentials able to empty a live repo.

**NEVER SHRINK is new.** The tideforge publisher had only the sync-down sanity check, which catches a bad download but not a bad local step.

## Two destinations are refused, by name and loudly

`scripts/plan-build-chain-publish.py` resolves requested cells against the catalog's own `r2_path` and rejects:

- **COLLISION.** `publish-tideforge-rpms.yml` syncs x86_64 to `repo/10-stream-x86_64` and mirrors it to `repo/10-x86_64`. `gnome50-el10-x86_64` declares **exactly** `repo/10-x86_64`. Since sync makes the destination match the source, publishing gnome50 there means the next tideforge run deletes it, and this run deletes tideforge's packages in between. Serialising the workflows stops a *race*, not an *overwrite*. That's a catalog question — own prefix, or a union mirror — and not one to guess at while holding credentials that can empty a repo.
- **NO HOME.** An empty `r2_path`, or `publish: false`. `fprintd-el10-x86_64` is both.

Any rejection fails the whole wave: a partial publish that silently dropped the requested cell reads green while the package is still missing.

Both publishers now share one concurrency group, so they can never sync into the same bucket at once.

## Verification

32 new tests, all mutation-checked:

| mutation | caught by |
|---|---|
| split the concurrency groups | `test_both_publishers_share_one_concurrency_group` |
| re-inline `rpmsign`/`createrepo_c` | `test_the_publisher_does_not_reimplement_the_rules` |
| sabotage the copy so the tree shrinks | `shrank from 5 to 3 … DELETES` |
| any tideforge destination as `r2_path` | `test_a_tideforge_destination_is_refused` |

The planner was also run against the **live catalog**: `xfce-el10-x86_64` → `xfce/10-stream-x86_64`; `gnome50-el10-x86_64` refused for the collision; `fprintd-el10-x86_64` refused for `publish: false`.

Full suite: **698 passed, 1 skipped.**

## Not yet proven

No wave has been published with this. The first dispatch is the real test — and `dry_run: true` builds, signs and indexes without syncing, so that can be checked without touching the bucket. I'd suggest `xfce-el10-x86_64` as the first cell: it has an uncontested destination and its `libxfce4ui-devel` is what `xfwl4` is blocked on.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_