### PR TITLE
Report at measure time what the donor suite cannot build

### DIFF
--- a/docs/gnome51-deb-gap.json
+++ b/docs/gnome51-deb-gap.json
@@ -13,6 +13,7 @@
   "stack": "gnome-51",
   "targets": {
     "debian": {
+      "donor_cannot_build": {},
       "donor_sources": 41343,
       "donor_suite": "experimental",
       "missing_roots": [],
@@ -35,7 +36,12 @@
       ]
     },
     "ubuntu": {
-      "donor_sources": 41629,
+      "donor_cannot_build": {
+        "wayland-protocols": [
+          "libwayland-dev (>= 1.25.0)"
+        ]
+      },
+      "donor_sources": 41630,
       "donor_suite": "stonking",
       "missing_roots": [],
       "needed_count": 16,

--- a/scripts/measure-deb-backport-gap.py
+++ b/scripts/measure-deb-backport-gap.py
@@ -277,6 +277,60 @@ def measure(roots, donor, target, bin2src, target_binary) -> dict:
     return {"needed": needed, "missing_roots": missing_roots}
 
 
+def donor_cannot_build(needed, donor, donor_binary) -> dict[str, list[str]]:
+    """Packages the DONOR itself cannot satisfy the build dependencies of.
+
+    A donor suite is not a static thing: it is mid-transition much of the
+    time, and a source package in it may have been built against a version
+    that has since moved on -- or has not yet migrated out of -proposed.
+
+    Measured, not hypothetical. wayland-protocols 1.49-1 in Ubuntu stonking
+    build-depends on libwayland-dev (>= 1.25.0), and `wayland` is 1.24.0-2 in
+    BOTH stonking and resolute; 1.26.0-1 sits in stonking-proposed and has not
+    migrated. So that package cannot be rebuilt from stonking at all, by us or
+    by anyone, and the closure was right to leave `wayland` out -- the donor
+    has nothing newer to offer.
+
+    Without this check the order looks fine and the chain discovers it two
+    minutes in, per package, after paying for a container and a buildroot
+    (run 32643256826). Checking against the donor's own versions up front
+    turns that into one line of the report.
+    """
+    blocked: dict[str, list[str]] = {}
+    for name in needed:
+        stanza = donor.get(name)
+        if stanza is None:
+            continue
+        unmet = []
+        for alternatives in build_dep_clauses(stanza):
+            if any(
+                satisfies(donor_binary.get(binary), op, version)
+                for binary, op, version in alternatives
+            ):
+                continue
+            # Only report what this view can actually decide. A Sources index
+            # lists a source's REAL binaries; it says nothing about Provides,
+            # so every virtual package looks absent. Reporting those made the
+            # first version of this check flag 16 of 16 packages on
+            # debhelper-compat, dh-sequence-gir, dh-sequence-gnome and the
+            # gir1.2-*-dev virtuals -- all of them satisfied in reality, and
+            # noise that would bury the one true finding.
+            #
+            # "Present but too old" is decidable. "Not in the map" is not, so
+            # it stays silent.
+            if not any(binary in donor_binary for binary, _, _ in alternatives):
+                continue
+            unmet.append(
+                " | ".join(
+                    f"{binary} ({op} {version})" if op else binary
+                    for binary, op, version in alternatives
+                )
+            )
+        if unmet:
+            blocked[name] = unmet
+    return blocked
+
+
 def tiers(needed: dict[str, dict]) -> list[list[str]]:
     by_depth: dict[int, list[str]] = collections.defaultdict(list)
     for name, record in needed.items():
@@ -355,6 +409,13 @@ def main() -> None:
             if binary
         }
         result = measure(roots, donor, target, binary_to_source(donor), target_binary)
+        donor_binary = {
+            binary: stanza["Version"]
+            for stanza in donor.values()
+            for binary in (b.strip() for b in stanza.get("Binary", "").split(","))
+            if binary
+        }
+        blocked = donor_cannot_build(result["needed"], donor, donor_binary)
         order = tiers(result["needed"])
         report["targets"][name] = {
             "donor_suite": spec["donor_suite"],
@@ -363,6 +424,7 @@ def main() -> None:
             "target_sources": len(target),
             "needed_count": len(result["needed"]),
             "missing_roots": result["missing_roots"],
+            "donor_cannot_build": blocked,
             "tiers": order,
             "packages": sorted(result["needed"].values(), key=lambda r: (-r["depth"], r["source"])),
         }
@@ -371,6 +433,10 @@ def main() -> None:
               f"{len(order)} tiers", file=sys.stderr)
         if result["missing_roots"]:
             print(f"  roots absent from donor: {result['missing_roots']}", file=sys.stderr)
+        if blocked:
+            print(f"  NOT BUILDABLE FROM {spec['donor_suite']} ({len(blocked)}):", file=sys.stderr)
+            for source, unmet in sorted(blocked.items()):
+                print(f"    {source}: {'; '.join(unmet)}", file=sys.stderr)
 
     if args.build_order:
         entry = report["targets"][args.target]

--- a/tests/test_the_deb_backport_gap_is_measured_not_guessed.py
+++ b/tests/test_the_deb_backport_gap_is_measured_not_guessed.py
@@ -123,3 +123,52 @@ def test_the_manifest_only_names_declared_targets():
         assert name in contract["targets"], name
         assert contract["targets"][name]["format"] == "deb", name
     assert manifest["roots"], "a gap over no roots measures nothing"
