### PR TITLE
Make the gnome packages buildable, and let the libunwind fix actually supersede the broken one

### DIFF
--- a/build-order-gnome51.yml
+++ b/build-order-gnome51.yml
@@ -129,6 +129,7 @@ tiers:
   # Tier 13: Compositor & Shell.
   - name: shell-foundations
     packages:
+      - path: src/deps/tecla
       - path: src/gnome-51/gnome-settings-daemon
       - path: src/gnome-51/mutter
 

--- a/build-order-gnome51.yml
+++ b/build-order-gnome51.yml
@@ -104,6 +104,7 @@ tiers:
   # Tier 11: GTK Core.
   - name: gtk-core
     packages:
+      - path: src/deps/libnotify
       - path: src/gnome-51/gsettings-desktop-schemas
       - path: src/gnome-51/gnome-desktop3
       - path: src/deps/gtk4

--- a/build-order.yml
+++ b/build-order.yml
@@ -141,6 +141,7 @@ tiers:
   # Tier 13: Compositor & Shell.
   - name: shell-foundations
     packages:
+      - path: src/deps/tecla
       - path: src/gnome-50/gnome-settings-daemon
       - path: src/gnome-50/mutter
 

--- a/build-order.yml
+++ b/build-order.yml
@@ -116,6 +116,7 @@ tiers:
   # Tier 11: GTK Core.
   - name: gtk-core
     packages:
+      - path: src/deps/libnotify
       - path: src/gnome-50/gsettings-desktop-schemas
       - path: src/gnome-50/gnome-desktop3
       - path: src/deps/gtk4

--- a/packages/libunwind-devel/package.yaml
+++ b/packages/libunwind-devel/package.yaml
@@ -1,7 +1,14 @@
 schema: 1
 name: libunwind-devel
 version: "1.8.1"
-release: 1
+# release 2, not 1. The BROKEN build is published as libunwind-devel-1.8.1-1
+# at rpm/el10/aarch64 — the one whose libunwind.so.8 carries four undefined
+# __aarch64_* symbols and no libgcc_s in NEEDED (#469). The LIBS: -lgcc_s fix
+# below changes the bytes but not the version, so republishing at release 1
+# would ship a different artifact under an identical NVR: dnf would see no
+# upgrade, consumers holding the broken one would keep it, and two distinct
+# builds would claim the same name-version-release.
+release: 2
 summary: Portable stack-unwinding library development files
 description: Headers and shared libraries required to build cpptrace with signal-safe stack unwinding.
 license: MIT

--- a/scripts/plan-rpm-publish.py
+++ b/scripts/plan-rpm-publish.py
@@ -59,6 +59,15 @@ BESPOKE = {
         "aarch64": {
             "src": "rpm/el10/aarch64",
             "served": "https://repo.tunaos.org/rpm/el10/aarch64/",
+            # 30 against the 39 currently served. This was absent -- defaulting
+            # to 0 -- because the prefix started empty and a minimum would have
+            # made the first publish impossible. It has content now, and the
+            # publisher's `Sync down the existing repo` ends in `|| true`, so a
+            # failed download would sync UP only the new packages and delete
+            # the rest: #124 / INCIDENT-repo-wipe-gnome exactly. Headroom for a
+            # few legitimate removals; a count near zero is the failure this
+            # exists to catch.
+            "min_rpms": 30,
         },
     },
 }

--- a/scripts/verify-package-factory-cell.sh
+++ b/scripts/verify-package-factory-cell.sh
@@ -67,13 +67,28 @@ if [[ ${ENGINE:?} == build-chain ]]; then
                        --enablerepo="tunaos${published_n}")
       published_n=$((published_n + 1))
     done
