### PR TITLE
fix(publish): supply SOURCE_DATE_EPOCH to the build-chain cell runner

### DIFF
--- a/.github/workflows/publish-build-chain-rpms.yml
+++ b/.github/workflows/publish-build-chain-rpms.yml
@@ -75,16 +75,34 @@ jobs:
         run: |
           sudo apt-get update -q
           sudo apt-get install -y -q createrepo-c podman rpm
+      - id: epoch
+        name: Date the build reproducibly
+        # run-package-factory-cell.sh requires SOURCE_DATE_EPOCH (`${VAR:?}`),
+        # and the first dispatch of this workflow died on its absence:
+        #   run-package-factory-cell.sh: line 14: SOURCE_DATE_EPOCH:
+        #   parameter null or not set
+        # Same derivation as package-factory-cell.yml's identity step for a
+        # build-chain cell: the newest commit touching the manifest or any of
+        # the family's source paths.
+        env:
+          SOURCE_PATHS: ${{ toJSON(matrix.source_paths) }}
+        run: |
+          set -euo pipefail
+          mapfile -t source_paths < <(jq -r '.[]' <<<"$SOURCE_PATHS")
+          epoch=$(git log -1 --format=%ct -- '${{ matrix.manifest }}' "${source_paths[@]}")
+          echo "epoch=$epoch" >> "$GITHUB_OUTPUT"
       - name: Build the cell
         env:
           CELL_ID: ${{ matrix.id }}
           ENGINE: build-chain
+          # No RECIPE or FORMAT: the build-chain branch of the runner exits
+          # before either is read (they belong to the tideforge path).
           TARGET: ${{ matrix.target }}
-          FORMAT: rpm
           ARCHITECTURE: ${{ matrix.architecture }}
           IMAGE: ${{ matrix.image }}
           MANIFEST: ${{ matrix.manifest }}
           MOCK_CONFIG: ${{ matrix.mock_config }}
+          SOURCE_DATE_EPOCH: ${{ steps.epoch.outputs.epoch }}
         run: bash scripts/run-package-factory-cell.sh
       - uses: actions/upload-artifact@v7
         with:

--- a/scripts/plan-build-chain-publish.py
+++ b/scripts/plan-build-chain-publish.py
@@ -92,6 +92,10 @@ def resolve(requested, available):
             "image": cell.get("image", ""),
             "manifest": cell.get("manifest", ""),
             "mock_config": cell.get("mock_config", ""),
+            # Needed to date the build reproducibly: SOURCE_DATE_EPOCH is the
+            # newest commit touching the manifest or any source path, the same
+            # derivation package-factory-cell.yml's identity step uses.
+            "source_paths": cell.get("source_paths", []),
             "r2_path": path,
         })
     return selected, rejections