+
+
+def test_a_package_the_donor_cannot_build_is_reported():
+    """The donor suite is not static, and a source in it can be temporarily
+    unbuildable from that suite alone.
+
+    Measured: wayland-protocols 1.49-1 in Ubuntu stonking build-depends on
+    libwayland-dev (>= 1.25.0), while `wayland` is 1.24.0-2 in BOTH stonking
+    and resolute -- 1.26.0-1 sits in stonking-proposed and has not migrated.
+    The closure was right to leave `wayland` out (the donor has nothing newer
+    to offer), so the order lists a package nobody can rebuild from stonking.
+    Run 32643256826 discovered that two minutes in, after paying for a
+    container and a buildroot; this turns it into a line of the report.
+    """
+    donor = {
+        "app": {"Package": "app", "Version": "2.0-1", "Binary": "app",
+                "Build-Depends": "libfoo-dev (>= 9.0)"},
+        "foo": {"Package": "foo", "Version": "1.0-1", "Binary": "libfoo-dev"},
+    }
+    donor_binary = {"app": "2.0-1", "libfoo-dev": "1.0-1"}
+    blocked = gap.donor_cannot_build({"app": {}}, donor, donor_binary)
+    assert blocked == {"app": ["libfoo-dev (>= 9.0)"]}, blocked
+
+
+def test_virtual_build_deps_are_not_reported_as_unbuildable():
+    """A Sources index lists a source's REAL binaries and says nothing about
+    Provides, so every virtual package looks absent.
+
+    The first version of this check reported all of debhelper-compat,
+    dh-sequence-gir, dh-sequence-gnome and the gir1.2-*-dev virtuals, flagging
+    16 of 16 packages and burying the single true finding. "Present but too
+    old" is decidable from this data; "not in the map" is not.
+    """
+    donor = {
+        "app": {"Package": "app", "Version": "2.0-1", "Binary": "app",
+                "Build-Depends": "debhelper-compat (= 13), dh-sequence-gir, gir1.2-gio-2.0-dev"},
+    }
+    donor_binary = {"app": "2.0-1"}
+    assert gap.donor_cannot_build({"app": {}}, donor, donor_binary) == {}
+
+
+def test_a_satisfied_constraint_is_not_reported():
+    donor = {
+        "app": {"Package": "app", "Version": "2.0-1", "Binary": "app",
+                "Build-Depends": "libfoo-dev (>= 1.0)"},
+        "foo": {"Package": "foo", "Version": "1.0-1", "Binary": "libfoo-dev"},
+    }
+    donor_binary = {"app": "2.0-1", "libfoo-dev": "1.0-1"}
+    assert gap.donor_cannot_build({"app": {}}, donor, donor_binary) == {}


### PR DESCRIPTION
The first *working* dispatch of the backport engine ([run 32643256826](https://github.com/tuna-os/tunaos-packages/actions/runs/32643256826)) built `pango1.0` and then failed on `wayland-protocols`:

```
builddeps: ... Depends: libwayland-dev (>= 1.25.0) but it is not going to be installed
```

## The engine is fine. So is the closure rule.

What this exposed is that **a donor suite is not static**. Measured:

| package | version | where |
| --- | --- | --- |
| wayland-protocols | 1.49-1 | stonking — build-depends `libwayland-dev >= 1.25.0` |
| wayland | 1.24.0-2 | **stonking** — the donor has nothing newer |
| wayland | 1.24.0-2 | resolute |
| wayland | 1.26.0-1 | stonking-**proposed**, not yet migrated |

So stonking's own `wayland-protocols` is not currently rebuildable from stonking — by us or by anyone. The closure was **right** to leave `wayland` out: including it would have been pointless, since the donor cannot supply a newer one either.

The actual defect is that the measurement emitted an order containing a package nobody can build, and the chain discovered it two minutes in, after paying for a container and a full buildroot. This checks each package's `Build-Depends` against the **donor's own** versions up front, so that becomes one line of the report instead of a wasted run.

## The first version of the check was useless, which is worth recording

Reporting every unsatisfied clause flagged **16 of 16** packages — on `debhelper-compat`, `dh-sequence-gir`, `dh-sequence-gnome` and the `gir1.2-*-dev` virtuals, all satisfied in reality. A `Sources` index lists a source's *real* binaries and says nothing about `Provides:`, so every virtual package looks absent and the one true finding was buried.

Narrowed to what this view can decide: a clause is reported only when at least one alternative names a binary the donor **does** have, and it is too old. *Present but too old* is decidable; *not in the map* is not, and now stays silent. That takes the report from 16 false to 1 true:

```
ubuntu: resolute <- stonking: 16 source packages need rebuilding, 3 tiers
  NOT BUILDABLE FROM stonking (1):
    wayland-protocols: libwayland-dev (>= 1.25.0)
```

## What the run also proved — most of the engine

`apt-get source` against the donor's `deb-src` line works, build-dep resolution against the target archive works, `dpkg-buildpackage` works, and the accumulating local repo re-indexes. **pango1.0 1.58.0-1 built and was added to the chain repo.**

## Left to the maintainer

`wayland-protocols` stays blocked until either the stonking transition migrates, or the donor is widened to include `-proposed` (where `wayland 1.26.0-1` already is). That's a policy decision about building against unmigrated packages, not a bug, so I haven't made it.

Suite: 1063 passed, 1 skipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_