+    mapfile -t names < <(rpm -qp --qf "%{NAME}\n" /factory-repo/*.rpm | sort -u)
+    # Install by NAME, not by file path. A build-chain tier list may build the
+    # same recipe twice on purpose -- gnome51 has glib2-bootstrap at tier 2 and
+    # glib2-full at tier 6, both src/gnome-51/glib2, and the same for
+    # gobject-introspection at tiers 5 and 7 -- so /artifacts holds two EVRs of
+    # those names. Passing every FILE asked dnf to install both at once, which
+    # is unsatisfiable by construction:
+    #
+    #   cannot install both glib2-2.88.0-4.el10.aarch64 from @commandline
+    #   and glib2-2.88.0-1.el10.aarch64 from @commandline
+    #
+    # By name, dnf resolves each to the newest EVR in the factory repo, which
+    # is the build the chain means to ship; the superseded bootstrap pass is
+    # scaffolding. rpm -q and rpm -V below still cover every name, so nothing
+    # goes unchecked. factory.priority=1 keeps these ahead of the published
+    # repo at priority 50.
     # ${a[@]+"${a[@]}"} and not "${a[@]}": under `set -u` an empty array
     # expansion is an unbound-variable error on bash < 4.4.
     dnf -y install --nogpgcheck --repofrompath factory,file:///factory-repo \
       --setopt=factory.priority=1 --enablerepo=factory \
       ${published_args[@]+"${published_args[@]}"} \
-      /factory-repo/*.rpm
-    mapfile -t names < <(rpm -qp --qf "%{NAME}\n" /factory-repo/*.rpm | sort -u)
+      "${names[@]}"
     rpm -q "${names[@]}"
     rpm -V "${names[@]}"
   '

--- a/src/deps/avahi/avahi.spec
+++ b/src/deps/avahi/avahi.spec
@@ -62,7 +62,7 @@
 
 Name:             avahi
 Version:          0.9%{?rc:~%{rc}}
-Release:          8%{?dist}
+Release:          9%{?dist}
 Summary:          Local network service discovery
 License:          LGPL-2.1-or-later AND LGPL-2.0-or-later AND BSD-2-Clause-Views AND MIT
 URL:              http://avahi.org
@@ -172,7 +172,17 @@ Requires:         %{name} = %{version}-%{release}
 Requires:         %{name}-libs%{?_isa} = %{version}-%{release}
 Requires:         %{name}-glib%{?_isa} = %{version}-%{release}
 Requires:         %{name}-ui-gtk3%{?_isa} = %{version}-%{release}
-Requires:         tigervnc
+# tigervnc is not in EL10 BaseOS, AppStream, CRB or EPEL 10, on either arch
+# (measured against the repository metadata; EPEL 10 lists 25573 names and no
+# tigervnc at all). A hard Requires therefore makes avahi-ui-tools impossible
+# to install on this target, which failed the cell's verify step:
+#
+#   nothing provides tigervnc needed by avahi-ui-tools-0.9~rc2-8.el10.aarch64
+#
+# Weak, so the package installs where tigervnc is absent and still pulls it in
+# on targets that do carry it. bvnc is the only thing that needs it; bssh and
+# the rest of the subpackage work without.
+Recommends:       tigervnc
 Requires:         openssh-clients
 %if %{WITH_PYTHON}
 Requires:         gdbm
@@ -851,6 +861,11 @@ fi
 
 
 %changelog
+* Sun Aug 23 2026 TunaOS Package Factory <packages@tunaos.org> - 0.9~rc2-9
+- Weaken avahi-ui-tools' tigervnc dependency to Recommends. EL10 has no
+  tigervnc in BaseOS, AppStream, CRB or EPEL on either arch, so the hard
+  Requires made the subpackage uninstallable and failed the cell (#480)
+
 * Fri Jan 16 2026 Fedora Release Engineering <releng@fedoraproject.org> - 0.9~rc2-8
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_44_Mass_Rebuild
 

--- a/src/deps/libglib-testing/libglib-testing.spec
+++ b/src/deps/libglib-testing/libglib-testing.spec
@@ -1,9 +1,9 @@
 Name:           libglib-testing
 Version:        0.1.0
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        GLib-based test library and harness
 
-License:        LicenseRef-Callaway-LGPLv2+
+License:        LGPL-2.1-or-later
 URL:            https://gitlab.gnome.org/pwithnall/libglib-testing
 Source0:        https://gitlab.gnome.org/pwithnall/libglib-testing/-/archive/%{version}/%{name}-%{version}.tar.bz2
 
@@ -18,7 +18,7 @@ any project which uses GLib and which wants to write internal unit tests.
 
 %package devel
 Summary:        Development files for %{name}
-License:        LicenseRef-Callaway-LGPLv2+
+License:        LGPL-2.1-or-later
 Requires:       %{name}%{?_isa} = %{version}-%{release}
 
 %description devel
@@ -54,6 +54,11 @@ DESTDIR=%{buildroot} ninja -C _build install
 %{_libdir}/pkgconfig/glib-testing-0.pc
 
 %changelog
+* Sun Aug 23 2026 TunaOS Package Factory <packages@tunaos.org> - 0.1.0-4
+- Use the SPDX identifier LGPL-2.1-or-later. LicenseRef-Callaway-LGPLv2+ is
+  not a valid LicenseRef: SPDX allows only [A-Za-z0-9.-] in the idstring, so
+  the trailing + made it invalid and rpmlint failed the cell (#480)
+
 * Mon Mar 30 2026 James Reilly <jreilly1821@gmail.com> - 0.1.0-3
 - Fix %%files devel: include dir is glib-testing-0/ not libglib-testing-0/
 

--- a/src/deps/libnotify/libnotify.spec
+++ b/src/deps/libnotify/libnotify.spec
@@ -95,6 +95,23 @@ introspection data for %{name}.
 # make a tier-10 package build-depend on a tier-10 sibling, which the tier
 # model cannot express and which would either deadlock the order or resolve
 # against whatever stale gtk4 happened to be installed.
+#
+# -Dgtk_doc=false is load-bearing for the same reason, and is easy to miss
+# because it DEFAULTS TO TRUE. With it on, docs/reference/meson.build runs:
+#
+#   dependency('gi-docgen', ..., required: get_option('gtk_doc'))
+#   gidocgen = find_program('gi-docgen')
+#
+# so gi-docgen becomes a hard configure-time requirement, and the target it
+# then builds installs into %%{_datadir}/doc/libnotify-0 -- an unpackaged
+# directory, which would fail the build a second time at %%install. libnotify
+# is here as a build dependency for gnome-settings-daemon, not as a docs
+# deliverable, so neither cost is worth paying.
+#
+# -Ddocbook_docs is `auto` upstream and resolves to off only because xmlto is
+# not in this buildroot. Pinning it to disabled means a stray xmlto arriving
+# through some other package's dependencies cannot silently start installing
+# %%{_datadir}/doc/libnotify/spec/notification-spec.html and break the build.
 meson setup _build \
     --buildtype=plain \
     --prefix=%{_prefix} \
@@ -106,7 +123,9 @@ meson setup _build \
     --wrap-mode=nodownload \
     -Dtests=false \
     -Dintrospection=enabled \
-    -Dman=true
+    -Dman=true \
+    -Dgtk_doc=false \
+    -Ddocbook_docs=disabled
 ninja -C _build -j%{_smp_build_ncpus}
 
 %install
@@ -132,3 +151,5 @@ DESTDIR=%{buildroot} ninja -C _build install
 - Build libnotify 0.8.7 for EL10, which ships only 0.8.6 (#480)
 - Require docbook5-style-xsl; docbook-style-xsl is the non-namespaced set and
   does not register the xsl-ns catalog rewrite meson.build:78 probes for
+- Pin -Dgtk_doc=false (it defaults to true, making gi-docgen a hard configure
+  requirement) and -Ddocbook_docs=disabled

--- a/src/deps/libnotify/libnotify.spec
+++ b/src/deps/libnotify/libnotify.spec
@@ -1,0 +1,110 @@
+Name:           libnotify
+Version:        0.8.7
+Release:        1%{?dist}
+Summary:        Desktop notification library
+
+# Built here because EL10 tops out below what GNOME 50 requires.
+#
+# gnome-settings-daemon 50.0's meson.build asks for libnotify >= 0.8.7 and
+# fails hard when it is not there:
+#
+#   meson.build:107:16: ERROR: Dependency lookup for libnotify with method
+#   'pkgconfig' failed: Invalid version, need 'libnotify' ['>= 0.8.7']
+#   found '0.8.6'.
+#
+# Measured across every repository the el10 buildroot can reach, on BOTH
+# arches (#480):
+#
+#   CS10 AppStream          0.8.3-5.el10
+#   CS10 koji c10s-build    0.8.6-1.el10   <- what the build actually found
+#   EPEL 10                 absent
+#
+# So the constraint is unsatisfiable from upstream and gnome-settings-daemon,
+# gnome-control-center and gnome-initial-setup all fail without this.
+#
+# repo.tunaos.org/repo/10-x86_64 already serves a libnotify-0.8.7-1.el10, but
+# it had no spec and no build-order entry anywhere in this repository — an
+# artifact the factory could not reproduce, and one that reached neither
+# buildroot. This recipe replaces that orphan with something rebuildable, and
+# on both architectures rather than one.
+#
+# 0.8.7 rather than the newer 0.8.8 deliberately: it is the minimum that
+# satisfies the requirement and it matches the version already published, so
+# nothing installed churns.
+License:        LGPL-2.1-or-later
+URL:            https://gitlab.gnome.org/GNOME/libnotify
+Source0:        https://download.gnome.org/sources/%{name}/0.8/%{name}-%{version}.tar.xz
+
+BuildRequires:  meson
+BuildRequires:  gcc
+BuildRequires:  pkgconfig(gdk-pixbuf-2.0)
+BuildRequires:  pkgconfig(glib-2.0)
+BuildRequires:  pkgconfig(gio-2.0)
+BuildRequires:  pkgconfig(gio-unix-2.0)
+BuildRequires:  gobject-introspection-devel
+# xsltproc plus the DocBook stylesheets, for the notify-send man page.
+BuildRequires:  libxslt
+BuildRequires:  docbook-style-xsl
+
+%description
+libnotify sends desktop notifications to a notification daemon, as defined in
+the Desktop Notifications spec. These notifications inform the user of an
+event or display some form of information without disturbing the user.
+
+%package devel
+Summary:        Development files for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description devel
+This package contains the pkg-config file, development headers and
+introspection data for %{name}.
+
+%prep
+%autosetup -n %{name}-%{version}
+
+%build
+# -Dtests=false is load-bearing, not tidiness. libnotify's meson.build makes
+# its gtk4 dependency conditional on the tests option:
+#
+#   gtk_dep = dependency('gtk4', version: '>= 4.0', required: get_option('tests'))
+#
+# gtk4 is built by THIS chain, three tiers after this one (tier 10 vs tier 13
+# for gnome-settings-daemon, with gtk-core at 10). Leaving tests enabled would
+# make a tier-10 package build-depend on a tier-10 sibling, which the tier
+# model cannot express and which would either deadlock the order or resolve
+# against whatever stale gtk4 happened to be installed.
+meson setup _build \
+    --buildtype=plain \
+    --prefix=%{_prefix} \
+    --libdir=%{_libdir} \
+    --libexecdir=%{_libexecdir} \
+    --includedir=%{_includedir} \
+    --datadir=%{_datadir} \
+    --mandir=%{_mandir} \
+    --wrap-mode=nodownload \
+    -Dtests=false \
+    -Dintrospection=enabled \
+    -Dman=true
+ninja -C _build -j%{_smp_build_ncpus}
+
+%install
+DESTDIR=%{buildroot} ninja -C _build install
+
+%files
+%license COPYING
+%doc AUTHORS NEWS README.md
+%{_bindir}/notify-send
+%{_libdir}/libnotify.so.4
+%{_libdir}/libnotify.so.4.*
+%{_libdir}/girepository-1.0/Notify-0.7.typelib
+%{_mandir}/man1/notify-send.1*
+
+%files devel
+%{_includedir}/libnotify/
+%{_libdir}/libnotify.so
+%{_libdir}/pkgconfig/libnotify.pc
+%{_datadir}/gir-1.0/Notify-0.7.gir
+
+%changelog
+* Sat Aug 22 2026 TunaOS Package Factory <packages@tunaos.org> - 0.8.7-1
+- Build libnotify 0.8.7 for EL10, which ships only 0.8.6 (#480)

--- a/src/deps/libnotify/libnotify.spec
+++ b/src/deps/libnotify/libnotify.spec
@@ -43,8 +43,30 @@ BuildRequires:  pkgconfig(gio-2.0)
 BuildRequires:  pkgconfig(gio-unix-2.0)
 BuildRequires:  gobject-introspection-devel
 # xsltproc plus the DocBook stylesheets, for the notify-send man page.
+#
+# docbook5-style-xsl, NOT docbook-style-xsl. meson.build:78 probes the
+# NAMESPACED stylesheet through the local XML catalog:
+#
+#   run_command(xsltproc, '--nonet',
+#     'http://docbook.sourceforge.net/release/xsl-ns/current/manpages/docbook.xsl')
+#
+# --nonet means that URI has to resolve offline, so the buildroot needs a
+# package whose %%post registers a rewrite rule for it. On EL10:
+#
+#   docbook-style-xsl    xsl-stylesheets-1.79.2      non-namespaced, no xsl-ns rule
+#   docbook5-style-xsl   xsl-ns-stylesheets-1.79.2   registers rewriteURI for
+#                                                    .../release/xsl-ns/current
+#
+# EL10 has no docbook-style-xsl-ns (the Fedora name) and no docbook-xsl-ns
+# (the Debian name the error message suggests) at all; docbook5-style-xsl is
+# the namespaced set under a different name. Building with docbook-style-xsl
+# fails at configure time with:
+#
+#   meson.build:78:4: ERROR: Problem encountered: DocBook stylesheet for
+#   generating man pages not found, you need to install docbook-xsl-ns or
+#   similar package.
 BuildRequires:  libxslt
-BuildRequires:  docbook-style-xsl
+BuildRequires:  docbook5-style-xsl
 
 %description
 libnotify sends desktop notifications to a notification daemon, as defined in
@@ -108,3 +130,5 @@ DESTDIR=%{buildroot} ninja -C _build install
 %changelog
 * Sat Aug 22 2026 TunaOS Package Factory <packages@tunaos.org> - 0.8.7-1
 - Build libnotify 0.8.7 for EL10, which ships only 0.8.6 (#480)
+- Require docbook5-style-xsl; docbook-style-xsl is the non-namespaced set and
+  does not register the xsl-ns catalog rewrite meson.build:78 probes for

--- a/src/deps/malcontent/malcontent.spec
+++ b/src/deps/malcontent/malcontent.spec
@@ -7,8 +7,20 @@ License:        LGPL-2.1-only AND CC-BY-3.0
 URL:            https://gitlab.freedesktop.org/pwithnall/%{name}/
 Source0:        https://tecnocode.co.uk/downloads/%{name}/%{name}-%{version}.tar.xz
 Source1:        https://gitlab.gnome.org/pwithnall/libgsystemservice/-/archive/0.3.0/libgsystemservice-0.3.0.tar.bz2
-Source2:        gvdb.tar.xz
-Source3:        tinycdb-0.81.tar.gz
+# tinycdb's canonical upstream, taken from malcontent's own
+# subprojects/tinycdb.wrap, which declares this exact source_url and a
+# source_hash of 469de2d4…ebc2 — verified to match the tarball this URL
+# serves. It was previously a bare filename with no URL, so spectool could
+# not fetch it and the SRPM build died before any compilation:
+#
+#   error: Bad file: /builddir/SOURCES/tinycdb-0.81.tar.gz: No such file
+#
+# gvdb was a second bare filename here and is now gone entirely: malcontent's
+# release tarball already ships subprojects/gvdb populated (15 files,
+# including its meson.build), so the extra source and its `tar -xf` were
+# redundant. `Provides: bundled(gvdb)` stays true — it is still bundled, just
+# by upstream rather than by us.
+Source2:        https://www.corpit.ru/mjt/tinycdb/tinycdb-0.81.tar.gz
 
 BuildRequires:  gettext
 BuildRequires:  gi-docgen
@@ -103,7 +115,9 @@ Documentation for libmalcontent.
 tar -xf %{SOURCE1} -C subprojects
 mv subprojects/libgsystemservice-0.3.0 subprojects/libgsystemservice
 tar -xf %{SOURCE2} -C subprojects
-tar -xf %{SOURCE3} -C subprojects
+# tinycdb.wrap declares patch_directory = tinycdb, which is meson's way of
+# saying "overlay subprojects/packagefiles/tinycdb/ onto the extracted tree".
+# rpmbuild is not running meson's wrap resolver, so the overlay is done here.
 cp subprojects/packagefiles/tinycdb/meson.build subprojects/tinycdb-0.81
 
 %build

--- a/src/deps/tecla/tecla.spec
+++ b/src/deps/tecla/tecla.spec
@@ -1,8 +1,8 @@
 %global tarball_version %%(echo %{version} | tr '~' '.')
 
 Name:           tecla
-Version:        50~rc
-Release:        100%{?dist}
+Version:        50.0
+Release:        1%{?dist}
 Summary:        Keyboard layout viewer
 
 License:        GPL-2.0-or-later
@@ -67,5 +67,9 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/org.gnome.Tecla.deskt
 
 
 %changelog
+* Sun Aug 23 2026 TunaOS Package Factory <packages@tunaos.org> - 50.0-1
+- Build the final 50.0 rather than 50~rc, and put the recipe in a build order
+  so it is actually built (#480)
+
 * Sat Mar 14 2026 James Reilly <jreilly1821@gmail.com> - 50~rc-100
 - Initial build for GNOME 50 bootstrap on EL10

--- a/src/deps/tinysparql/tinysparql.spec
+++ b/src/deps/tinysparql/tinysparql.spec
@@ -12,7 +12,7 @@
 
 Name:           tinysparql
 Version:        3.11~rc
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Desktop-neutral metadata database and search tool
 
 License:        GPL-2.0-or-later
@@ -100,7 +100,7 @@ developing applications that use %{name}.
 Summary:        Documentation for %{name}
 BuildArch:      noarch
 # docs/reference/COPYING
-License:        LicenceRef-Fedora-Public-Domain AND LGPL-2.1-or-later AND GPL-2.0-or-later
+License:        LicenseRef-Fedora-Public-Domain AND LGPL-2.1-or-later AND GPL-2.0-or-later
 
 %description doc
 This package contains the documentation for %{name}.
@@ -196,6 +196,11 @@ DESTDIR=%{buildroot} ninja -C _build install
 
 
 %changelog
+* Sun Aug 23 2026 TunaOS Package Factory <packages@tunaos.org> - 3.11~rc-4
+- Spell the -doc subpackage's license LicenseRef-Fedora-Public-Domain. It read
+  "LicenceRef-", which is not a LicenseRef at all, and rpmlint failed the cell
+  on it (#480)
+
 * Sat Mar 28 2026 James Reilly <jreilly1821@gmail.com> - 3.11~rc-3
 - Replace %%meson/%%meson_build/%%meson_install with explicit meson/ninja
   to avoid "fg: no job control" on COPR builders (non-interactive bash).

--- a/src/gnome-49/tinysparql/tinysparql.spec
+++ b/src/gnome-49/tinysparql/tinysparql.spec
@@ -97,7 +97,7 @@ developing applications that use %{name}.
 Summary:        Documentation for %{name}
 BuildArch:      noarch
 # docs/reference/COPYING
-License:        LicenceRef-Fedora-Public-Domain AND LGPL-2.1-or-later AND GPL-2.0-or-later
+License:        LicenseRef-Fedora-Public-Domain AND LGPL-2.1-or-later AND GPL-2.0-or-later
 
 %description doc
 This package contains the documentation for %{name}.

--- a/tests/test_a_fix_supersedes_the_artifact_it_replaces.py
+++ b/tests/test_a_fix_supersedes_the_artifact_it_replaces.py
@@ -1,0 +1,85 @@
+"""A rebuilt fix must not ship under the NVR of the thing it replaces.
+
+libunwind-devel's aarch64 build was broken: its libunwind.so.8 carried four
+undefined `__aarch64_*` symbols and no libgcc_s in NEEDED, so every consumer
+died at load (#469). The recipe fix — `LIBS: -lgcc_s` — changes the bytes and
+nothing else.
+
+The broken build is published as **libunwind-devel-1.8.1-1.el10** at
+rpm/el10/aarch64. Republishing the fix at release 1 would have put a second,
+different artifact into the world under an identical name-version-release:
+dnf would report no upgrade, anyone already holding the broken one would keep
+it, and the repository would contain two builds claiming to be the same thing.
+
+That is why the wave was not dispatched before this bump. The publisher was
+ready and the fix was merged; the version was the blocker, and publishing
+would have looked successful while changing nothing for consumers.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+RECIPE = ROOT / "packages" / "libunwind-devel" / "package.yaml"
+
+# What rpm/el10/aarch64 served on 2026-08-22, measured from its primary.xml.
+PUBLISHED_BROKEN_RELEASE = 1
+
+
+def recipe() -> dict:
+    return yaml.safe_load(RECIPE.read_text(encoding="utf-8"))
+
+
+def test_the_release_moved_past_the_broken_publish():
+    assert int(recipe()["release"]) > PUBLISHED_BROKEN_RELEASE
+
+
+def test_the_version_did_not_change():
+    """A release bump, not a version bump: the sources are identical, only the
+    link line changed. Moving the version would misreport what was fixed."""
+    assert str(recipe()["version"]) == "1.8.1"
+
+
+def test_the_fix_the_bump_exists_for_is_still_there():
+    """A bumped release carrying the unfixed build would be worse than no bump
+    at all — it would advertise a fix that is not present."""
+    assert recipe()["build"]["environment"]["LIBS"] == "-lgcc_s"
+
+
+def test_the_aarch64_prefix_has_an_anti_wipe_floor():
+    """rpm/el10/aarch64 serves 39 packages. The publisher's sync-down ends in
+    `|| true`, so without a floor a failed download syncs up only the new
+    packages and deletes the rest (#124)."""
+    sys.path.insert(0, str(ROOT / "scripts"))
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "plan_rpm_publish", ROOT / "scripts" / "plan-rpm-publish.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    aarch64 = module.BESPOKE["el10"]["aarch64"]
+    assert aarch64.get("min_rpms", 0) > 0, "a populated prefix must have a floor"
+    assert aarch64["min_rpms"] < 39, "a floor at or above the current count blocks every publish"
+
+
+def test_every_populated_bespoke_prefix_has_a_floor():
+    """The general rule, so the next prefix to gain content is not left open."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "plan_rpm_publish", ROOT / "scripts" / "plan-rpm-publish.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    for target, arches in module.BESPOKE.items():
+        for arch, override in arches.items():
+            assert "min_rpms" in override, (
+                f"{target}/{arch} has a bespoke prefix but no min_rpms — state the "
+                f"floor explicitly, even if 0 for a genuinely empty prefix"
+            )

--- a/tests/test_docbook_man_pages_name_the_right_stylesheets.py
+++ b/tests/test_docbook_man_pages_name_the_right_stylesheets.py
@@ -1,0 +1,167 @@
+"""The DocBook stylesheet a spec BuildRequires has to be the one upstream probes.
+
+libnotify failed configure in gnome51-el10-aarch64 (run 32604266038) with:
+
+    meson.build:78:4: ERROR: Problem encountered: DocBook stylesheet for
+    generating man pages not found, you need to install docbook-xsl-ns or
+    similar package.
+
+The spec BuildRequired `docbook-style-xsl`, which is present on EL10 and is
+the wrong set. libnotify's meson.build probes the NAMESPACED stylesheet, and
+it does so offline:
+
+    run_command(xsltproc, '--nonet',
+      'http://docbook.sourceforge.net/release/xsl-ns/current/manpages/docbook.xsl')
+
+`--nonet` means that URI must resolve through /etc/xml/catalog, so the
+buildroot needs a package whose %post registers a rewrite rule for it.
+Measured against CentOS Stream 10 BaseOS/AppStream/CRB, aarch64:
+
+    docbook-style-xsl     xsl-stylesheets-1.79.2      present, no xsl-ns rule
+    docbook5-style-xsl    xsl-ns-stylesheets-1.79.2   present, and its %post runs
+                            xmlcatalog --add rewriteURI
+                            "http://docbook.sourceforge.net/release/xsl-ns/current"
+    docbook-style-xsl-ns  (the Fedora name)           ABSENT
+    docbook-xsl-ns        (the Debian name the error suggests)  ABSENT
+    docbook-xsl           (the plain Debian name)     ABSENT
+
+So on EL10 the namespaced set exists only under the name `docbook5-style-xsl`,
+and the error message's own suggestion names a package that cannot be
+installed. Both wrong answers -- keeping docbook-style-xsl, or believing the
+error message -- cost a full cell run to discover, and a gnome cell is ~2.5h.
+
+The rule here is deliberately narrow. It does NOT say "every spec generating
+man pages needs the namespaced set": most of this factory's specs
+(gtk4, gnome-control-center, thunar, xfce4-terminal) probe the
+non-namespaced `xsl/current` URI and are correct with `docbook-style-xsl`.
+Which package is right depends on which URI the upstream meson.build asks
+for, and that is not visible in the spec. A rule broad enough to decide it
+from the spec alone would flag the correct ones too.
+
+What is checkable without guessing is narrower and still catches the class:
+no spec may BuildRequire a docbook stylesheet package that EL10 does not
+ship at all, and the two specs known to need the namespaced set must keep
+naming it.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Names that do not exist in any repository the el10 buildroot can reach.
+# Measured, not assumed -- see the module docstring.
+ABSENT_ON_EL10 = ("docbook-style-xsl-ns", "docbook-xsl-ns", "docbook-xsl")
+
+# The one EL10 name for the namespaced (xsl-ns) stylesheets.
+NAMESPACED = "docbook5-style-xsl"
+
+BUILDREQUIRES = re.compile(r"^BuildRequires:\s*(.+)$", re.MULTILINE | re.IGNORECASE)
+
+
+def specs() -> list[Path]:
+    return sorted(ROOT.rglob("*.spec"))
+
+
+def build_requires(spec: Path) -> list[str]:
+    """Every name on every BuildRequires line, one line often listing several."""
+    text = spec.read_text(encoding="utf-8", errors="replace")
+    names: list[str] = []
+    for line in BUILDREQUIRES.findall(text):
+        # Drop version constraints: `foo >= 1.2` contributes `foo`.
+        parts = re.split(r"\s+", line.strip())
+        skip = False
+        for part in parts:
+            if part in (">=", "<=", "=", ">", "<"):
+                skip = True
+                continue
+            if skip:
+                skip = False
+                continue
+            names.append(part)
+    return names
+
+
+def absent_requirements(spec: Path) -> list[str]:
+    """BuildRequires naming a docbook package EL10 does not have.
+
+    Exact match: `docbook-xsl` must not swallow `docbook-xsl-stylesheets` or,
+    more to the point, must not match `docbook-style-xsl` -- which does exist.
+    """
+    return sorted({name for name in build_requires(spec) if name in ABSENT_ON_EL10})
+
+
+def test_there_are_specs_to_check():
+    """A sweep over an empty set passes for the wrong reason."""
+    assert len(specs()) > 50
+
+
+def test_no_spec_requires_a_docbook_package_el10_does_not_have():
+    offenders = {
+        str(spec.relative_to(ROOT)): found
+        for spec in specs()
+        if (found := absent_requirements(spec))
+    }
+    assert not offenders, offenders
+
+
+def test_libnotify_requires_the_namespaced_stylesheets():
+    """The spec that broke, pinned by content so it survives edits above it."""
+    spec = ROOT / "src" / "deps" / "libnotify" / "libnotify.spec"
+    names = build_requires(spec)
+    assert NAMESPACED in names, names
+    assert "docbook-style-xsl" not in names, (
+        "the non-namespaced set does not register the xsl-ns catalog rewrite "
+        "meson.build:78 probes for"
+    )
+    # The BuildRequires only matters because man pages are enabled. If the
+    # option ever goes away the requirement is dead weight, and if it is
+    # silently dropped the man page EL10's own libnotify ships disappears.
+    text = spec.read_text(encoding="utf-8")
+    assert "-Dman=true" in text
+    assert "%{_mandir}/man1/notify-send.1*" in text
+
+
+def test_colord_gtk_shows_the_same_choice():
+    """Not a second pin so much as evidence the name is right: colord-gtk
+    already builds on EL10 asking for the namespaced set."""
+    spec = ROOT / "src" / "gnome-49" / "colord-gtk" / "colord-gtk.spec"
+    assert NAMESPACED in build_requires(spec)
+
+
+def test_specs_probing_the_plain_stylesheets_are_not_flagged():
+    """docbook-style-xsl is a correct answer for the projects that ask for the
+    non-namespaced URI. Flagging them would be noise."""
+    for rel in (
+        ("src", "gnome-51", "gnome-control-center", "gnome-control-center.spec"),
+        ("src", "xfce-wayland", "thunar", "thunar.spec"),
+    ):
+        spec = ROOT.joinpath(*rel)
+        assert "docbook-style-xsl" in build_requires(spec)
+        assert absent_requirements(spec) == []
+
+
+def test_the_rule_would_catch_believing_the_error_message(tmp_path):
+    """Mutation in miniature: taking the error message's suggestion literally
+    names a package EL10 does not have, and must be flagged."""
+    broken = tmp_path / "broken.spec"
+    broken.write_text(
+        "Name: libnotify\n"
+        "BuildRequires:  libxslt\n"
+        "BuildRequires:  docbook-xsl-ns\n"
+        "\n"
+        "%prep\n",
+        encoding="utf-8",
+    )
+    assert absent_requirements(broken) == ["docbook-xsl-ns"]
+
+
+def test_a_versioned_requirement_still_parses_to_its_name(tmp_path):
+    spec = tmp_path / "versioned.spec"
+    spec.write_text(
+        "Name: x\nBuildRequires:  docbook5-style-xsl >= 1.79.2\n%prep\n",
+        encoding="utf-8",
+    )
+    assert "docbook5-style-xsl" in build_requires(spec)
+    assert absent_requirements(spec) == []

--- a/tests/test_docbook_man_pages_name_the_right_stylesheets.py
+++ b/tests/test_docbook_man_pages_name_the_right_stylesheets.py
@@ -123,6 +123,56 @@ def test_libnotify_requires_the_namespaced_stylesheets():
     assert "%{_mandir}/man1/notify-send.1*" in text
 
 
+def test_libnotify_turns_off_the_documentation_it_does_not_ship():
+    """Two upstream defaults that fail this build, neither of them obvious.
+
+    libnotify's meson_options.txt:
+
+        option('gtk_doc',       type: 'boolean', value: true)
+        option('docbook_docs',  type: 'feature', value: 'auto')
+
+    gtk_doc DEFAULTS TO TRUE, and docs/reference/meson.build then does
+
+        dependency('gi-docgen', ..., required: get_option('gtk_doc'))
+        gidocgen = find_program('gi-docgen')
+
+    so gi-docgen becomes a hard configure-time requirement -- and it is not in
+    this spec's BuildRequires, because libnotify is here to satisfy
+    gnome-settings-daemon's `libnotify >= 0.8.7`, not to ship documentation.
+    Satisfying it instead would not help: the target installs into
+    %{_datadir}/doc/libnotify-0, which no %files section lists, and an
+    unpackaged directory fails the build at %install.
+
+    This is easy to miss from a failing log. The configure error that was
+    actually observed came from meson.build:78, which runs BEFORE
+    subdir('docs') -- so the gtk_doc requirement had never been reached, let
+    alone reported, at the point the docbook fix was written.
+
+    docbook_docs is `auto`, so today it resolves to off only because xmlto
+    happens not to be in the buildroot. Pinning it means another package's
+    dependencies pulling xmlto in cannot silently start installing
+    %{_datadir}/doc/libnotify/spec/notification-spec.html and break the build.
+    """
+    text = (ROOT / "src" / "deps" / "libnotify" / "libnotify.spec").read_text(
+        encoding="utf-8"
+    )
+    assert "-Dgtk_doc=false" in text, (
+        "gtk_doc defaults to true and makes gi-docgen a hard requirement"
+    )
+    assert "-Ddocbook_docs=disabled" in text, (
+        "docbook_docs is auto upstream; an xmlto that arrives by accident "
+        "would install an unpackaged html file"
+    )
+    # Neither doc tree is packaged, so neither may be built. Comments are
+    # excluded: the spec explains this in prose, with the macro escaped.
+    packaged = [
+        line
+        for line in text.splitlines()
+        if not line.lstrip().startswith("#") and "%{_datadir}/doc" in line
+    ]
+    assert not packaged, packaged
+
+
 def test_colord_gtk_shows_the_same_choice():
     """Not a second pin so much as evidence the name is right: colord-gtk
     already builds on EL10 asking for the namespaced set."""

--- a/tests/test_gnome_sources_are_fetchable.py
+++ b/tests/test_gnome_sources_are_fetchable.py
@@ -1,0 +1,155 @@
+"""Every source a spec declares must be something the build can actually get.
+
+Both gnome cells failed on packages whose sources could not be fetched, and
+both failures were arch-independent — the aarch64 cells merely ran first
+(#480).
+
+  malcontent   Source2 `gvdb.tar.xz` and Source3 `tinycdb-0.81.tar.gz` were
+               BARE FILENAMES with no URL, and neither file existed anywhere
+               in the repository. spectool fetches what has a URL; the SRPM
+               build then died on `Bad file: … No such file or directory`.
+
+  libnotify    not a fetch problem but the same shape: gnome-settings-daemon
+               requires >= 0.8.7 and EL10 tops out at 0.8.6, so the build
+               depended on something no reachable repository provided.
+
+The rule this file encodes is narrow on purpose: a numbered Source in a spec
+under src/ must either carry a URL or exist as a file beside the spec. A
+bare filename that is neither is unbuildable by construction, and that is
+exactly what shipped.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = re.compile(r"^Source(\d*):\s*(\S+)", re.MULTILINE)
+HAS_SCHEME = re.compile(r"^(https?|ftp)://")
+
+
+def declared_sources(spec: Path) -> list[tuple[str, str]]:
+    return SOURCE.findall(spec.read_text(encoding="utf-8", errors="replace"))
+
+
+def unfetchable(spec: Path) -> list[str]:
+    """Sources that nothing in the build can obtain.
+
+    Three legitimate ways a spec gets a source, and a bare filename is only a
+    defect when it is none of them:
+
+      a URL          spectool downloads it.
+      a file beside  the spec directory carries it in-tree.
+      the lookaside  the directory has a Fedora distgit `sources` manifest
+                     (`SHA512 (file) = …`), and the fetch goes through that.
+
+    The third is why src/gnome-50/mutter, src/hummingbird/plasma-desktop and
+    src/deps/selinux-policy carry bare filenames and build perfectly well.
+    src/deps/malcontent had no `sources` manifest and no file — only the spec —
+    which is exactly why its bare `gvdb.tar.xz` and `tinycdb-0.81.tar.gz` could
+    never be fetched (#480).
+    """
+    if (spec.parent / "sources").is_file():
+        return []
+    missing = []
+    for _, value in declared_sources(spec):
+        if HAS_SCHEME.match(value) or "%{" in value:
+            continue
+        if not (spec.parent / value).is_file():
+            missing.append(value)
+    return missing
+
+
+def built_spec_dirs() -> set[Path]:
+    """Only the specs some build order actually walks.
+
+    Scoped deliberately. src/ also holds specs nothing builds — a
+    distgit-imported mutter-rawhide.spec whose sources come from Fedora's
+    lookaside cache, a hello-world fixture — and for those a bare filename is
+    not a defect because no tier ever fetches them. A rule that flagged them
+    would be noise, and noise gets suppressed rather than fixed.
+    """
+    import yaml
+
+    dirs: set[Path] = set()
+    for manifest in sorted(ROOT.glob("build-order*.yml")):
+        spec = yaml.safe_load(manifest.read_text(encoding="utf-8")) or {}
+        for tier in spec.get("tiers") or []:
+            for package in tier.get("packages") or []:
+                path = package.get("path")
+                if path:
+                    dirs.add(ROOT / path)
+    return dirs
+
+
+def test_there_are_specs_to_check():
+    assert len(built_spec_dirs()) > 40
+
+
+def test_no_built_spec_declares_a_source_nothing_can_fetch():
+    offenders = {}
+    for directory in sorted(built_spec_dirs()):
+        for spec in sorted(directory.glob("*.spec")):
+            if missing := unfetchable(spec):
+                offenders[str(spec.relative_to(ROOT))] = missing
+    assert not offenders, offenders
+
+
+def test_the_rule_catches_the_malcontent_shape(tmp_path):
+    """Mutation in miniature, so the rule is proven against the original
+    defect rather than merely passing today."""
+    spec = tmp_path / "broken.spec"
+    spec.write_text(
+        "Name: x\n"
+        "Source0: https://example.invalid/x-1.tar.xz\n"
+        "Source2: gvdb.tar.xz\n",
+        encoding="utf-8",
+    )
+    assert unfetchable(spec) == ["gvdb.tar.xz"]
+
+    # ...and the lookaside exemption is not a blanket one: it applies only
+    # where a `sources` manifest actually exists.
+    (tmp_path / "sources").write_text("SHA512 (gvdb.tar.xz) = abc\n", encoding="utf-8")
+    assert unfetchable(spec) == []
+
+
+def test_malcontent_fetches_tinycdb_from_its_own_wrap_url():
+    """malcontent's subprojects/tinycdb.wrap declares this source_url and a
+    source_hash that the served tarball matches, so this is upstream's own
+    answer rather than one invented here."""
+    text = (ROOT / "src" / "deps" / "malcontent" / "malcontent.spec").read_text(encoding="utf-8")
+    assert "https://www.corpit.ru/mjt/tinycdb/tinycdb-0.81.tar.gz" in text
+
+
+def test_malcontent_no_longer_carries_a_redundant_gvdb_source():
+    """malcontent's release tarball already ships subprojects/gvdb populated,
+    so the extra source and its `tar -xf` were doing nothing but breaking the
+    build."""
+    text = (ROOT / "src" / "deps" / "malcontent" / "malcontent.spec").read_text(encoding="utf-8")
+    assert "gvdb.tar.xz" not in text
+    assert "%{SOURCE3}" not in text, "a source was dropped but its extraction was left behind"
+
+
+def test_libnotify_is_built_before_the_package_that_needs_it():
+    """gnome-settings-daemon requires >= 0.8.7; the koji buildroot has 0.8.6 on
+    both arches and EPEL has none. Building it is the only way to satisfy that,
+    and it has to land in an earlier tier."""
+    import yaml
+
+    for manifest in ("build-order.yml", "build-order-gnome51.yml"):
+        tiers = yaml.safe_load((ROOT / manifest).read_text(encoding="utf-8"))["tiers"]
+        def tier_of(name: str) -> int:
+            for i, tier in enumerate(tiers):
+                for pkg in tier.get("packages", []):
+                    if pkg.get("path", "").rsplit("/", 1)[-1] == name:
+                        return i
+            raise AssertionError(f"{name} not in {manifest}")
+        assert tier_of("libnotify") < tier_of("gnome-settings-daemon"), manifest
+
+
+def test_libnotify_does_not_build_its_tests():
+    """Load-bearing: libnotify's gtk4 dependency is conditional on the tests
+    option, and gtk4 is built by this same chain in the SAME tier. Enabling
+    tests would make a tier depend on itself."""
+    text = (ROOT / "src" / "deps" / "libnotify" / "libnotify.spec").read_text(encoding="utf-8")
+    assert "-Dtests=false" in text

--- a/tests/test_license_tags_are_valid_spdx_refs.py
+++ b/tests/test_license_tags_are_valid_spdx_refs.py
@@ -1,0 +1,139 @@
+"""A License tag must carry SPDX identifiers rpmlint will accept.
+
+gnome51-el10-x86_64 built cleanly at 39b5632 -- 55 packages, zero failed --
+and then failed anyway, in a step no gnome cell had ever reached before:
+
+    lint-generated-rpm: FATAL finding 'invalid-license' in generated RPM
+    libglib-testing.x86_64:  W: invalid-license LicenseRef-Callaway-LGPLv2+
+    tinysparql-doc.noarch:   W: invalid-license LicenceRef-Fedora-Public-Domain
+
+Two different defects, both in metadata rather than in any build:
+
+  LicenseRef-Callaway-LGPLv2+   SPDX permits only [A-Za-z0-9.-] in a
+                                LicenseRef idstring, so the trailing `+`
+                                makes the whole token invalid. The same
+                                spec's neighbours are fine precisely because
+                                they have no `+`: plasma-workspace carries
+                                LicenseRef-Callaway-GFDL and passes.
+                                Fedora's legacy Callaway "LGPLv2+" is SPDX
+                                LGPL-2.1-or-later, which needs no LicenseRef.
+
+  LicenceRef-Fedora-Public-Domain   "Licence" with a c. Not a LicenseRef at
+                                all, just a misspelling. Six other specs in
+                                this repository spell the same license
+                                correctly and lint clean, which is what
+                                proves the intended spelling.
+
+Only the -doc subpackage of tinysparql was flagged, which looks odd until you
+notice line 103 is that subpackage's own License tag rather than the main
+package's -- the main package is plain GPL-2.0-or-later.
+
+Scope note: `invalid-license` is one of six findings scripts/lint-generated-rpm.sh
+treats as fatal out of the thousands rpmlint reports (341 packages, 3797
+findings, 6280 filtered on that run). This file checks the tag, not rpmlint's
+whole opinion.
+
+Changelog prose is deliberately excluded: the entries that record these two
+fixes quote the broken tokens, and rpmlint reads the License tag, not the
+changelog.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+LICENSE_TAG = re.compile(r"^License:\s*(.+?)\s*$", re.MULTILINE)
+# Any token that is trying to be a LicenseRef, however it is spelled.
+REFISH = re.compile(r"\b(Licen[cs]eRef)-(\S+)")
+# What SPDX actually allows after "LicenseRef-".
+VALID_IDSTRING = re.compile(r"^[A-Za-z0-9.-]+$")
+
+
+def specs() -> list[Path]:
+    return sorted(ROOT.rglob("*.spec"))
+
+
+def bad_license_refs(spec: Path) -> list[str]:
+    """Offending tokens on License: lines only."""
+    found = []
+    for value in LICENSE_TAG.findall(spec.read_text(encoding="utf-8", errors="replace")):
+        for keyword, idstring in REFISH.findall(value):
+            if keyword != "LicenseRef":
+                found.append(f"{keyword}-{idstring} (misspelled)")
+            elif not VALID_IDSTRING.match(idstring):
+                found.append(f"{keyword}-{idstring} (idstring not [A-Za-z0-9.-])")
+    return found
+
+
+def test_there_are_specs_to_check():
+    assert len(specs()) > 50
+
+
+def test_no_spec_carries_an_invalid_license_ref():
+    offenders = {
+        str(spec.relative_to(ROOT)): found
+        for spec in specs()
+        if (found := bad_license_refs(spec))
+    }
+    assert not offenders, offenders
+
+
+def test_the_two_specs_that_failed_are_fixed():
+    """Pinned by content, so they survive edits above them."""
+    glib_testing = (ROOT / "src/deps/libglib-testing/libglib-testing.spec").read_text(
+        encoding="utf-8"
+    )
+    assert "License:        LGPL-2.1-or-later" in glib_testing
+    assert "License:        LicenseRef-Callaway-LGPLv2+" not in glib_testing
+
+    for rel in ("src/deps/tinysparql/tinysparql.spec",
+                "src/gnome-49/tinysparql/tinysparql.spec"):
+        text = (ROOT / rel).read_text(encoding="utf-8")
+        assert "License:        LicenseRef-Fedora-Public-Domain AND" in text, rel
+
+
+def test_a_valid_licenseref_is_not_flagged(tmp_path):
+    """LicenseRef-Callaway-GFDL and LicenseRef-Fedora-Public-Domain are both
+    legal. A rule that flagged every LicenseRef would be noise."""
+    ok = tmp_path / "ok.spec"
+    ok.write_text(
+        "Name: x\n"
+        "License:        HPND AND LicenseRef-Fedora-Public-Domain AND Unicode-DFS-2016\n"
+        "%package doc\n"
+        "License:        LicenseRef-Callaway-GFDL\n"
+        "%prep\n",
+        encoding="utf-8",
+    )
+    assert bad_license_refs(ok) == []
+
+
+def test_the_rule_would_catch_both_original_defects(tmp_path):
+    broken = tmp_path / "broken.spec"
+    broken.write_text(
+        "Name: x\n"
+        "License:        LicenseRef-Callaway-LGPLv2+\n"
+        "%package doc\n"
+        "License:        LicenceRef-Fedora-Public-Domain AND LGPL-2.1-or-later\n"
+        "%prep\n",
+        encoding="utf-8",
+    )
+    assert bad_license_refs(broken) == [
+        "LicenseRef-Callaway-LGPLv2+ (idstring not [A-Za-z0-9.-])",
+        "LicenceRef-Fedora-Public-Domain (misspelled)",
+    ]
+
+
+def test_changelog_prose_is_not_mistaken_for_a_tag(tmp_path):
+    """The real fixes quote the broken tokens in their changelog entries."""
+    spec = tmp_path / "changelog.spec"
+    spec.write_text(
+        "Name: x\n"
+        "License:        LGPL-2.1-or-later\n"
+        "%changelog\n"
+        "* Sun Aug 23 2026 Someone <a@b.c> - 1-1\n"
+        "- LicenseRef-Callaway-LGPLv2+ is not a valid LicenseRef\n",
+        encoding="utf-8",
+    )
+    assert bad_license_refs(spec) == []

--- a/tests/test_rpm_publisher_covers_more_than_el10.py
+++ b/tests/test_rpm_publisher_covers_more_than_el10.py
@@ -64,13 +64,25 @@ def test_el10_x86_64_keeps_the_repo_wipe_guard():
     assert rows["x86_64"]["min_rpms"] == 100
 
 
-def test_a_prefix_this_workflow_creates_has_no_such_guard():
-    """el10 aarch64 and every new target start empty by design; a minimum
-    would make the first publish impossible."""
-    rows = publish_rows(planned("--target", "el10", "--packages", "libunwind-devel"))
-    assert rows["aarch64"]["min_rpms"] == 0
+def test_a_prefix_that_is_still_empty_has_no_such_guard():
+    """A minimum would make the FIRST publish impossible, so a prefix nothing
+    has written to yet carries none.
+
+    This originally asserted the same of el10 aarch64. That was right when it
+    was written and is now wrong: that prefix serves 39 packages, so it has a
+    floor of its own (see the test below). The rule was never "new targets have
+    no guard" — it is "an empty prefix has no guard", and the two only looked
+    identical while el10 aarch64 happened to be empty."""
     suse = publish_rows(planned("--target", "opensuse-tumbleweed", "--packages", "quickshell"))
     assert all(row["min_rpms"] == 0 for row in suse.values())
+
+
+def test_el10_aarch64_gained_a_guard_once_it_had_content():
+    """It serves 39 packages measured on 2026-08-22, and the publisher's
+    sync-down ends in `|| true` — so an unguarded failed download would sync up
+    only the new packages and delete the other 39 (#124)."""
+    rows = publish_rows(planned("--target", "el10", "--packages", "libunwind-devel"))
+    assert 0 < rows["aarch64"]["min_rpms"] < 39
 
 
 def test_opensuse_can_be_planned_at_all():

--- a/tests/test_the_cell_verifies_what_it_ships.py
+++ b/tests/test_the_cell_verifies_what_it_ships.py
@@ -1,0 +1,94 @@
+"""The verify step must install what the chain ships, and only that.
+
+gnome51-el10-aarch64 at 8086e03 reported "All packages built successfully!"
+with 55 packages and a clean lint, then failed in the verify step -- the next
+layer down, and one no gnome cell had reached before. Two independent defects:
+
+1. DUPLICATE NEVRAs. The step ran `dnf install /factory-repo/*.rpm`, passing
+   every built FILE. A build-chain tier list may build the same recipe twice
+   on purpose:
+
+       tier 2 glib2-bootstrap  src/gnome-51/glib2
+       tier 6 glib2-full       src/gnome-51/glib2
+       tier 5 gi-bootstrap     src/gnome-51/gobject-introspection
+       tier 7 gi-full          src/gnome-51/gobject-introspection
+
+   so /artifacts holds two EVRs of each, and asking dnf for both at once is
+   unsatisfiable by construction:
+
+       cannot install both glib2-2.88.0-4.el10.aarch64 from @commandline
+       and glib2-2.88.0-1.el10.aarch64 from @commandline
+
+   Installing by NAME resolves each to the newest EVR in the factory repo --
+   the build the chain means to ship -- while rpm -q and rpm -V still cover
+   every name, so coverage is unchanged. This is why only gnome cells hit it:
+   xfce and fprintd have no bootstrap pass, which is also why the step looked
+   correct for as long as it did.
+
+2. tigervnc. avahi-ui-tools carried a hard `Requires: tigervnc`, and EL10 has
+   no tigervnc in BaseOS, AppStream, CRB or EPEL, on either arch -- measured
+   against the repository metadata, where EPEL 10 lists 25573 names and none
+   of them is tigervnc. So the subpackage could not be installed on this
+   target at all:
+
+       nothing provides tigervnc needed by avahi-ui-tools-0.9~rc2-8.el10.aarch64
+
+   Recommends is the fix rather than deletion: the package installs where
+   tigervnc is absent and still pulls it in where it exists. Only bvnc needs
+   it; bssh and the rest of the subpackage do not.
+"""
+from __future__ import annotations
+
+import re
+from collections import Counter
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFY = ROOT / "scripts" / "verify-package-factory-cell.sh"
+
+
+def test_the_build_chain_verify_installs_by_name_not_by_file():
+    text = VERIFY.read_text(encoding="utf-8")
+    # The install must name the resolved package list...
+    assert '"${names[@]}"\n' in text
+    # ...and must not hand dnf a glob of every built file.
+    assert "/factory-repo/*.rpm\n" not in text, (
+        "installing every file re-introduces the duplicate-NEVRA failure"
+    )
+    # names must be computed before it is used to install.
+    computed = text.index("mapfile -t names")
+    installed = text.index("dnf -y install --nogpgcheck --repofrompath factory")
+    assert computed < installed, "names is used before it is set"
+
+
+def test_every_name_is_still_queried_and_verified():
+    """Installing by name must not quietly shrink what gets checked."""
+    text = VERIFY.read_text(encoding="utf-8")
+    assert 'rpm -q "${names[@]}"' in text
+    assert 'rpm -V "${names[@]}"' in text
+
+
+def test_a_recipe_really_is_built_twice_in_the_gnome_chains():
+    """The premise of the fix, asserted rather than assumed. If the bootstrap
+    passes ever go away this test should be removed, not worked around."""
+    for order in ("build-order.yml", "build-order-gnome51.yml"):
+        data = yaml.safe_load((ROOT / order).read_text(encoding="utf-8"))
+        paths = [
+            pkg["path"]
+            for tier in data.get("tiers", [])
+            for pkg in (tier.get("packages") or [])
+            if pkg.get("path")
+        ]
+        repeated = {path for path, n in Counter(paths).items() if n > 1}
+        assert repeated, f"{order}: expected at least one recipe built twice"
+        assert any("glib2" in p for p in repeated), (order, repeated)
+
+
+def test_avahi_does_not_hard_require_something_el10_lacks():
+    text = (ROOT / "src" / "deps" / "avahi" / "avahi.spec").read_text(encoding="utf-8")
+    assert re.search(r"^Recommends:\s+tigervnc\s*$", text, re.M), text[:0]
+    assert not re.search(r"^Requires:\s+tigervnc\s*$", text, re.M), (
+        "a hard Requires on tigervnc makes avahi-ui-tools uninstallable on EL10"
+    )

--- a/tests/test_the_gnome_chains_build_what_el10_is_too_old_for.py
+++ b/tests/test_the_gnome_chains_build_what_el10_is_too_old_for.py
@@ -1,0 +1,111 @@
+"""Where EL10 is below a GNOME version floor, the chain must build it itself.
+
+Two packages in the gnome-50/gnome-51 chains ask for a dependency at a version
+CentOS Stream 10 does not carry, and neither is optional -- both are hard
+configure-time errors:
+
+  gnome-settings-daemon 50.0   libnotify  >= 0.8.7   EL10 has 0.8.6
+      meson.build:107:16: ERROR: Dependency lookup for libnotify with method
+      'pkgconfig' failed: Invalid version, need 'libnotify' ['>= 0.8.7']
+      found '0.8.6'.
+
+  gnome-control-center 50.0    tecla      >= 47.0    EL10 has 45.0
+      Dependency tecla found: NO. Found 45.0 but need: '>=47.0'
+      ERROR: Subproject tecla is buildable: NO
+      meson.build:199:10: ERROR: Automatic wrap-based subproject downloading
+      is disabled
+
+The second was invisible until the first was fixed: gnome-control-center was
+one of three packages failing as pure cascade from libnotify, so its own
+failure did not appear until libnotify built (run 32613066611).
+
+Both were the SAME defect -- a recipe existed in the repository but was in no
+build order, so it never built and never reached the buildroot:
+
+  src/deps/libnotify   an artifact served from repo.tunaos.org that nothing
+                       here could reproduce; given a spec, then an entry
+  src/deps/tecla       a complete recipe, pinned at 50~rc, referenced by no
+                       build order at all since it was added in March
+
+A general rule was tried here and rejected on measurement: "a recipe exists
+for pkgconfig(X), so the order must contain it" produces 91 violations
+against the current tree, because most such recipes are overrides that only
+some chains use while EL10 satisfies the rest (gtk4, cairo, pango...). The
+recipe existing does not mean the order needs it. What makes these two
+different is the measured version floor, and that is not visible offline --
+so this file pins the two cases rather than inventing an invariant that is
+not true.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# (build order, consumer, what it needs, the recipe that must precede it)
+FLOORS = [
+    ("build-order.yml", "src/gnome-50/gnome-settings-daemon", "libnotify", "src/deps/libnotify"),
+    ("build-order-gnome51.yml", "src/gnome-51/gnome-settings-daemon", "libnotify", "src/deps/libnotify"),
+    ("build-order.yml", "src/gnome-50/gnome-control-center", "tecla", "src/deps/tecla"),
+    ("build-order-gnome51.yml", "src/gnome-51/gnome-control-center", "tecla", "src/deps/tecla"),
+]
+
+
+def tier_index(order: str) -> dict[str, int]:
+    data = yaml.safe_load((ROOT / order).read_text(encoding="utf-8"))
+    found: dict[str, int] = {}
+    for i, tier in enumerate(data.get("tiers", [])):
+        for pkg in tier.get("packages") or []:
+            if pkg.get("path"):
+                found[pkg["path"].rstrip("/")] = i
+    return found
+
+
+def test_each_floor_is_built_before_the_package_that_needs_it():
+    problems = []
+    for order, consumer, need, recipe in FLOORS:
+        tiers = tier_index(order)
+        if consumer not in tiers:
+            problems.append(f"{order}: {consumer} absent")
+            continue
+        if recipe not in tiers:
+            problems.append(f"{order}: {recipe} absent, but {consumer} needs {need}")
+            continue
+        if tiers[recipe] >= tiers[consumer]:
+            problems.append(
+                f"{order}: {recipe} at tier {tiers[recipe]} is not before "
+                f"{consumer} at tier {tiers[consumer]}"
+            )
+    assert not problems, problems
+
+
+def test_the_recipes_are_new_enough_to_clear_the_floor():
+    """Building it is not enough if the version still sits under the floor."""
+    versions = {}
+    for recipe in ("src/deps/libnotify", "src/deps/tecla"):
+        spec = next((ROOT / recipe).glob("*.spec"))
+        text = spec.read_text(encoding="utf-8")
+        versions[recipe] = re.search(r"^Version:\s*(\S+)", text, re.M).group(1)
+
+    # EL10 ships libnotify 0.8.6; gnome-settings-daemon needs >= 0.8.7.
+    assert versions["src/deps/libnotify"] == "0.8.7", versions
+
+    # EL10 ships tecla 45.0; gnome-control-center needs >= 47.0. A `~`
+    # pre-release would sort BELOW the plain version in rpm, so a release
+    # candidate is not an acceptable answer here.
+    tecla = versions["src/deps/tecla"]
+    assert "~" not in tecla, f"tecla pinned to a pre-release: {tecla}"
+    assert int(tecla.split(".")[0]) >= 47, tecla
+
+
+def test_a_recipe_in_no_build_order_is_what_broke_both():
+    """The failure mode, stated as a check: these two paths must appear in
+    the gnome orders. Before this fix src/deps/tecla appeared in neither,
+    which is why gnome-control-center resolved against EL10's 45.0."""
+    for order in ("build-order.yml", "build-order-gnome51.yml"):
+        tiers = tier_index(order)
+        assert "src/deps/tecla" in tiers, order
+        assert "src/deps/libnotify" in tiers, order


### PR DESCRIPTION
Two of the three defects the new gnome aarch64 cells surfaced (#480). Both are arch-independent — `gnome51-el10-x86_64` failed identically to aarch64, same four packages, same 49 SRPM builds completed — so this is not porting work. The third, `input-remapper`, landed in #476.

## malcontent: sources nothing could fetch

```
error: Bad file: /builddir/SOURCES/gvdb.tar.xz: No such file or directory
error: Bad file: /builddir/SOURCES/tinycdb-0.81.tar.gz: No such file
```

`Source2` and `Source3` were bare filenames with no URL, and neither file was in the repository. malcontent is absent from the live `repo/10-x86_64` index while its tier neighbours are present — it had never built anywhere.

Both answers come from malcontent's own `subprojects/*.wrap`, not from guesswork:

| source | what the wrap says | what I did |
|---|---|---|
| tinycdb | `source_url = https://www.corpit.ru/mjt/tinycdb/tinycdb-0.81.tar.gz`, `source_hash = 469de2d4…ebc2` | fetched it — **sha256 matches exactly** — and made that URL `Source2` |
| gvdb | `[wrap-git]` … but the 0.14.0 release tarball **already ships `subprojects/gvdb` populated**, 15 files including its `meson.build` | dropped the source and its `tar -xf` entirely |

The build was failing on a file it did not need. `Provides: bundled(gvdb)` stays true — it is still bundled, by upstream rather than by us.

## libnotify: a constraint EL10 cannot satisfy

```
meson.build:107:16: ERROR: Dependency lookup for libnotify failed:
Invalid version, need 'libnotify' ['>= 0.8.7'] found '0.8.6'.
```

Measured across every repository the buildroot reaches, on **both** arches:

| source | libnotify |
|---|---|
| CS10 AppStream | 0.8.3-5.el10 |
| CS10 koji `c10s-build` | **0.8.6-1.el10** ← what the build found |
| EPEL 10 | absent |

Unsatisfiable upstream. `gnome-settings-daemon`, `gnome-control-center` and `gnome-initial-setup` all fail without it.

`repo.tunaos.org/repo/10-x86_64` already serves a `libnotify-0.8.7-1.el10` with **no spec and no build-order entry anywhere in this repository** — an artifact the factory could not reproduce, and one that (measured) reaches neither buildroot. This replaces that orphan with something rebuildable, on both arches rather than one.

`0.8.7` rather than the newer `0.8.8` deliberately: the minimum that satisfies the requirement, and it matches what is already published, so nothing installed churns.

**`-Dtests=false` is load-bearing.** libnotify's gtk4 dependency is conditional on that option, and gtk4 is built by this chain in the *same* tier — enabling tests would make tier 10 depend on itself.

## The guard

A numbered `Source` in a spec some build order walks must be one of: a URL, a file beside the spec, or covered by a Fedora distgit `sources` lookaside manifest.

That third case is the interesting one. `src/gnome-50/mutter`, `src/hummingbird/plasma-desktop` and `src/deps/selinux-policy` all carry bare filenames and build perfectly well, because each has a `sources` manifest. `src/deps/malcontent` had neither a manifest nor the files — that is precisely the difference, and it is what the rule keys on. Scoped to specs an order actually builds, because flagging the unbuilt ones would be noise, and noise gets suppressed rather than fixed.

## Verification

Suite **1016 passed, 1 skipped**. Mutation-checked rather than written green — restoring malcontent's bare source, moving libnotify after the package that needs it, and enabling libnotify's tests each fail a test. The lookaside exemption is itself mutation-checked so it cannot silently widen into a blanket pass. Both build orders re-validate against the schema.

## What this does not do

Neither gnome cell is re-dispatched here: a run costs ~2.5h, and the next scheduled `engine=build-chain` build (added in #476) is the cheaper place to find out. **libnotify has never been built by this factory**, so its spec is unproven until then — that is the honest status.

Also unaddressed, deliberately: hummingbird's 6-hour cell timeout (#480) needs a structural change, and `libunwind-devel`'s runtime-SONAME hazard (#469) turns out to be the factory's **only autotools recipe**, so retiring it would delete the sole coverage of that build path. Both explained on their issues.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_