### PR TITLE
fix(libunwind): link libgcc so the aarch64 library resolves at load (#469)

### DIFF
--- a/packages/libunwind-devel/package.yaml
+++ b/packages/libunwind-devel/package.yaml
@@ -13,6 +13,17 @@ build_system: autotools
 build:
   autoreconf: true
   configure_options: [--disable-tests]
+  environment:
+    # aarch64 GCC emits outline-atomics calls (__aarch64_cas8_acq_rel and
+    # friends) that live in libgcc. libunwind's link line does not pull it in,
+    # so the shipped libunwind.so.8 carried four UNDEFINED symbols and every
+    # consumer died at load: "symbol lookup error: /lib64/libunwind.so.8"
+    # (#469, seen on tideforge-quickshell-el10-aarch64).
+    #
+    # LIBS rather than LDFLAGS: LDFLAGS is already set by the distro's
+    # hardened build macros, and replacing it would silently drop relro,
+    # -z now and the annobin specs. LIBS appends to the link line instead.
+    LIBS: -lgcc_s
 dependencies:
   build:
     # No common list: it held RPM names (gcc-c++) that leaked into the deb

--- a/scripts/tideforge.py
+++ b/scripts/tideforge.py
@@ -542,7 +542,19 @@ def rpm_build_lines(build_system: str, recipe: dict | None = None) -> tuple[str,
         options = meson_options(recipe or {})
         return f"%meson {options}\n%meson_build".rstrip(), "%meson_install"
     if build_system == "autotools":
-        prefix = "autoreconf -fi\n" if autoreconf_enabled(recipe or {}) else ""
+        # build.environment was wired into the cargo and go paths only, so an
+        # autotools recipe had no way to influence its own link line:
+        # configure_options rejects anything not starting with "--", and
+        # nothing prefixed %configure. libunwind needed LIBS=-lgcc_s and could
+        # express it nowhere (#469), shipping an aarch64 library with four
+        # undefined outline-atomics symbols.
+        #
+        # Exported on their own lines rather than prefixed onto %configure:
+        # that macro expands to a multi-line script, so `VAR=x %configure`
+        # would apply the assignment to its first command only.
+        exports = build_environment_exports(recipe or {})
+        prefix = f"{exports}\n" if exports else ""
+        prefix += "autoreconf -fi\n" if autoreconf_enabled(recipe or {}) else ""
         options = configure_options(recipe or {})
         # Delete libtool archives explicitly. EL10's rpm strips them in
         # brp-remove-la-files, so the el10 gate never sees them; openSUSE's

--- a/tests/test_autotools_build_environment.py
+++ b/tests/test_autotools_build_environment.py
@@ -1,0 +1,112 @@
+"""An autotools recipe must be able to influence its own link line (#469).
+
+`build.environment` was wired into the cargo and go paths only. An autotools
+recipe therefore had NO way to add a library to its link:
+
+  - `configure_options` rejects anything not starting with "--", so
+    `LIBS=-lgcc_s` could not go there;
+  - nothing prefixed `%configure`, so `build.environment` was silently ignored.
+
+That is not a style gap. libunwind needed `LIBS=-lgcc_s` on aarch64 and could
+express it nowhere, so the published libunwind.so.8 shipped with four
+UNDEFINED outline-atomics symbols and every consumer died at load:
+
+    quickshell: symbol lookup error: /lib64/libunwind.so.8:
+      undefined symbol: __aarch64_cas8_acq_rel
+
+Verified against the published RPM: `readelf -d` showed libgcc_s.so.1 absent
+from NEEDED while `__aarch64_cas8_acq_rel`, `__aarch64_swp1_acq_rel`,
+`__aarch64_ldadd8_acq_rel` and `__aarch64_ldadd4_acq_rel` were all UND.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[1]
+_spec = importlib.util.spec_from_file_location("tf", ROOT / "scripts" / "tideforge.py")
+tf = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(tf)
+
+RECIPE = ROOT / "packages" / "libunwind-devel" / "package.yaml"
+
+
+def render(recipe):
+    return tf.rpm_build_lines("autotools", recipe)[0]
+
+
+def test_the_environment_reaches_the_autotools_build() -> None:
+    build = render({"build": {"environment": {"LIBS": "-lgcc_s"}}})
+    assert "export LIBS=-lgcc_s" in build
+
+
+def test_it_is_exported_before_configure_runs() -> None:
+    """A late export would not affect the configure tests that consume it."""
+    build = render({"build": {"environment": {"LIBS": "-lgcc_s"}}})
+    assert build.index("export LIBS") < build.index("%configure")
+
+
+def test_it_is_exported_rather_than_prefixed() -> None:
+    """`VAR=x %configure` applies to %configure's FIRST command only.
+
+    %configure expands to a multi-line script, so a prefix assignment would
+    silently cover part of it -- the shape most likely to look correct in a
+    diff and fail in the buildroot.
+    """
+    build = render({"build": {"environment": {"LIBS": "-lgcc_s"}}})
+    assert not any(
+        line.strip().startswith("LIBS=") and "%configure" in line
+        for line in build.splitlines()
+    )
+    assert any(line.startswith("export LIBS=") for line in build.splitlines())
+
+
+def test_it_composes_with_autoreconf() -> None:
+    build = render({"build": {"environment": {"LIBS": "-lgcc_s"}, "autoreconf": True}})
+    lines = [l for l in build.splitlines() if l.strip()]
+    assert lines[0].startswith("export LIBS=")
+    assert lines[1] == "autoreconf -fi"
+    assert lines[2].startswith("%configure")
+
+
+def test_a_recipe_without_environment_is_unchanged() -> None:
+    """Every already-working autotools recipe must render byte-identically.
+
+    Pinned against what the renderer actually emitted before this change,
+    trailing space after %configure included -- an assertion written from
+    what the output "should" look like failed here and would have hidden a
+    real regression behind a cosmetic one.
+    """
+    assert render({"build": {"autoreconf": True}}) == "autoreconf -fi\n%configure \n%make_build"
+    assert render({}) == "%configure \n%make_build"
+    assert "export" not in render({"build": {"autoreconf": True}})
+
+
+def test_values_are_shell_quoted() -> None:
+    build = render({"build": {"environment": {"LIBS": "-lgcc_s -lfoo bar"}}})
+    assert "export LIBS='-lgcc_s -lfoo bar'" in build
+
+
+# --- the recipe this exists for --------------------------------------------
+
+
+def test_libunwind_links_libgcc() -> None:
+    """Without this the aarch64 library has undefined outline-atomics symbols."""
+    recipe = yaml.safe_load(RECIPE.read_text())
+    assert recipe["build"]["environment"]["LIBS"] == "-lgcc_s"
+
+
+def test_libunwind_does_not_clobber_the_hardened_ldflags() -> None:
+    """LDFLAGS carries relro, -z now and the annobin specs from the distro
+    macros; replacing it to add one library would silently drop all of them."""
+    recipe = yaml.safe_load(RECIPE.read_text())
+    assert "LDFLAGS" not in recipe["build"]["environment"]
+
+
+def test_libunwind_renders_the_export() -> None:
+    recipe = yaml.safe_load(RECIPE.read_text())
+    assert "export LIBS=-lgcc_s" in render(recipe)


### PR DESCRIPTION
Fixes the link-flag half of #469. Unblocks `tideforge-quickshell-el10-aarch64`.

## The library cannot be loaded

Confirmed by reading the published RPM, not inferred from a build log:

```
$ readelf -d libunwind.so.8.1.0 | grep NEEDED
 (NEEDED)  libc.so.6
 (NEEDED)  ld-linux-aarch64.so.1        ← no libgcc_s.so.1

$ readelf -sW --dyn-syms libunwind.so.8.1.0 | grep __aarch64_
 UND __aarch64_cas8_acq_rel
 UND __aarch64_swp1_acq_rel
 UND __aarch64_ldadd8_acq_rel
 UND __aarch64_ldadd4_acq_rel
```

aarch64 GCC emits outline-atomics calls that live in libgcc; libunwind's link line never pulls it in. Every consumer dies at load — which is what killed quickshell **after** it had compiled all 1322 targets and produced its RPM:

```
quickshell: symbol lookup error: /lib64/libunwind.so.8:
  undefined symbol: __aarch64_cas8_acq_rel
```

## The recipe could not express the fix

This is the part worth noting. `build.environment` was wired into the **cargo** and **go** paths only, and `configure_options` rejects anything not starting with `--`. So an autotools recipe had **no way at all** to add a library to its own link line. The fix wasn't unwritten — it was unrepresentable.

`rpm_build_lines` now exports `build.environment` before `%configure` on the autotools path, reusing the existing `build_environment_exports()`.

**Exported on its own line rather than prefixed onto `%configure`**: that macro expands to a multi-line script, so `VAR=x %configure` would cover only its first command — the shape most likely to look right in review and fail in the buildroot.

**`LIBS` rather than `LDFLAGS`**, deliberately: `LDFLAGS` already carries the distro's hardened flags (relro, `-z now`, the annobin specs), and replacing it to add one library would silently drop all of them. `LIBS` appends.

Rendered result:

```
export LIBS=-lgcc_s
autoreconf -fi
%configure --disable-tests
%make_build
```

## Deliberately not in this PR

`libunwind-devel` also **ships the runtime SONAME** (`usr/lib64/libunwind.so.8.1.0`), because its files glob is `usr/lib64/libunwind*.so*`. The served aarch64 index has no `libunwind` base package, so our devel package shadows EPEL's working runtime on anything that installs it.

That's a packaging restructure with dependency consequences for `cpptrace`, and it doesn't belong bundled into a link-flag fix. It stays tracked on #469 with the recommended shape.

## Verification

- **Rendering is byte-identical to main** for every recipe without `build.environment` — pinned in a test against what the renderer actually emits, trailing space and all. An assertion written from what the output *should* look like failed here first, and would have masked a real regression behind a cosmetic one.
- Reverting the renderer change fails **6 of the 9** new tests.
- Full suite: **724 passed, 1 skipped.**

**The real proof is the rebuilt RPM**, and it isn't in yet: `readelf -d` should list `libgcc_s.so.1`, and no `__aarch64_*` symbol should remain `UND`. Worth checking on the first publish rather than trusting the green tick.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_