### PR TITLE
fix(publish): give gnome50 its own R2 prefix, not the shared repo path

### DIFF
--- a/manifests/package-builds.yaml
+++ b/manifests/package-builds.yaml
@@ -28,7 +28,17 @@ native_builds:
     manifest: build-order.yml
     mock_config: centos-stream-10-ci
     source_paths: [src/gnome-50/, src/deps/]
-    r2_path: repo/10-x86_64
+    # gnome50/..., not repo/10-x86_64. The old value is the one path in this
+    # file that does not follow <family>/<tag> -- gnome49, gnome51, xfce and
+    # fprintd all do -- and it is historical: the March distributed build
+    # wrote the main repo path directly, before there was a tideforge
+    # publisher to collide with. There is now. publish-tideforge-rpms.yml
+    # MIRRORS its x86_64 tree to repo/10-x86_64 with `rclone sync`, and sync
+    # makes the destination match the source: publishing gnome50 there means
+    # the next tideforge run deletes all 55 of its packages, and this one
+    # deletes tideforge's in between. Sharing a concurrency group stops the
+    # two racing; it does not stop them overwriting.
+    r2_path: gnome50/10-stream-x86_64
   - id: gnome51-el10-x86_64
     family: gnome51
     track: next

--- a/tests/test_plan_build_chain_publish.py
+++ b/tests/test_plan_build_chain_publish.py
@@ -140,3 +140,49 @@ def test_every_rejection_is_reported_not_just_the_first() -> None:
     )
     _, rejections = planner.resolve(["a", "b", "c"], available)
     assert len(rejections) == 3
+
+
+# --- the invariant, against the real manifests ------------------------------
+
+
+def test_no_declared_r2_path_collides_with_the_tideforge_publisher() -> None:
+    """The durable half of the gnome50 fix.
+
+    Correcting one manifest entry stops that collision; this stops the next
+    one. A family given a colliding r2_path would be refused at plan time
+    (loudly, which is good) but the refusal is a symptom -- the defect is a
+    catalog that can express "publish here" for a destination another
+    publisher `rclone sync`s into.
+    """
+    offenders = {
+        cell["id"]: cell["r2_path"]
+        for cell in planner.build_chain_cells().values()
+        if (cell.get("r2_path") or "").strip().strip("/")
+        in planner.TIDEFORGE_DESTINATIONS
+    }
+    assert offenders == {}, (
+        f"these cells declare a destination publish-tideforge-rpms.yml syncs "
+        f"into, so the two publishers would delete each other's packages: "
+        f"{offenders}"
+    )
+
+
+def test_gnome50_follows_the_family_prefix_convention() -> None:
+    """gnome49 and gnome51 both use <family>/10-stream-x86_64; 50 was the odd
+    one out, pointing at the shared repo path for historical reasons."""
+    cells = planner.build_chain_cells()
+    assert cells["gnome50-el10-x86_64"]["r2_path"] == "gnome50/10-stream-x86_64"
+
+
+def test_every_build_chain_family_has_a_distinct_destination() -> None:
+    """Two families sharing a prefix is the same overwrite fault, internally."""
+    seen = {}
+    for cell in planner.build_chain_cells().values():
+        path = (cell.get("r2_path") or "").strip().strip("/")
+        if not path:
+            continue
+        assert path not in seen, (
+            f"{cell['id']} and {seen[path]} both publish to '{path}'; "
+            "whichever syncs second deletes the first"
+        )
+        seen[path] = cell["id"]


### PR DESCRIPTION
Resolves the one destination #463 refused.

## What #463 left open

The build-chain publisher landed with `gnome50-el10-x86_64` refused, because its declared `r2_path` was `repo/10-x86_64` — the exact prefix `publish-tideforge-rpms.yml` **mirrors** its x86_64 tree into with `rclone sync`. Sync makes the destination match the source, so publishing gnome50 there means the next tideforge run deletes all 55 of its packages, and this one deletes tideforge's in between. Sharing a concurrency group stops the two *racing*; it does not stop them *overwriting*.

I refused it rather than guessing while holding credentials that can empty a live repo.

## The manifests answer it without guessing

```
gnome49-el10-x86_64  -> gnome49/10-stream-x86_64
gnome50-el10-x86_64  -> repo/10-x86_64             <- the only anomaly
gnome51-el10-x86_64  -> gnome51/10-stream-x86_64
xfce-el10-x86_64     -> xfce/10-stream-x86_64
fprintd-el10-aarch64 -> fprintd/10-stream-aarch64
```

Every family uses `<family>/<tag>` — gnome49 and gnome51 included, the same lineage on either side of gnome50. `repo/10-x86_64` is historical: the March distributed build wrote the main repo path directly, before there was a tideforge publisher to collide with.

So this restores the convention gnome50 was always meant to follow rather than inventing a destination for it.

## The durable half

A test against the **real manifests**: no build-chain `r2_path` may be one `publish-tideforge-rpms.yml` syncs into, and no two families may share a destination.

Correcting one entry fixes this collision; the invariant stops the next. A colliding path would already be refused at plan time — loudly, which is good — but the refusal is a *symptom*. The defect is a catalog that can express "publish here" for a destination another publisher will overwrite.

## Verification

3 new tests, mutation-checked:

| mutation | caught by |
|---|---|
| restore `repo/10-x86_64` | `test_no_declared_r2_path_collides_with_the_tideforge_publisher`, `test_gnome50_follows_the_family_prefix_convention` |
| give xfce gnome51's path | `test_every_build_chain_family_has_a_distinct_destination` |

Against the live catalog the planner now resolves `gnome50-el10-x86_64 -> gnome50/10-stream-x86_64`. Full suite: **701 passed, 1 skipped**.

## Note on #464

Rebasing this surfaced #464 — `SOURCE_DATE_EPOCH` missing from the build-chain cell runner's env, which killed #463's first dispatch 35 seconds in. That was my defect: I wrote the env block without checking which variables `run-package-factory-cell.sh` hard-requires via `${VAR:?}`. It's already merged, and this branch is rebased on top of it rather than around it.

With both in place, `gnome50-el10-x86_64` and `xfce-el10-x86_64` are both dispatchable. `dry_run: true` still builds, signs and indexes without touching the bucket.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_