### PR TITLE
feat(publish): verify the wave is in the served index, not just that CI passed

### DIFF
--- a/.github/workflows/publish-build-chain-rpms.yml
+++ b/.github/workflows/publish-build-chain-rpms.yml
@@ -179,3 +179,46 @@ jobs:
         if: ${{ inputs.dry_run }}
         run: |
           echo "::notice::dry run — built, signed and indexed ${{ matrix.id }} but synced nothing to ${{ matrix.r2_path }}"
+
+  # The #179 job, and the one this publisher shipped without.
+  #
+  # publish-tideforge-rpms.yml has carried a verify job from its first
+  # publish, for the reason its own comment gives: "a repo that was never
+  # actually published can never sit behind a green workflow". Every step
+  # here can succeed -- build, sign, index, rclone sync -- and the packages
+  # still not be reachable, because "the workflow exited 0" and "dnf can
+  # install it" are different claims and only the second one matters.
+  #
+  # It earned its place immediately. Run against the live indexes while being
+  # written, it showed libxfce4ui-devel already served at
+  # xfce/10-stream-x86_64 and entirely absent from repo/10/x86_64 -- the el10
+  # target's published_index, the repo tideforge buildroots actually read. The
+  # package was never unpublished; it was published where nothing looks
+  # (tuna-os/tunaos-packages#466).
+  #
+  # ON THE URL. Derived from r2_path, which is safe for the build-chain
+  # families and NOT in general: manifests/package-factory.yaml records that
+  # the el10 tideforge target writes rpm/el10/x86_64 and serves
+  # repo/10/x86_64. Confirmed by request that xfce/10-stream-x86_64,
+  # xfce/44-x86_64 and hummingbird/20251124-* each serve at their own
+  # r2_path. A family whose read path diverges must gain an explicit key
+  # rather than being quietly mis-verified against a URL that 404s.
+  verify:
+    needs: [plan, publish]
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          name: publish-rpm-${{ matrix.id }}
+          path: staged
+      - name: Assert every published package is in the served index
+        run: |
+          set -euo pipefail
+          python3 scripts/verify-published-wave.py \
+            --served-url "https://repo.tunaos.org/${{ matrix.r2_path }}/" \
+            --staged staged

