### PR TITLE
Verify the newest build of each source, not of each name

### DIFF
--- a/scripts/verify-package-factory-cell.sh
+++ b/scripts/verify-package-factory-cell.sh
@@ -67,7 +67,50 @@ if [[ ${ENGINE:?} == build-chain ]]; then
                        --enablerepo="tunaos${published_n}")
       published_n=$((published_n + 1))
     done
-    mapfile -t names < <(rpm -qp --qf "%{NAME}\n" /factory-repo/*.rpm | sort -u)
+    # Only the NEWEST BUILD OF EACH SOURCE. Installing by name alone was not
+    # enough, and the residue is instructive: a subpackage that exists ONLY in
+    # the superseded bootstrap build has its own newest version in that older
+    # build, and drags in an exact `= EVR` dependency on a sibling whose
+    # newest is the newer one:
+    #
+    #   cannot install both gobject-introspection-debuginfo-1.86.0-2 and
+    #   -1 from factory
+    #     - gobject-introspection-devel-debuginfo-1.86.0-1 requires
+    #       gobject-introspection-debuginfo(aarch-64) = 1.86.0-1.el10
+    #
+    # gobject-introspection-devel-debuginfo is produced by the bootstrap pass
+    # and not by the full one, so "newest by name" picks a package the chain
+    # never meant to ship. "Newest by SOURCE" is the right unit: it is exactly
+    # what the chain intends to ship, and the bootstrap pass drops out whole
+    # rather than leaving orphan subpackages behind.
+    #
+    # sort -V rather than the rpm library comparison, because the container is
+    # the target image and may carry dnf5 without python3-rpm. Adequate HERE
+    # and not in general: the two builds come from one chain run of one recipe
+    # and differ only in RELEASE (2.88.0-1 vs 2.88.0-4, 1.86.0-1 vs -2), which
+    # sort -V orders correctly. It implements neither epochs nor the rpm tilde
+    # rule, so this must not be lifted somewhere those can occur.
+    #
+    # No apostrophes anywhere in this block: it lives inside a single-quoted
+    # bash -lc string, and one would end the string mid-script.
+    declare -A newest_srpm
+    while IFS="|" read -r srpm pkgname; do
+      [ -n "$srpm" ] || continue
+      base=${srpm%-*-*.src.rpm}
+      cur=${newest_srpm[$base]:-}
+      if [ -z "$cur" ] || [ "$(printf "%s\n%s\n" "$cur" "$srpm" | sort -V | tail -1)" = "$srpm" ]; then
+        newest_srpm[$base]=$srpm
+      fi
+    done < <(rpm -qp --qf "%{SOURCERPM}|%{NAME}\n" /factory-repo/*.rpm 2>/dev/null)
+    mapfile -t names < <(
+      rpm -qp --qf "%{SOURCERPM}|%{NAME}\n" /factory-repo/*.rpm 2>/dev/null |
+        while IFS="|" read -r srpm pkgname; do
+          [ -n "$srpm" ] || continue
+          base=${srpm%-*-*.src.rpm}
+          [ "${newest_srpm[$base]:-}" = "$srpm" ] && printf "%s\n" "$pkgname"
+        done | sort -u
+    )
+    echo "==> verifying ${#names[@]} package name(s) from the newest build of each source"
     # Install by NAME, not by file path. A build-chain tier list may build the
     # same recipe twice on purpose -- gnome51 has glib2-bootstrap at tier 2 and
     # glib2-full at tier 6, both src/gnome-51/glib2, and the same for

--- a/tests/test_the_cell_verifies_what_it_ships.py
+++ b/tests/test_the_cell_verifies_what_it_ships.py
@@ -92,3 +92,73 @@ def test_avahi_does_not_hard_require_something_el10_lacks():
     assert not re.search(r"^Requires:\s+tigervnc\s*$", text, re.M), (
         "a hard Requires on tigervnc makes avahi-ui-tools uninstallable on EL10"
     )
+
+
+def _newest_by_source_block() -> str:
+    """The real selection code, lifted out of the container script."""
+    text = VERIFY.read_text(encoding="utf-8")
+    start = text.index("    declare -A newest_srpm")
+    end = text.index("verifying ${#names[@]} package name(s)")
+    end = text.index("\n", end) + 1
+    return text[start:end]
+
+
+def test_only_the_newest_build_of_each_source_is_installed():
+    """Installing the newest by NAME was not enough.
+
+    A subpackage produced ONLY by the superseded bootstrap pass has its own
+    newest version in that older build, and carries an exact `= EVR` dep on a
+    sibling whose newest is the newer build:
+
+        cannot install both gobject-introspection-debuginfo-1.86.0-2 and -1
+          - gobject-introspection-devel-debuginfo-1.86.0-1 requires
+            gobject-introspection-debuginfo(aarch-64) = 1.86.0-1.el10
+
+    Newest by SOURCE drops the bootstrap pass whole, so no orphan subpackage
+    survives to demand a sibling that is no longer the newest.
+
+    This runs the script's own code with a stubbed rpm, so it tests the
+    shipped algorithm rather than a copy of it.
+    """
+    import subprocess, textwrap
+
+    fixture = textwrap.dedent("""\
+        glib2-2.88.0-1.el10.src.rpm|glib2
+        glib2-2.88.0-1.el10.src.rpm|glib2-devel
+        glib2-2.88.0-4.el10.src.rpm|glib2
+        glib2-2.88.0-4.el10.src.rpm|glib2-devel
+        gobject-introspection-1.86.0-1.el10.src.rpm|gobject-introspection
+        gobject-introspection-1.86.0-1.el10.src.rpm|gobject-introspection-devel-debuginfo
+        gobject-introspection-1.86.0-2.el10.src.rpm|gobject-introspection
+        pango-1.55.0-1.el10.src.rpm|pango
+        """)
+    script = (
+        "set -euo pipefail\n"
+        f"rpm() {{ cat <<'FIXTURE'\n{fixture}FIXTURE\n}}\n"
+        + _newest_by_source_block()
+        + 'printf "%s\\n" "${names[@]}"\n'
+    )
+    out = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert out.returncode == 0, out.stderr
+    names = [line for line in out.stdout.splitlines() if line and not line.startswith("==>")]
+
+    assert "gobject-introspection" in names
+    assert "glib2" in names and "glib2-devel" in names and "pango" in names
+    # The whole point: the bootstrap-only subpackage must not be installed.
+    assert "gobject-introspection-devel-debuginfo" not in names, names
+
+
+def test_the_container_block_carries_no_apostrophe():
+    """The verify body is a single-quoted `bash -lc` string, so one apostrophe
+    anywhere inside ends the string and the shell fails on a later line that
+    looks innocent. Adding a comment containing "rpm's" broke it exactly that
+    way, and the reported syntax error pointed at an unrelated comment 40
+    lines further down.
+    """
+    text = VERIFY.read_text(encoding="utf-8")
+    start = text.index('"${IMAGE:?}" -lc \'')
+    end = text.index("\n  '\n", start)
+    body = text[start:end]
+    assert "'" not in body[len('"${IMAGE:?}" -lc \''):], (
+        "an apostrophe inside the single-quoted container body ends it early"
+    )


### PR DESCRIPTION
The build-chain validation run on main ([32636273333](https://github.com/tuna-os/tunaos-packages/actions/runs/32636273333), dispatched to prove the fixes #490 merged unvalidated) got both gnome **aarch64** cells to a clean build *and* a clean lint — 55 packages, *"All packages built successfully!"* — then failed in verify with **one** dependency problem, down from nine.

Installing by name fixed the bulk. What remains is a subtler shape of the same defect:

```
cannot install both gobject-introspection-debuginfo-1.86.0-2.el10.aarch64
and gobject-introspection-debuginfo-1.86.0-1.el10.aarch64 from factory
  - gobject-introspection-devel-debuginfo-1.86.0-1.el10.aarch64 requires
    gobject-introspection-debuginfo(aarch-64) = 1.86.0-1.el10
```

`gobject-introspection-devel-debuginfo` is produced by the **bootstrap** pass and not by the full one. So its own newest version lives in the *older* build, and it carries an exact `= EVR` dependency on a sibling whose newest is the *newer* build. "Newest by name" therefore selects a package the chain never meant to ship — and then cannot satisfy it.

## The right unit is the source

Newest-by-source is exactly what the chain intends to ship, and it drops the bootstrap pass **whole** rather than leaving orphan subpackages behind demanding siblings that no longer exist at that EVR.

`sort -V` rather than the rpm library comparison, because the container is the target image and may carry dnf5 without `python3-rpm`. That's adequate *here* and the code says so: the two builds come from one chain run of one recipe and differ only in RELEASE, which `sort -V` orders correctly. It implements neither epochs nor the rpm tilde rule, so it must not be lifted somewhere those occur.

## Two tests, both mutation-verified

The first runs the **shipped selection code** with a stubbed `rpm` rather than a copy of it, on the exact fixture that broke: two glib2 builds, two gobject-introspection builds, and a bootstrap-only subpackage that must not survive.

The second guards something I broke while writing this. The verify body is a single-quoted `bash -lc` string, so **one apostrophe inside ends it early** — adding a comment containing `rpm's` made bash report a syntax error forty lines later, on an unrelated comment. `bash -n` caught it; nothing else would have until CI.

Suite: 1065 passed, 1 skipped. `bash -n` and `shellcheck -S warning` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_