### PR TITLE
Mount the deb chain output by absolute path

### DIFF
--- a/scripts/build-deb-chain.sh
+++ b/scripts/build-deb-chain.sh
@@ -48,6 +48,17 @@ done
 }
 
 mkdir -p "$out"/{artifacts,logs,repo}
+# Absolute, because docker reads a RELATIVE --volume source as a NAMED VOLUME
+# rather than a host path, and then blames the characters in the name rather
+# than the relativeness:
+#
+#   docker: Error response from daemon: create .factory/backport-ubuntu:
+#   ".factory/backport-ubuntu" includes invalid characters for a local volume
+#   name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed.
+#
+# Resolved here rather than at the call site so every caller is safe, not just
+# the workflow that happened to hit it (run 32641183871).
+out=$(cd "$out" && pwd)
 
 # The order is parsed on the HOST. The target image is a stock distro
 # container: it has python3 but no pyyaml, and installing one to read our own

--- a/tests/test_the_deb_chain_rebuilds_against_the_target.py
+++ b/tests/test_the_deb_chain_rebuilds_against_the_target.py
@@ -155,3 +155,24 @@ def test_the_rendered_order_names_sources_and_exact_versions():
     # Deepest build-dependency first: gtk4 must build before mutter.
     assert parsed["tiers"][1]["packages"][0]["source"] == "mutter"
     assert text.startswith("# GENERATED"), "a generated file must say so"
+
+
+def test_the_mounted_output_path_is_absolute():
+    """docker reads a RELATIVE --volume source as a NAMED VOLUME.
+
+    The first real dispatch (run 32641183871) died on exactly this, and the
+    error blames the wrong thing -- it complains about invalid characters in a
+    volume name rather than saying the path was relative:
+
+        docker: Error response from daemon: create .factory/backport-ubuntu:
+        ".factory/backport-ubuntu" includes invalid characters for a local
+        volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed.
+
+    Everything before it worked: the measurement ran, --tier narrowed the order
+    to 2 source packages, and the image pulled. Resolved inside the script so
+    every caller is covered rather than only the workflow that hit it.
+    """
+    text = chain_text()
+    resolve = text.index('out=$(cd "$out" && pwd)')
+    mount = text.index('--volume "$out:/work"')
+    assert resolve < mount, "the output path must be absolute before it is mounted"


### PR DESCRIPTION
The first real dispatch of the backport engine (run [32641183871](https://github.com/tuna-os/tunaos-packages/actions/runs/32641183871), `tier-0` for ubuntu/resolute) failed after 28 seconds:

```
docker: Error response from daemon: create .factory/backport-ubuntu:
".factory/backport-ubuntu" includes invalid characters for a local volume name,
only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host
directory, use absolute path
```

docker reads a **relative** `--volume` source as a **named volume**, and the message blames the characters in the name rather than the relativeness — which is why this gets a comment and a test rather than a silent one-word fix.

Resolved inside `build-deb-chain.sh` rather than at the call site, so every caller is covered and not just the workflow that happened to hit it.

## What the failed run did prove

The engine had never executed before, so the front half is now evidenced:

- the measurement ran **in CI** and regenerated the order from the live archives
- `--tier tier-0` correctly narrowed it: *"resolute <- stonking: 2 source packages to rebuild"*
- `docker.io/library/ubuntu:26.04` resolved and pulled from the target contract's `probe_image`

Everything past the mount is still unproven — `apt-get source` against the donor's `deb-src`, build-dep resolution on resolute, and `dpkg-buildpackage` — which is what the re-dispatch after this merges will exercise.

Suite: 1060 passed, 1 skipped. `bash -n` and `shellcheck -S warning` clean. Guard mutation-tested.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_