--- a/scripts/verify-published-wave.py
+++ b/scripts/verify-published-wave.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Assert that a published wave is actually in the SERVED index.
+
+This is the #179 lesson, which publish-tideforge-rpms.yml already carries a
+verify job for and publish-build-chain-rpms.yml shipped without: a repo that
+was never really published sitting behind a green workflow. Every step can
+succeed -- build, sign, index, rclone sync -- and the packages still not be
+reachable, because "the workflow exited 0" and "dnf can install it" are
+different claims and only the second one matters.
+
+WHAT IT CHECKS
+
+Every binary RPM in the staged wave must appear as a <location href> in the
+served repository's primary index. That is stronger than fetching repomd.xml
+(which proves a repo exists, not that it contains this wave) and needs no
+knowledge of package names, so it works for any family.
+
+TWO THINGS IT HAS TO MODEL
+
+  '+' RENAMING   publish-rpm-wave.sh renames '+' to '.' in filenames, because
+                 librepo percent-encodes '+' while the repo.tunaos.org worker
+                 looks up raw paths, so those files 404 at install time (run
+                 32411090239). The index therefore holds the RENAMED name and
+                 a naive comparison against the staged name reports every
+                 such package missing.
+
+  SRPMS          excluded from publishing, so they must be excluded here too
+                 or every wave looks short.
+
+ON THE URL
+
+The served URL is passed in rather than derived, because write path and read
+path are NOT always the same: manifests/package-factory.yaml records that
+rpm/el10/x86_64 404s while repo/10/x86_64 serves. For the build-chain
+families they do coincide (xfce/10-stream-x86_64, xfce/44-x86_64 and
+hummingbird/20251124-* all serve at their r2_path, verified by request), but
+deriving it here would bake in an assumption that is false one target over.
+"""
+from __future__ import annotations
+
+import argparse
+import gzip
+import io
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+TIMEOUT = 60
+
+
+def published_names(staged: Path) -> set[str]:
+    """Filenames as they will appear in the index, after the '+' rename."""
+    return {
+        p.name.replace("+", ".")
+        for p in staged.rglob("*.rpm")
+        if not p.name.endswith(".src.rpm")
+    }
+
+
+def fetch(url: str) -> bytes:
+    with urllib.request.urlopen(url, timeout=TIMEOUT) as fh:
+        return fh.read()
+
+
+def primary_href(repomd: bytes) -> str | None:
+    """The primary index's location, from repomd.xml."""
+    # Deliberately a regex rather than an XML parse: repomd.xml is namespaced
+    # and tiny, and the one thing needed is unambiguous in the raw text.
+    for block in re.findall(rb'<data[^>]*type="primary"[^>]*>.*?</data>',
+                            repomd, re.S):
+        m = re.search(rb'<location[^>]*href="([^"]+)"', block)
+        if m:
+            return m.group(1).decode()
+    return None
+
+
+def indexed_names(served_url: str) -> set[str]:
+    base = served_url.rstrip("/") + "/"
+    repomd = fetch(base + "repodata/repomd.xml")
+    href = primary_href(repomd)
+    if not href:
+        raise RuntimeError(f"no primary index in {base}repodata/repomd.xml")
+    raw = fetch(base + href)
+    if href.endswith(".gz"):
+        raw = gzip.decompress(raw)
+    # Index hrefs are repo-relative paths; only the basename is comparable.
+    return {h.decode().rsplit("/", 1)[-1]
+            for h in re.findall(rb'<location[^>]*href="([^"]+)"', raw)}
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--served-url", required=True)
+    ap.add_argument("--staged", required=True, type=Path)
+    args = ap.parse_args(argv)
+
+    expected = published_names(args.staged)
+    if not expected:
+        print(f"ERROR: no binary RPMs under {args.staged}; nothing to verify",
+              file=sys.stderr)
+        return 2
+
+    try:
+        served = indexed_names(args.served_url)
+    except Exception as exc:
+        print(f"ERROR: could not read the served index at "
+              f"{args.served_url}: {exc}", file=sys.stderr)
+        return 1
+
+    missing = sorted(expected - served)
+    print(f"==> {len(expected)} published, {len(served)} in the served index "
+          f"at {args.served_url}")
+    if missing:
+        print(f"ERROR: {len(missing)} published package(s) are NOT in the "
+              f"served index -- the workflow went green and the repo did not "
+              f"actually receive them:", file=sys.stderr)
+        for name in missing[:40]:
+            print(f"  {name}", file=sys.stderr)
+        if len(missing) > 40:
+            print(f"  ... and {len(missing) - 40} more", file=sys.stderr)
+        return 1
+
+    print(f"==> all {len(expected)} published package(s) are served")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_publishers_share_one_implementation.py
+++ b/tests/test_publishers_share_one_implementation.py
@@ -79,3 +79,29 @@ def test_the_wave_script_is_executable_and_self_documenting() -> None:
     text = WAVE.read_text()
     for rule in ("EMPTY WAVE", "NEVER SHRINK", "'+' IN NAMES", "SRPMS EXCLUDED"):
         assert rule in text, f"the {rule} rule lost its reasoning"
+
+
+# --- the #179 job -----------------------------------------------------------
+
+
+@pytest.mark.parametrize("path", PUBLISHERS, ids=lambda p: p.name)
+def test_the_publisher_verifies_what_it_served(path) -> None:
+    """Neither publisher may trust its own exit code.
+
+    "the workflow exited 0" and "dnf can install it" are different claims and
+    only the second matters. #463 shipped without this; the check found a
+    real wrong assumption on its first use (#466).
+    """
+    jobs = doc(path)["jobs"]
+    assert "verify" in jobs, (
+        f"{path.name} has no verify job -- a repo that was never actually "
+        "published would sit behind a green workflow (#179)"
+    )
+    assert "publish" in jobs["verify"]["needs"]
+
+
+def test_the_build_chain_verify_does_not_run_on_a_dry_run() -> None:
+    """A dry run syncs nothing, so verifying the served index would fail on
+    the previous wave's contents and read as a publish defect."""
+    verify_job = doc(BUILD_CHAIN)["jobs"]["verify"]
+    assert "dry_run" in str(verify_job.get("if", ""))

