### PR TITLE
Measure the GNOME 51 deb backport gap (RFC 011's deb half)

### DIFF
--- a/docs/gnome51-deb-gap.json
+++ b/docs/gnome51-deb-gap.json
@@ -1,0 +1,184 @@
+{
+  "roots": [
+    "gnome-shell",
+    "mutter",
+    "gnome-session",
+    "gnome-settings-daemon",
+    "gnome-control-center",
+    "gnome-initial-setup",
+    "gdm3",
+    "nautilus",
+    "xdg-desktop-portal-gnome"
+  ],
+  "stack": "gnome-51",
+  "targets": {
+    "debian": {
+      "donor_sources": 41343,
+      "donor_suite": "experimental",
+      "missing_roots": [],
+      "needed_count": 1,
+      "packages": [
+        {
+          "depth": 0,
+          "donor_version": "51~beta-1",
+          "reason": "target is older",
+          "source": "mutter",
+          "target_version": "50.3-1"
+        }
+      ],
+      "target_sources": 41195,
+      "target_suite": "sid",
+      "tiers": [
+        [
+          "mutter"
+        ]
+      ]
+    },
+    "ubuntu": {
+      "donor_sources": 41629,
+      "donor_suite": "stonking",
+      "missing_roots": [],
+      "needed_count": 16,
+      "packages": [
+        {
+          "depth": 2,
+          "donor_version": "1.58.0-1",
+          "reason": "target is older",
+          "source": "pango1.0",
+          "target_version": "1.57.0-1"
+        },
+        {
+          "depth": 2,
+          "donor_version": "1.49-1",
+          "reason": "target is older",
+          "source": "wayland-protocols",
+          "target_version": "1.47-1"
+        },
+        {
+          "depth": 1,
+          "donor_version": "0.16.2-1",
+          "reason": "target is older",
+          "source": "gexiv2",
+          "target_version": "0.14.6-2"
+        },
+        {
+          "depth": 1,
+          "donor_version": "51~alpha-4",
+          "reason": "target is older",
+          "source": "gnome-desktop",
+          "target_version": "44.5-1ubuntu1"
+        },
+        {
+          "depth": 1,
+          "donor_version": "51~beta-0ubuntu2",
+          "reason": "target is older",
+          "source": "gnome-session",
+          "target_version": "50.0-0ubuntu3"
+        },
+        {
+          "depth": 1,
+          "donor_version": "51~beta-1ubuntu1",
+          "reason": "target is older",
+          "source": "gsettings-desktop-schemas",
+          "target_version": "50.0-1ubuntu2"
+        },
+        {
+          "depth": 1,
+          "donor_version": "4.23.2+ds-1",
+          "reason": "target is older",
+          "source": "gtk4",
+          "target_version": "4.22.2+ds-1ubuntu1"
+        },
+        {
+          "depth": 1,
+          "donor_version": "51~alpha-0ubuntu2",
+          "reason": "target is older",
+          "source": "mutter",
+          "target_version": "50.1-0ubuntu2"
+        },
+        {
+          "depth": 1,
+          "donor_version": "1.0.0ubuntu",
+          "reason": "target is older",
+          "source": "ubuntu-insights",
+          "target_version": "0.9.3ubuntu"
+        },
+        {
+          "depth": 0,
+          "donor_version": "51~beta-0ubuntu1",
+          "reason": "target is older",
+          "source": "gdm3",
+          "target_version": "50.0-0ubuntu1"
+        },
+        {
+          "depth": 0,
+          "donor_version": "1:51~beta-1ubuntu1",
+          "reason": "target is older",
+          "source": "gnome-control-center",
+          "target_version": "1:50.0-0ubuntu6"
+        },
+        {
+          "depth": 0,
+          "donor_version": "51~alpha-0ubuntu2",
+          "reason": "target is older",
+          "source": "gnome-initial-setup",
+          "target_version": "50.0-0ubuntu7"
+        },
+        {
+          "depth": 0,
+          "donor_version": "51~beta-2ubuntu2",
+          "reason": "target is older",
+          "source": "gnome-settings-daemon",
+          "target_version": "50.0-1ubuntu1"
+        },
+        {
+          "depth": 0,
+          "donor_version": "51~alpha-0ubuntu4",
+          "reason": "target is older",
+          "source": "gnome-shell",
+          "target_version": "50.1-0ubuntu1"
+        },
+        {
+          "depth": 0,
+          "donor_version": "1:51~alpha-0ubuntu1",
+          "reason": "target is older",
+          "source": "nautilus",
+          "target_version": "1:50.0-0ubuntu2"
+        },
+        {
+          "depth": 0,
+          "donor_version": "51~alpha-0ubuntu1",
+          "reason": "target is older",
+          "source": "xdg-desktop-portal-gnome",
+          "target_version": "50.0-0ubuntu1"
+        }
+      ],
+      "target_sources": 39736,
+      "target_suite": "resolute",
+      "tiers": [
+        [
+          "pango1.0",
+          "wayland-protocols"
+        ],
+        [
+          "gexiv2",
+          "gnome-desktop",
+          "gnome-session",
+          "gsettings-desktop-schemas",
+          "gtk4",
+          "mutter",
+          "ubuntu-insights"
+        ],
+        [
+          "gdm3",
+          "gnome-control-center",
+          "gnome-initial-setup",
+          "gnome-settings-daemon",
+          "gnome-shell",
+          "nautilus",
+          "xdg-desktop-portal-gnome"
+        ]
+      ]
+    }
+  }
+}

--- a/manifests/gnome51-deb.yaml
+++ b/manifests/gnome51-deb.yaml
@@ -1,0 +1,56 @@
+# What a deb suite would have to rebuild to carry GNOME 51.
+#
+# GNOME 51.0 ships 2026-09-12 (issue #107), so today's donor suites carry
+# alpha/beta. That is the point of measuring now rather than in September:
+# the closure shape is already visible, and re-running this after 51.0 lands
+# changes versions, not structure.
+#
+# Only the ROOTS are declared. Everything else is computed by closing over
+# Build-Depends and keeping only what the target suite cannot already
+# satisfy, so this file does not rot the way a hand-curated build order does
+# (RFC 011's "system-repos-first becomes computed, not remembered").
+#
+# openSUSE Tumbleweed is deliberately absent: it is rpm-md, not deb, so it
+# belongs to the rpm gap engine (measure-target-gap.py), not this one.
+stack: gnome-51
+
+roots:
+  - gnome-shell
+  - mutter
+  - gnome-session
+  - gnome-settings-daemon
+  - gnome-control-center
+  - gnome-initial-setup
+  - gdm3
+  - nautilus
+  - xdg-desktop-portal-gnome
+
+targets:
+  # The only PERMANENT gap of the three deb/rpm targets. resolute is 26.04
+  # LTS: frozen at GNOME 50 for its support life, exactly the situation that
+  # justifies the EL10 backport. stonking (26.10) already carries the whole
+  # 51 stack, so this is a rebuild of existing packaging, not an authoring job.
+  ubuntu:
+    target_suite: resolute
+    donor_suite: stonking
+    target_index:
+      - https://archive.ubuntu.com/ubuntu/dists/resolute/main/source/Sources.xz
+      - https://archive.ubuntu.com/ubuntu/dists/resolute/universe/source/Sources.xz
+    donor_index:
+      - https://archive.ubuntu.com/ubuntu/dists/stonking/main/source/Sources.xz
+      - https://archive.ubuntu.com/ubuntu/dists/stonking/universe/source/Sources.xz
+
+  # sid is unstable and will take GNOME 51 on its own within weeks of release,
+  # so this measurement is early-access only. Kept because the engine's own
+  # rule retires it automatically: once sid carries 51, every root drops out
+  # and the answer becomes zero packages without anyone editing this file.
+  # Debian stages GNOME in experimental, which today holds mutter 51~beta but
+  # not yet gnome-shell -- expect roots to be reported absent from the donor.
+  debian:
+    target_suite: sid
+    donor_suite: experimental
+    target_index:
+      - https://deb.debian.org/debian/dists/sid/main/source/Sources.xz
+    donor_index:
+      - https://deb.debian.org/debian/dists/experimental/main/source/Sources.xz
+      - https://deb.debian.org/debian/dists/sid/main/source/Sources.xz

--- a/scripts/measure-deb-backport-gap.py
+++ b/scripts/measure-deb-backport-gap.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Measure what a deb suite needs backported from a newer donor suite.
+
+RFC 011's gap engine covers rpm-md only: measure-target-gap.py is a shim over
+measure-hummingbird-gap.py, which parses primary.xml and knows nothing about
+APT. This is the deb half, and it answers a different question than the
+Hummingbird measurer does.
+
+Hummingbird asks "what does this target fail to PROVIDE at runtime", and
+closes over Requires:. A backport asks "what must I REBUILD to move a stack
+from one suite to another", and closes over Build-Depends: -- because the
+packaging already exists in the donor suite and the work is a rebuild, not an
+authoring job.
+
+The restriction that makes the closure finite is the same rule RFC 011 states
+for rpm: a build dependency only enters the closure when the DONOR's version
+is strictly newer than the TARGET's. Everything the target already satisfies
+drops out, so debhelper, gcc and the rest of the toolchain never appear, and
+the answer shrinks by itself as the target catches up. Nothing is remembered;
+it is recomputed from two live indexes.
+
+Usage:
+    scripts/measure-deb-backport-gap.py --manifest manifests/gnome51-deb.yaml
+    scripts/measure-deb-backport-gap.py --manifest manifests/gnome51-deb.yaml \
+        --target ubuntu --report-json docs/gnome51-deb-gap.json
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import lzma
+import pathlib
+import sys
+import urllib.request
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+# --- dpkg version comparison -------------------------------------------------
+# Implemented here rather than shelling out: this repo's runners have no
+# python-apt, and `dpkg --compare-versions` is not present in every image the
+# factory uses. The algorithm is dpkg's, including the rule that '~' sorts
+# before everything, end-of-string included, which is the only reason
+# 51~beta correctly sorts BELOW 51.
+
+def _order(char: str) -> int:
+    if char == "":
+        return 0
+    if char == "~":
+        return -1
+    if char.isdigit():
+        return 0
+    if char.isalpha():
+        return ord(char)
+    return ord(char) + 256
+
+
+def _compare_fragment(a: str, b: str) -> int:
+    i = j = 0
+    while i < len(a) or j < len(b):
+        first_diff = 0
+        while (i < len(a) and not a[i].isdigit()) or (j < len(b) and not b[j].isdigit()):
+            ac = _order(a[i] if i < len(a) else "")
+            bc = _order(b[j] if j < len(b) else "")
+            if ac != bc:
+                return -1 if ac < bc else 1
+            i += 1
+            j += 1
+        while i < len(a) and a[i] == "0":
+            i += 1
+        while j < len(b) and b[j] == "0":
+            j += 1
+        while i < len(a) and a[i].isdigit() and j < len(b) and b[j].isdigit():
+            if not first_diff:
+                first_diff = (a[i] > b[j]) - (a[i] < b[j])
+            i += 1
+            j += 1
+        if i < len(a) and a[i].isdigit():
+            return 1
+        if j < len(b) and b[j].isdigit():
+            return -1
+        if first_diff:
+            return first_diff
+    return 0
+
+
+def compare_versions(a: str, b: str) -> int:
+    """-1, 0 or 1, following dpkg's ordering."""
+    def split(v: str) -> tuple[int, str, str]:
+        epoch = 0
+        if ":" in v:
+            head, _, v = v.partition(":")
+            epoch = int(head) if head.isdigit() else 0
+        upstream, sep, revision = v.rpartition("-")
+        if not sep:
+            upstream, revision = v, ""
+        return epoch, upstream, revision
+
+    ea, ua, ra = split(a)
+    eb, ub, rb = split(b)
+    if ea != eb:
+        return -1 if ea < eb else 1
+    result = _compare_fragment(ua, ub)
+    if result:
+        return result
+    return _compare_fragment(ra, rb)
+
+
+# --- APT index reading -------------------------------------------------------
+
+def fetch(url: str) -> bytes:
+    with urllib.request.urlopen(url, timeout=300) as response:
+        return response.read()
+
+
+def parse_sources(text: str) -> dict[str, dict[str, str]]:
+    """deb822 Sources index -> {source name: stanza}.
+
+    Only the fields this measurement uses are kept, and a later stanza for the
+    same source wins only if its version is higher -- a suite can legitimately
+    carry two versions of a source (e.g. -updates merged into a single view).
+    """
+    wanted = {"Package", "Version", "Binary", "Build-Depends", "Build-Depends-Arch"}
+    sources: dict[str, dict[str, str]] = {}
+    for block in text.split("\n\n"):
+        if not block.strip():
+            continue
+        stanza: dict[str, str] = {}
+        key = None
+        for line in block.splitlines():
+            if line.startswith((" ", "\t")):
+                if key in wanted:
+                    stanza[key] = stanza.get(key, "") + " " + line.strip()
+                continue
+            key, _, value = line.partition(":")
+            if key in wanted:
+                stanza[key] = value.strip()
+        name = stanza.get("Package")
+        if not name or "Version" not in stanza:
+            continue
+        existing = sources.get(name)
+        if existing is None or compare_versions(stanza["Version"], existing["Version"]) > 0:
+            sources[name] = stanza
+    return sources
+
+
+def binary_to_source(sources: dict[str, dict[str, str]]) -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    for name, stanza in sources.items():
+        for binary in stanza.get("Binary", "").split(","):
+            binary = binary.strip()
+            if binary:
+                mapping[binary] = name
+    return mapping
+
+
+def build_dep_clauses(stanza: dict[str, str]) -> list[list[tuple[str, str, str]]]:
+    """Build-Depends as clauses of alternatives: [(name, op, version), ...].
+
+    The constraint is kept, not discarded. Dropping it was the first version of
+    this measurement and it was wrong: against a devel suite nearly every
+    source is newer than an LTS's, so "donor is newer" closed over the whole
+    archive and reported 1263 packages for Ubuntu, sweeping in swig, gettext,
+    node-mocha and the Go and Ruby toolchains. What actually forces a rebuild
+    is the target failing a DECLARED constraint, and most build-deps carry
+    none at all.
+    """
+    clauses: list[list[tuple[str, str, str]]] = []
+    raw = " ".join(
+        stanza.get(field, "") for field in ("Build-Depends", "Build-Depends-Arch")
+    )
+    for clause in raw.split(","):
+        alternatives: list[tuple[str, str, str]] = []
+        for alternative in clause.split("|"):
+            token = alternative.strip()
+            if not token:
+                continue
+            name, op, version = token, "", ""
+            if "(" in token:
+                name, _, rest = token.partition("(")
+                constraint = rest.split(")")[0].strip()
+                for candidate in (">=", "<=", ">>", "<<", "="):
+                    if constraint.startswith(candidate):
+                        op = candidate
+                        version = constraint[len(candidate):].strip()
+                        break
+            name = name.split("[")[0].split("<")[0].strip().split(":")[0].strip()
+            if name:
+                alternatives.append((name, op, version))
+        if alternatives:
+            clauses.append(alternatives)
+    return clauses
+
+
+def satisfies(have: str | None, op: str, want: str) -> bool:
+    """Does `have` meet the constraint? Absent never satisfies."""
+    if have is None:
+        return False
+    if not op:
+        return True  # present at any version is enough
+    result = compare_versions(have, want)
+    return {
+        ">=": result >= 0,
+        ">>": result > 0,
+        "<=": result <= 0,
+        "<<": result < 0,
+        "=": result == 0,
+    }[op]
+
+
+# --- the measurement ---------------------------------------------------------
+
+def merge_indexes(urls) -> dict[str, dict[str, str]]:
+    """One suite view from one or more component indexes, highest version wins."""
+    if isinstance(urls, str):
+        urls = [urls]
+    merged: dict[str, dict[str, str]] = {}
+    for url in urls:
+        text = lzma.decompress(fetch(url)).decode("utf8", "replace")
+        for name, stanza in parse_sources(text).items():
+            existing = merged.get(name)
+            if existing is None or compare_versions(stanza["Version"], existing["Version"]) > 0:
+                merged[name] = stanza
+    return merged
+
+
+
+def measure(roots, donor, target, bin2src, target_binary) -> dict:
+    """Close over Build-Depends, keeping only what the target cannot satisfy."""
+    needed: dict[str, dict] = {}
+    missing_roots: list[str] = []
+    queue = collections.deque()
+
+    for root in roots:
+        if root not in donor:
+            missing_roots.append(root)
+            continue
+        queue.append((root, 0))
+
+    while queue:
+        name, depth = queue.popleft()
+        donor_stanza = donor.get(name)
+        if donor_stanza is None:
+            continue
+        donor_version = donor_stanza["Version"]
+        target_version = target.get(name, {}).get("Version")
+        # The rule that bounds the closure: already satisfied means not our job.
+        if target_version is not None and compare_versions(donor_version, target_version) <= 0:
+            continue
+        record = needed.get(name)
+        if record is not None:
+            record["depth"] = max(record["depth"], depth)
+            continue
+        needed[name] = {
+            "source": name,
+            "donor_version": donor_version,
+            "target_version": target_version,
+            "reason": "absent from target" if target_version is None else "target is older",
+            "depth": depth,
+        }
+        for alternatives in build_dep_clauses(donor_stanza):
+            # An alternative group is satisfied if ANY of its members is, so a
+            # rebuild is only forced when every alternative fails.
+            if any(
+                satisfies(target_binary.get(binary), op, version)
+                for binary, op, version in alternatives
+            ):
+                continue
+            binary, _, _ = alternatives[0]
+            source = bin2src.get(binary)
+            if source and source != name:
+                queue.append((source, depth + 1))
+
+    return {"needed": needed, "missing_roots": missing_roots}
+
+
+def tiers(needed: dict[str, dict]) -> list[list[str]]:
+    by_depth: dict[int, list[str]] = collections.defaultdict(list)
+    for name, record in needed.items():
+        by_depth[record["depth"]].append(name)
+    # Deepest build-dependency first: a tier must build before what needs it.
+    return [sorted(by_depth[d]) for d in sorted(by_depth, reverse=True)]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--target", help="Only measure this target from the manifest")
+    parser.add_argument("--report-json")
+    args = parser.parse_args()
+
+    manifest = yaml.safe_load(pathlib.Path(args.manifest).read_text(encoding="utf-8"))
+    roots = manifest["roots"]
+    report = {"stack": manifest.get("stack"), "roots": roots, "targets": {}}
+
+    for name, spec in manifest["targets"].items():
+        if args.target and name != args.target:
+            continue
+        # A suite's sources are split across components (Ubuntu keeps some of
+        # GNOME in universe), so each side is a LIST of indexes merged into one
+        # view. Merging by highest version is what parse_sources already does
+        # within an index; do the same across them.
+        donor = merge_indexes(spec["donor_index"])
+        target = merge_indexes(spec["target_index"])
+        # Build-Depends name BINARY packages; the target's source version is
+        # the honest proxy available from a Sources index, and binary and
+        # source versions agree except where a source renames its binaries.
+        target_binary = {
+            binary: stanza["Version"]
+            for stanza in target.values()
+            for binary in (b.strip() for b in stanza.get("Binary", "").split(","))
+            if binary
+        }
+        result = measure(roots, donor, target, binary_to_source(donor), target_binary)
+        order = tiers(result["needed"])
+        report["targets"][name] = {
+            "donor_suite": spec["donor_suite"],
+            "target_suite": spec["target_suite"],
+            "donor_sources": len(donor),
+            "target_sources": len(target),
+            "needed_count": len(result["needed"]),
+            "missing_roots": result["missing_roots"],
+            "tiers": order,
+            "packages": sorted(result["needed"].values(), key=lambda r: (-r["depth"], r["source"])),
+        }
+        print(f"{name}: {spec['target_suite']} <- {spec['donor_suite']}: "
+              f"{len(result['needed'])} source packages need rebuilding, "
+              f"{len(order)} tiers", file=sys.stderr)
+        if result["missing_roots"]:
+            print(f"  roots absent from donor: {result['missing_roots']}", file=sys.stderr)
+
+    text = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.report_json:
+        pathlib.Path(args.report_json).write_text(text, encoding="utf-8")
+    else:
+        print(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_the_deb_backport_gap_is_measured_not_guessed.py
+++ b/tests/test_the_deb_backport_gap_is_measured_not_guessed.py
@@ -1,0 +1,125 @@
+"""The deb backport gap must be computed, and computed with the right rule.
+
+RFC 011's gap engine is rpm-md only -- measure-target-gap.py is a shim over
+measure-hummingbird-gap.py, which parses primary.xml and knows nothing about
+APT. scripts/measure-deb-backport-gap.py is the deb half, and it answers a
+different question: Hummingbird asks what a target fails to PROVIDE and closes
+over Requires:, while a backport asks what must be REBUILT and closes over
+Build-Depends:, because the packaging already exists in the donor suite.
+
+The rule that bounds the closure is the interesting part, and the first
+version of it was WRONG. "Include a build dependency when the donor's version
+is newer than the target's" sounds right and is not: measured against Ubuntu
+stonking, nearly every source in a devel suite is newer than in an LTS, so the
+closure swallowed the archive and reported 1263 packages -- swig, gettext,
+node-mocha, ruby-rspec, the Go toolchain. With the constraint honoured the
+same measurement reports 16, all of them real GNOME-stack packages.
+
+So the rule is: a build dependency forces a rebuild only when the target
+FAILS A DECLARED CONSTRAINT. An unversioned build-dep is satisfied by the
+target having the package at all, which is what keeps the toolchain out.
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+_spec = importlib.util.spec_from_file_location(
+    "measure_deb_backport_gap", ROOT / "scripts" / "measure-deb-backport-gap.py"
+)
+gap = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gap)
+
+
+def test_a_tilde_sorts_below_the_release_it_precedes():
+    """Load-bearing: every donor version in the manifest today is a ~alpha or
+    ~beta, so a comparator that got this backwards would report the whole
+    stack as already satisfied and measure a gap of zero."""
+    assert gap.compare_versions("51~beta", "51") < 0
+    assert gap.compare_versions("51~alpha", "51~beta") < 0
+    assert gap.compare_versions("50.1", "51~beta") < 0
+    assert gap.compare_versions("51", "51") == 0
+
+
+def test_epoch_and_revision_follow_dpkg():
+    assert gap.compare_versions("1:50.0", "50.9") > 0
+    assert gap.compare_versions("1.0-1", "1.0-2") < 0
+    assert gap.compare_versions("1.0", "1.0-1") < 0
+    assert gap.compare_versions("2.88.0", "2.89.3") < 0
+
+
+def test_an_unversioned_build_dep_is_satisfied_by_mere_presence():
+    """This single rule is what separates 16 packages from 1263."""
+    assert gap.satisfies("11.7.5", "", "") is True
+    assert gap.satisfies(None, "", "") is False
+
+
+def test_a_version_floor_is_enforced():
+    assert gap.satisfies("2.88.0", ">=", "2.89.0") is False
+    assert gap.satisfies("2.89.3", ">=", "2.89.0") is True
+    assert gap.satisfies("1.0", ">>", "1.0") is False
+
+
+def test_clauses_keep_their_constraints():
+    stanza = {"Build-Depends": "debhelper, libglib2.0-dev (>= 2.89.0) [amd64], a | b"}
+    clauses = gap.build_dep_clauses(stanza)
+    assert ["debhelper", "", ""] == list(clauses[0][0])
+    assert ["libglib2.0-dev", ">=", "2.89.0"] == list(clauses[1][0])
+    assert [name for name, _, _ in clauses[2]] == ["a", "b"]
+
+
+def test_a_newer_donor_dep_alone_does_not_force_a_rebuild():
+    """The 1263-package regression, in miniature. `tool` is newer in the donor
+    but the build-dep is unversioned, so it must NOT enter the closure."""
+    donor = {
+        "app": {"Package": "app", "Version": "51~beta-1", "Binary": "app",
+                "Build-Depends": "tool"},
+        "tool": {"Package": "tool", "Version": "2.0", "Binary": "tool"},
+    }
+    target = {
+        "app": {"Package": "app", "Version": "50.0-1", "Binary": "app"},
+        "tool": {"Package": "tool", "Version": "1.0", "Binary": "tool"},
+    }
+    target_binary = {"app": "50.0-1", "tool": "1.0"}
+    result = gap.measure(["app"], donor, target, gap.binary_to_source(donor), target_binary)
+    assert set(result["needed"]) == {"app"}, result["needed"]
+
+
+def test_a_failed_version_floor_does_force_a_rebuild():
+    """The same shape, with a constraint the target cannot meet."""
+    donor = {
+        "app": {"Package": "app", "Version": "51~beta-1", "Binary": "app",
+                "Build-Depends": "tool (>= 2.0)"},
+        "tool": {"Package": "tool", "Version": "2.0", "Binary": "tool"},
+    }
+    target = {
+        "app": {"Package": "app", "Version": "50.0-1", "Binary": "app"},
+        "tool": {"Package": "tool", "Version": "1.0", "Binary": "tool"},
+    }
+    target_binary = {"app": "50.0-1", "tool": "1.0"}
+    result = gap.measure(["app"], donor, target, gap.binary_to_source(donor), target_binary)
+    assert set(result["needed"]) == {"app", "tool"}, result["needed"]
+    # tool must build BEFORE app, so it sits in an earlier tier.
+    order = gap.tiers(result["needed"])
+    assert order[0] == ["tool"] and order[-1] == ["app"], order
+
+
+def test_a_target_that_has_caught_up_needs_nothing():
+    """The engine retires itself. Once a suite ships the stack, the answer is
+    zero without anyone editing the manifest -- which is why debian/sid is
+    listed even though it will get GNOME 51 on its own."""
+    donor = {"app": {"Package": "app", "Version": "51.0-1", "Binary": "app"}}
+    target = {"app": {"Package": "app", "Version": "51.0-1", "Binary": "app"}}
+    result = gap.measure(["app"], donor, target, gap.binary_to_source(donor), {"app": "51.0-1"})
+    assert result["needed"] == {}
+
+
+def test_the_manifest_only_names_declared_targets():
+    import yaml
+    manifest = yaml.safe_load((ROOT / "manifests" / "gnome51-deb.yaml").read_text())
+    contract = yaml.safe_load((ROOT / "manifests" / "package-factory.yaml").read_text())
+    for name in manifest["targets"]:
+        assert name in contract["targets"], name
+        assert contract["targets"][name]["format"] == "deb", name
+    assert manifest["roots"], "a gap over no roots measures nothing"


### PR DESCRIPTION
Measures what it would take to put GNOME 51 on the deb targets, so the answer comes from the live archives rather than an estimate. Nothing is built or published yet — this is the Phase 0 measurement RFC 011 asks for first.

## Why a new script

RFC 011's gap engine is rpm-md only. `measure-target-gap.py` is a shim over `measure-hummingbird-gap.py`, which parses `primary.xml` and knows nothing about APT, so today no deb target can be measured at all. This is the deb half.

It answers a **different question** than the Hummingbird measurer, and that distinction drives the design:

| | asks | closes over |
| --- | --- | --- |
| Hummingbird | what does the target fail to **provide** at runtime | `Requires:` |
| a backport | what must be **rebuilt** to move a stack between suites | `Build-Depends:` |

The backport question is the cheaper one, because the packaging already exists. Ubuntu stonking (26.10) carries the whole GNOME 51 stack today, so this is a rebuild of existing source packages — not the spec-authoring job the EL10 GNOME backport was.

## Measured, against the live archives

```
ubuntu   resolute <- stonking       16 source packages, 3 tiers
debian   sid      <- experimental    1 source package,  1 tier
```

The 16 are all genuine GNOME-stack packages — the 8 roots plus `gtk4`, `mutter`, `gnome-desktop`, `gnome-session`, `gsettings-desktop-schemas`, `gexiv2`, `pango1.0`, `wayland-protocols`, `ubuntu-insights`. Debian's 1 is `mutter`, which is the honest answer: experimental holds `mutter 51~beta` but not yet `gnome-shell`, so Debian's 51 transition has barely started.

Full report committed at `docs/gnome51-deb-gap.json`.

## The closure rule, and the version of it that was wrong

The obvious rule — *include a build dependency when the donor's version is newer than the target's* — is wrong, and looks right until measured. Against a devel suite nearly every source is newer than in an LTS, so the closure swallowed the archive: **1263 packages** for Ubuntu, dragging in `swig`, `gettext`, `node-mocha`, `ruby-rspec` and the Go and Ruby toolchains.

Honouring the **declared constraint** instead gives 16. An unversioned build-dep is satisfied by the target simply having the package, and that single distinction is the entire difference. `tests/test_the_deb_backport_gap_is_measured_not_guessed.py` pins both directions so the runaway cannot come back.

## The engine retires itself

`debian/sid` is listed even though sid will take GNOME 51 on its own within weeks of release. That is deliberate: by the same rule, once a suite ships the stack every root drops out and the answer becomes zero with nobody editing the manifest. The same is true of Arch and openSUSE Tumbleweed, both rolling.

Only the **roots** are declared — everything else is computed, so the manifest cannot rot the way a hand-curated build order does.

openSUSE Tumbleweed is deliberately **absent**: it is rpm-md, so it belongs to the rpm engine, not this one.

## Notes

- dpkg version comparison is implemented in-tree rather than shelled out: the runners have no `python-apt` and not every factory image ships `dpkg`. The `~` rule is load-bearing and tested — every donor version today is a `~alpha` or `~beta`, so a comparator that got it backwards would report a gap of zero.
- Build-Depends name *binary* packages; the target's source version is the honest proxy available from a `Sources` index, and the two agree except where a source renames its binaries.
- Ubuntu splits GNOME across `main` and `universe`, so each side is a list of component indexes merged into one view.

## Scope this does not cover

No build order is generated, no packaging is added, nothing is published. The natural next steps, in order: generate a build order from this report, teach the factory a deb-rebuild engine, then re-run after GNOME 51.0 ships **2026-09-12** (#107) — which changes versions, not structure.

Suite: 1052 passed, 1 skipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_