--- a/tests/test_cell_runner_env_contract.py
+++ b/tests/test_cell_runner_env_contract.py
@@ -1,0 +1,123 @@
+"""Every workflow that runs the cell script must supply what its engine reads.
+
+scripts/run-package-factory-cell.sh hard-requires variables via `${VAR:?}`.
+A caller that omits one fails at the first line that reads it -- after the
+checkout, the apt-get and the image pull have all been paid for -- with a
+message naming the variable but not the caller.
+
+That is how the first dispatch of publish-build-chain-rpms.yml died:
+
+    run-package-factory-cell.sh: line 14: SOURCE_DATE_EPOCH: parameter null
+    or not set
+
+Every unit test around that workflow passed. They covered the planner and the
+wave script -- the parts written in Python and bash -- and not the YAML glue
+between them, which is where the defect was.
+
+Two things this test has to model correctly, both learned by getting them
+wrong first:
+
+  ENGINE BRANCHES  the requirement is not one flat list. CELL_ID, ENGINE,
+                   TARGET, ARCHITECTURE, IMAGE and SOURCE_DATE_EPOCH are read
+                   before the branch; MANIFEST and MOCK_CONFIG only on the
+                   build-chain path, which then `exit 0`s; RECIPE and FORMAT
+                   only on the tideforge path. Demanding all ten of every
+                   caller flags the working publisher.
+
+  HOW IT ARRIVES   a variable can come from workflow env, job env, step env,
+                   or be assigned inside the run block. publish-tideforge
+                   -rpms.yml computes SOURCE_DATE_EPOCH with `git log` in the
+                   script body and exports it there. Checking only `env:`
+                   keys reports a false failure.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNNER = ROOT / "scripts" / "run-package-factory-cell.sh"
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+_REQUIRED = re.compile(r"\$\{([A-Z_][A-Z0-9_]*):\?")
+_BUILD_CHAIN_GUARD = "if [[ $engine == build-chain ]]; then"
+_TIDEFORGE_GUARD = "[[ $engine == tideforge ]]"
+
+
+def _requirements():
+    """(always, build_chain_only, tideforge_only) variable names."""
+    text = RUNNER.read_text()
+    bc_start = text.index(_BUILD_CHAIN_GUARD)
+    tf_start = text.index(_TIDEFORGE_GUARD)
+    always = set(_REQUIRED.findall(text[:bc_start]))
+    build_chain = set(_REQUIRED.findall(text[bc_start:tf_start])) - always
+    tideforge = set(_REQUIRED.findall(text[tf_start:])) - always
+    return always, build_chain, tideforge
+
+
+ALWAYS, BUILD_CHAIN_ONLY, TIDEFORGE_ONLY = _requirements()
+
+
+def _callers():
+    out = []
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        text = path.read_text()
+        if "run-package-factory-cell.sh" not in text:
+            continue
+        doc = yaml.safe_load(text)
+        wf_env = set((doc.get("env") or {}).keys())
+        for job in (doc.get("jobs") or {}).values():
+            job_env = set((job.get("env") or {}).keys())
+            for step in (job.get("steps") or []):
+                body = step.get("run") or ""
+                if "run-package-factory-cell.sh" not in body:
+                    continue
+                step_env = dict(step.get("env") or {})
+                # A variable may also be assigned or exported in the body.
+                assigned = set(re.findall(r"^\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=", body, re.M))
+                out.append({
+                    "path": path,
+                    "engine": str(step_env.get("ENGINE", job.get("env", {}).get("ENGINE", ""))),
+                    "supplied": wf_env | job_env | set(step_env) | assigned,
+                })
+    return out
+
+
+CALLERS = _callers()
+
+
+def test_the_requirement_split_is_not_vacuous() -> None:
+    """Guards the guard: a parse that found nothing would pass everything."""
+    assert "SOURCE_DATE_EPOCH" in ALWAYS
+    assert "MANIFEST" in BUILD_CHAIN_ONLY
+    assert "RECIPE" in TIDEFORGE_ONLY
+
+
+def test_callers_are_found() -> None:
+    assert CALLERS, "no workflow appears to run run-package-factory-cell.sh"
+
+
+@pytest.mark.parametrize("caller", CALLERS, ids=lambda c: f"{c['path'].name}:{c['engine'] or '?'}")
+def test_every_caller_supplies_what_its_engine_reads(caller) -> None:
+    needed = set(ALWAYS)
+    engine = caller["engine"]
+    if engine == "build-chain":
+        needed |= BUILD_CHAIN_ONLY
+    elif engine == "tideforge":
+        needed |= TIDEFORGE_ONLY
+    else:
+        # An engine chosen at runtime (a matrix expression) could take either
+        # branch, so it must satisfy both.
+        needed |= BUILD_CHAIN_ONLY | TIDEFORGE_ONLY
+
+    missing = needed - caller["supplied"]
+    assert not missing, (
+        f"{caller['path'].name} runs the cell script with ENGINE="
+        f"{engine or '<dynamic>'} but does not supply {sorted(missing)}; "
+        "the script exits on the first one it reads, after the checkout and "
+        "the image pull have already been paid for"
+    )


### PR DESCRIPTION
Fixes the first dispatch of the publisher merged in #463.

## What happened

Run 32450335840 died 35 seconds in:

```
run-package-factory-cell.sh: line 14: SOURCE_DATE_EPOCH: parameter null or not set
```

The `plan` job was fine — it resolved `xfce-el10-x86_64` → `xfce/10-stream-x86_64` and emitted the matrix, exactly as designed. The `build` job never got past the runner's third line, because the workflow didn't pass an environment variable the script hard-requires.

## The fix

Derive it the way `package-factory-cell.yml`'s identity step does for a build-chain cell: the newest commit touching the manifest or any of the family's source paths. That needed `source_paths` threaded through the planner — already in the catalog data, simply not carried over.

Verified against the real cell: `build-order-xfce.yml` + `src/xfce-wayland/` → `1787244481` (2026-08-20 16:48:01Z).

Also dropped `RECIPE` and `FORMAT` from that step. I'd added `RECIPE: ""` with a comment claiming the script requires the name to be set — a misreading. The build-chain branch `exit 0`s before either is read; they belong to the tideforge path.

## Why the tests didn't catch it

They covered the planner and the wave script — the parts written in Python and bash — and **not the YAML glue between them**, which is where the defect was.

That's the same shape as two other bugs fixed this week: the `tail -30` that hid the very log it captured, and the uncapped sweep that recreated the herd the stagger had just removed. In each case the unit was right and the seam was wrong.

`tests/test_cell_runner_env_contract.py` now checks the seam: for every workflow that runs the cell script, every `${VAR:?}` its engine actually reaches must be supplied. Two things it has to model — both of which I got wrong on the first attempt:

- **Engine branches.** The requirement isn't one flat list. Six vars are read before the branch; `MANIFEST`/`MOCK_CONFIG` only on build-chain; `RECIPE`/`FORMAT` only on tideforge. A flat list flags the *working* publisher as broken.
- **How it arrives.** A variable can come from workflow env, job env, step env, or be assigned in the run body — `publish-tideforge-rpms.yml` computes `SOURCE_DATE_EPOCH` with `git log` inside the script. Checking only `env:` keys reports a false failure on a green workflow.

## Verification

Deleting `SOURCE_DATE_EPOCH` from the workflow reproduces the real run's failure **verbatim**, naming that variable:

```
publish-build-chain-rpms.yml runs the cell script with ENGINE=build-chain
but does not supply ['SOURCE_DATE_EPOCH']
```

Deleting `MOCK_CONFIG` catches the build-chain-only case. Full suite: **703 passed, 1 skipped.**

Re-dispatching the dry run once this merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_