--- a/tests/test_verify_published_wave.py
+++ b/tests/test_verify_published_wave.py
@@ -1,0 +1,149 @@
+"""A wave is not published until the SERVED index lists it.
+
+This is the #179 lesson: a repo that was never really published sitting
+behind a green workflow. publish-tideforge-rpms.yml carries a verify job for
+exactly this; publish-build-chain-rpms.yml (#463) shipped without one, so it
+trusted "the workflow exited 0" for the one failure mode that phrase cannot
+detect.
+
+The check earned its place on first contact with reality. Run against the
+live indexes it showed libxfce4ui-devel already served at
+xfce/10-stream-x86_64 and entirely absent from repo/10/x86_64 -- which is
+the el10 target's published_index, the repo tideforge buildroots actually
+read. The package was never unpublished; it was published where nothing
+looks. See #466.
+
+Two behaviours have to be modelled or the check lies:
+
+  '+' RENAMING   publish-rpm-wave.sh renames '+' to '.', so the index holds
+                 the renamed name and a naive comparison reports every such
+                 package missing (run 32411090239).
+  SRPMS          excluded from publishing, so excluded here, or every wave
+                 looks short.
+"""
+from __future__ import annotations
+
+import gzip
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "verify-published-wave.py"
+
+_spec = importlib.util.spec_from_file_location("verify_wave", SCRIPT)
+verify = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(verify)
+
+
+REPOMD = b'''<?xml version="1.0" encoding="UTF-8"?>
+<repomd xmlns="http://linux.duke.edu/metadata/repo">
+  <data type="filelists"><location href="repodata/aaa-filelists.xml.gz"/></data>
+  <data type="primary"><location href="repodata/bbb-primary.xml.gz"/></data>
+  <data type="other"><location href="repodata/ccc-other.xml.gz"/></data>
+</repomd>'''
+
+
+def primary_for(*names):
+    body = "".join(
+        f'<package><location href="build-chain/{n}"/></package>' for n in names
+    )
+    return gzip.compress(f"<metadata>{body}</metadata>".encode())
+
+
+def stage(tmp_path, *names):
+    d = tmp_path / "staged"
+    d.mkdir(exist_ok=True)
+    for n in names:
+        (d / n).write_text("rpm")
+    return d
+
+
+def transport(primary):
+    def fetch(url):
+        if url.endswith("repomd.xml"):
+            return REPOMD
+        if url.endswith("-primary.xml.gz"):
+            return primary
+        raise AssertionError(f"unexpected fetch: {url}")
+    return fetch
+
+
+# --- what counts as published -----------------------------------------------
+
+
+def test_srpms_are_not_expected_in_the_index(tmp_path) -> None:
+    d = stage(tmp_path, "foo-1.0.el10.x86_64.rpm", "foo-1.0.src.rpm")
+    assert verify.published_names(d) == {"foo-1.0.el10.x86_64.rpm"}
+
+
+def test_plus_is_renamed_the_same_way_the_publisher_renames_it(tmp_path) -> None:
+    """Otherwise every '+'-named package reports missing forever."""
+    d = stage(tmp_path, "oversteer-udev-0.8.3+git74c7484.el10.noarch.rpm")
+    assert verify.published_names(d) == {
+        "oversteer-udev-0.8.3.git74c7484.el10.noarch.rpm"
+    }
+
+
+# --- reading the served index -----------------------------------------------
+
+
+def test_primary_href_picks_primary_not_filelists() -> None:
+    assert verify.primary_href(REPOMD) == "repodata/bbb-primary.xml.gz"
+
+
+def test_primary_href_is_none_when_absent() -> None:
+    assert verify.primary_href(b"<repomd></repomd>") is None
+
+
+def test_indexed_names_gunzips_and_takes_basenames(monkeypatch) -> None:
+    monkeypatch.setattr(verify, "fetch",
+                        transport(primary_for("a-1.el10.x86_64.rpm")))
+    assert verify.indexed_names("https://example.test/repo/") == {
+        "a-1.el10.x86_64.rpm"
+    }
+
+
+# --- the verdict ------------------------------------------------------------
+
+
+def test_a_fully_served_wave_passes(tmp_path, monkeypatch, capsys) -> None:
+    d = stage(tmp_path, "a-1.el10.x86_64.rpm", "b-2.el10.x86_64.rpm")
+    monkeypatch.setattr(verify, "fetch", transport(
+        primary_for("a-1.el10.x86_64.rpm", "b-2.el10.x86_64.rpm", "old.rpm")))
+    rc = verify.main(["--served-url", "https://example.test/repo/",
+                      "--staged", str(d)])
+    assert rc == 0
+    assert "all 2 published package(s) are served" in capsys.readouterr().out
+
+
+def test_a_missing_package_fails_and_is_named(tmp_path, monkeypatch, capsys) -> None:
+    """The #179 shape: workflow green, package not actually reachable."""
+    d = stage(tmp_path, "a-1.el10.x86_64.rpm", "ghost-9.el10.x86_64.rpm")
+    monkeypatch.setattr(verify, "fetch",
+                        transport(primary_for("a-1.el10.x86_64.rpm")))
+    rc = verify.main(["--served-url", "https://example.test/repo/",
+                      "--staged", str(d)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "ghost-9.el10.x86_64.rpm" in err
+    assert "did not actually receive them" in err
+
+
+def test_an_unreachable_repo_fails_rather_than_passing_vacuously(
+        tmp_path, monkeypatch) -> None:
+    d = stage(tmp_path, "a-1.el10.x86_64.rpm")
+
+    def boom(url):
+        raise OSError("404")
+    monkeypatch.setattr(verify, "fetch", boom)
+    assert verify.main(["--served-url", "https://example.test/nope/",
+                        "--staged", str(d)]) == 1
+
+
+def test_an_empty_stage_is_an_error_not_a_pass(tmp_path) -> None:
+    """Zero expected packages would otherwise satisfy any index trivially."""
+    d = stage(tmp_path)
+    assert verify.main(["--served-url", "https://example.test/repo/",
+                        "--staged", str(d)]) == 2


### PR DESCRIPTION
Adds the verify job #463 shipped without — and which found a wrong assumption before it even merged.

## The gap

`publish-tideforge-rpms.yml` has carried a verify job since its first publish, for the reason its own comment gives: *"a repo that was never actually published can never sit behind a green workflow"* (#179). Every step can succeed — build, sign, index, `rclone sync` — and the packages still not be reachable, because **"the workflow exited 0" and "dnf can install it" are different claims and only the second one matters.**

My publisher trusted the first for exactly the failure mode the second exists to catch. That was my omission in #463.

## The check

Every binary RPM in the wave must appear as a `<location href>` in the **served** primary index. Stronger than fetching `repomd.xml` (which proves a repo exists, not that it holds this wave), and it needs no package-name knowledge, so it works for any family.

Two behaviours it has to model or it reports false failures:

- **`+` renaming** — `publish-rpm-wave.sh` renames `+` to `.` because librepo percent-encodes `+` while the worker looks up raw paths (run 32411090239). The index holds the *renamed* name.
- **srpms** — excluded from publishing, so excluded here.

The served URL is **passed in, not derived**: `manifests/package-factory.yaml` records that the el10 tideforge target writes `rpm/el10/x86_64` and serves `repo/10/x86_64`. I confirmed by request that `xfce/10-stream-x86_64`, `xfce/44-x86_64` and `hummingbird/20251124-*` each serve at their own `r2_path`, so deriving is safe for build-chain families specifically — and would be wrong one target over.

## It earned its place before shipping

Run against the live indexes while being written:

| served URL | packages | `libxfce4ui*` |
|---|---|---|
| `xfce/10-stream-x86_64/` | 107 | **present**, incl. `libxfce4ui-devel` |
| `repo/10/x86_64/` — el10's `published_index` | 358 | **none** |

So `libxfce4ui-devel` was **never unpublished**. It's published where nothing looks, and `tideforge-xfwl4-el10` is blocked by that rather than by a missing publish.

The premise several of today's changes rested on — mine included — was wrong, and a check whose entire job is "do not trust the exit code" caught it on first contact with real data. Filed as #467. #466 closed, because its conclusion followed from the same wrong premise.

## Verification

9 tests on the script, 2 structural on the workflows, all mutation-checked:

| mutation | caught by |
|---|---|
| remove the verify job | `test_the_publisher_verifies_what_it_served` |
| let verify run on a dry run | `test_the_build_chain_verify_does_not_run_on_a_dry_run` |

That dry-run guard matters: a dry run syncs nothing, so verifying the served index would check the *previous* wave and read as a publish defect. An unreachable repo and an empty stage both fail rather than passing vacuously.

Full suite: **715 passed, 1 skipped.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_