### PR TITLE
Unblock the deb chain with -proposed, and order tiers topologically

### DIFF
--- a/docs/gnome51-deb-gap.json
+++ b/docs/gnome51-deb-gap.json
@@ -15,7 +15,10 @@
     "debian": {
       "donor_cannot_build": {},
       "donor_sources": 41343,
-      "donor_suite": "experimental",
+      "donor_suites": [
+        "experimental",
+        "sid"
+      ],
       "missing_roots": [],
       "needed_count": 1,
       "packages": [
@@ -24,7 +27,7 @@
           "donor_version": "51~beta-1",
           "reason": "target is older",
           "source": "mutter",
-          "target_version": "50.3-1"
+          "target_version": "50.4-1"
         }
       ],
       "target_sources": 41195,
@@ -36,15 +39,14 @@
       ]
     },
     "ubuntu": {
-      "donor_cannot_build": {
-        "wayland-protocols": [
-          "libwayland-dev (>= 1.25.0)"
-        ]
-      },
-      "donor_sources": 41630,
-      "donor_suite": "stonking",
+      "donor_cannot_build": {},
+      "donor_sources": 41957,
+      "donor_suites": [
+        "stonking",
+        "stonking-proposed"
+      ],
       "missing_roots": [],
-      "needed_count": 16,
+      "needed_count": 17,
       "packages": [
         {
           "depth": 2,
@@ -52,6 +54,13 @@
           "reason": "target is older",
           "source": "pango1.0",
           "target_version": "1.57.0-1"
+        },
+        {
+          "depth": 2,
+          "donor_version": "1.26.0-1",
+          "reason": "target is older",
+          "source": "wayland",
+          "target_version": "1.24.0-2"
         },
         {
           "depth": 2,
@@ -97,7 +106,7 @@
         },
         {
           "depth": 1,
-          "donor_version": "51~alpha-0ubuntu2",
+          "donor_version": "51~beta-1ubuntu2",
           "reason": "target is older",
           "source": "mutter",
           "target_version": "50.1-0ubuntu2"
@@ -139,7 +148,7 @@
         },
         {
           "depth": 0,
-          "donor_version": "51~alpha-0ubuntu4",
+          "donor_version": "51~beta-0ubuntu1",
           "reason": "target is older",
           "source": "gnome-shell",
           "target_version": "50.1-0ubuntu1"
@@ -163,26 +172,29 @@
       "target_suite": "resolute",
       "tiers": [
         [
+          "gdm3",
+          "gexiv2",
+          "gnome-desktop",
+          "gnome-initial-setup",
+          "gnome-session",
+          "gsettings-desktop-schemas",
           "pango1.0",
+          "ubuntu-insights",
+          "wayland",
+          "xdg-desktop-portal-gnome"
+        ],
+        [
+          "gnome-settings-daemon",
+          "nautilus",
           "wayland-protocols"
         ],
         [
-          "gexiv2",
-          "gnome-desktop",
-          "gnome-session",
-          "gsettings-desktop-schemas",
           "gtk4",
-          "mutter",
-          "ubuntu-insights"
+          "mutter"
         ],
         [
-          "gdm3",
           "gnome-control-center",
-          "gnome-initial-setup",
-          "gnome-settings-daemon",
-          "gnome-shell",
-          "nautilus",
-          "xdg-desktop-portal-gnome"
+          "gnome-shell"
         ]
       ]
     }

--- a/manifests/gnome51-deb.yaml
+++ b/manifests/gnome51-deb.yaml
@@ -32,13 +32,34 @@ targets:
   # 51 stack, so this is a rebuild of existing packaging, not an authoring job.
   ubuntu:
     target_suite: resolute
-    donor_suite: stonking
+    # -proposed is included DELIBERATELY, and it is a trade rather than an
+    # obvious win.
+    #
+    # Without it the chain is blocked: wayland-protocols 1.49-1 in stonking
+    # build-depends libwayland-dev (>= 1.25.0), and `wayland` is 1.24.0-2 in
+    # BOTH stonking and resolute -- 1.26.0-1 is sitting in stonking-proposed,
+    # unmigrated. So stonking's own wayland-protocols cannot be rebuilt from
+    # stonking, by us or by anyone (run 32643256826).
+    #
+    # What it costs: -proposed is a staging area. Packages there can be
+    # removed or superseded, so a measured order can name a version that is
+    # gone by the time the chain runs, and the closure will churn more than
+    # one computed from a released suite would. That is acceptable HERE
+    # because GNOME 51.0 has not shipped yet (2026-09-12, #107) -- this whole
+    # target is preparatory, and -proposed is precisely where the 51 work
+    # lands first. Revisit after release: once 51 is in stonking proper,
+    # dropping these two URLs should change versions and nothing else.
+    donor_suites:
+      - stonking
+      - stonking-proposed
     target_index:
       - https://archive.ubuntu.com/ubuntu/dists/resolute/main/source/Sources.xz
       - https://archive.ubuntu.com/ubuntu/dists/resolute/universe/source/Sources.xz
     donor_index:
       - https://archive.ubuntu.com/ubuntu/dists/stonking/main/source/Sources.xz
       - https://archive.ubuntu.com/ubuntu/dists/stonking/universe/source/Sources.xz
+      - https://archive.ubuntu.com/ubuntu/dists/stonking-proposed/main/source/Sources.xz
+      - https://archive.ubuntu.com/ubuntu/dists/stonking-proposed/universe/source/Sources.xz
 
   # sid is unstable and will take GNOME 51 on its own within weeks of release,
   # so this measurement is early-access only. Kept because the engine's own
@@ -48,7 +69,9 @@ targets:
   # not yet gnome-shell -- expect roots to be reported absent from the donor.
   debian:
     target_suite: sid
-    donor_suite: experimental
+    donor_suites:
+      - experimental
+      - sid
     target_index:
       - https://deb.debian.org/debian/dists/sid/main/source/Sources.xz
     donor_index:

--- a/scripts/build-deb-chain.sh
+++ b/scripts/build-deb-chain.sh
@@ -75,16 +75,16 @@ for tier in order.get("tiers", []):
         print(f"{tier['name']}\t{pkg['source']}\t{pkg['version']}")
 PY
 
-donor_suite=$(python3 -c "import yaml,sys;print(yaml.safe_load(open(sys.argv[1]))['donor_suite'])" "$order")
+donor_suites=$(python3 -c "import yaml,sys;print(' '.join(yaml.safe_load(open(sys.argv[1]))['donor_suites']))" "$order")
 target_suite=$(python3 -c "import yaml,sys;print(yaml.safe_load(open(sys.argv[1]))['target_suite'])" "$order")
 count=$(wc -l < "$out/worklist")
-echo "==> $target_suite <- $donor_suite: $count source packages to rebuild"
+echo "==> $target_suite <- $donor_suites: $count source packages to rebuild"
 
 : "${SOURCE_DATE_EPOCH:=$(date -u +%s)}"
 export SOURCE_DATE_EPOCH
 
 "$backend" run --rm \
-  --env SOURCE_DATE_EPOCH --env DONOR_SUITE="$donor_suite" \
+  --env SOURCE_DATE_EPOCH --env DONOR_SUITES="$donor_suites" \
   --env TZ=UTC --env LANG=C.UTF-8 --env LC_ALL=C.UTF-8 \
   --volume "$out:/work" "$image" bash -lc '
     set -euo pipefail
@@ -111,13 +111,20 @@ export SOURCE_DATE_EPOCH
     else
       donor_url="http://deb.debian.org/debian"
     fi
-    printf "deb-src %s %s main universe\n" "$donor_url" "$DONOR_SUITE" \
-      > /etc/apt/sources.list.d/donor-src.list
-    # Debian has no `universe`; asking for it is a hard error there.
-    if [ "${ID:-}" != "ubuntu" ]; then
-      printf "deb-src %s %s main\n" "$donor_url" "$DONOR_SUITE" \
-        > /etc/apt/sources.list.d/donor-src.list
-    fi
+    # One deb-src line per donor suite. Ubuntu needs -proposed alongside the
+    # release pocket because an in-flight transition can leave a source
+    # unbuildable from the release pocket alone: wayland-protocols 1.49-1
+    # needs libwayland-dev >= 1.25.0 and wayland is 1.24.0-2 in both stonking
+    # and resolute, with 1.26.0-1 waiting in stonking-proposed.
+    #
+    # Debian has no `universe`; asking for it there is a hard error.
+    if [ "${ID:-}" = "ubuntu" ]; then components="main universe"; else components="main"; fi
+    : > /etc/apt/sources.list.d/donor-src.list
+    for donor_suite in $DONOR_SUITES; do
+      printf "deb-src %s %s %s\n" "$donor_url" "$donor_suite" "$components" \
+        >> /etc/apt/sources.list.d/donor-src.list
+    done
+    echo "==> donor sources:"; cat /etc/apt/sources.list.d/donor-src.list
 
     # The accumulating local repo. Empty on the first pass, which apt accepts
     # only if the Packages file exists.

--- a/scripts/measure-deb-backport-gap.py
+++ b/scripts/measure-deb-backport-gap.py
@@ -331,12 +331,57 @@ def donor_cannot_build(needed, donor, donor_binary) -> dict[str, list[str]]:
     return blocked
 
 
-def tiers(needed: dict[str, dict]) -> list[list[str]]:
-    by_depth: dict[int, list[str]] = collections.defaultdict(list)
-    for name, record in needed.items():
-        by_depth[record["depth"]].append(name)
-    # Deepest build-dependency first: a tier must build before what needs it.
-    return [sorted(by_depth[d]) for d in sorted(by_depth, reverse=True)]
+def build_edges(needed, donor, bin2src, target_binary) -> dict[str, set[str]]:
+    """For each needed package, the needed packages it must be built AFTER."""
+    edges: dict[str, set[str]] = {name: set() for name in needed}
+    for name in needed:
+        stanza = donor.get(name)
+        if stanza is None:
+            continue
+        for alternatives in build_dep_clauses(stanza):
+            if any(
+                satisfies(target_binary.get(binary), op, version)
+                for binary, op, version in alternatives
+            ):
+                continue
+            binary, _, _ = alternatives[0]
+            source = bin2src.get(binary)
+            if source and source != name and source in needed:
+                edges[name].add(source)
+    return edges
+
+
+def tiers(edges: dict[str, set[str]]) -> list[list[str]]:
+    """Topological layers: everything a package needs is in an EARLIER tier.
+
+    Not BFS depth, which was the first implementation and is only correct on a
+    tree. Measured failure: with -proposed in the donor, `wayland` and
+    `wayland-protocols` both came out at depth 2 and so shared a tier, even
+    though wayland-protocols build-depends on libwayland-dev from wayland.
+    Depth is assigned by first reach, so a cross-edge discovered later does
+    not push the dependency deeper, and the chain then only worked because
+    "wayland" happens to sort before "wayland-protocols" inside the tier.
+
+    Layering by actual edges removes the luck: a package is only ready once
+    every needed package it depends on has been placed.
+    """
+    remaining = {name: set(deps) for name, deps in edges.items()}
+    layers: list[list[str]] = []
+    while remaining:
+        ready = sorted(
+            name for name, deps in remaining.items() if not (deps & remaining.keys())
+        )
+        if not ready:
+            # A cycle means the stack cannot be built in one pass from this
+            # donor -- it needs a bootstrap split, which is a human decision.
+            # Saying so beats emitting an order that silently cannot work.
+            raise SystemExit(
+                "build-dependency cycle among: " + ", ".join(sorted(remaining))
+            )
+        layers.append(ready)
+        for name in ready:
+            del remaining[name]
+    return layers
 
 
 def render_build_order(target: str, entry: dict, roots: list[str]) -> str:
@@ -359,9 +404,10 @@ def render_build_order(target: str, entry: dict, roots: list[str]) -> str:
         "# either suite moves, which is the failure this file exists to avoid.",
         f"target: {target}",
         f"target_suite: {entry['target_suite']}",
-        f"donor_suite: {entry['donor_suite']}",
-        "roots:",
+        "donor_suites:",
     ]
+    lines += [f"  - {suite}" for suite in entry["donor_suites"]]
+    lines.append("roots:")
     lines += [f"  - {root}" for root in roots]
     lines.append("tiers:")
     for index, tier in enumerate(entry["tiers"]):
@@ -369,7 +415,7 @@ def render_build_order(target: str, entry: dict, roots: list[str]) -> str:
         lines.append("    packages:")
         for source in tier:
             lines.append(f"      - source: {source}")
-            lines.append(f"        version: \"{versions[source]}\"")
+            lines.append(f'        version: "{versions[source]}"')
     return "\n".join(lines) + "\n"
 
 
@@ -416,9 +462,10 @@ def main() -> None:
             if binary
         }
         blocked = donor_cannot_build(result["needed"], donor, donor_binary)
-        order = tiers(result["needed"])
+        edges = build_edges(result["needed"], donor, binary_to_source(donor), target_binary)
+        order = tiers(edges)
         report["targets"][name] = {
-            "donor_suite": spec["donor_suite"],
+            "donor_suites": spec["donor_suites"],
             "target_suite": spec["target_suite"],
             "donor_sources": len(donor),
             "target_sources": len(target),
@@ -428,13 +475,14 @@ def main() -> None:
             "tiers": order,
             "packages": sorted(result["needed"].values(), key=lambda r: (-r["depth"], r["source"])),
         }
-        print(f"{name}: {spec['target_suite']} <- {spec['donor_suite']}: "
+        donor_label = " + ".join(spec["donor_suites"])
+        print(f"{name}: {spec['target_suite']} <- {donor_label}: "
               f"{len(result['needed'])} source packages need rebuilding, "
               f"{len(order)} tiers", file=sys.stderr)
         if result["missing_roots"]:
             print(f"  roots absent from donor: {result['missing_roots']}", file=sys.stderr)
         if blocked:
-            print(f"  NOT BUILDABLE FROM {spec['donor_suite']} ({len(blocked)}):", file=sys.stderr)
+            print(f"  NOT BUILDABLE FROM {donor_label} ({len(blocked)}):", file=sys.stderr)
             for source, unmet in sorted(blocked.items()):
                 print(f"    {source}: {'; '.join(unmet)}", file=sys.stderr)
 

--- a/tests/test_the_deb_backport_gap_is_measured_not_guessed.py
+++ b/tests/test_the_deb_backport_gap_is_measured_not_guessed.py
@@ -101,7 +101,8 @@ def test_a_failed_version_floor_does_force_a_rebuild():
     result = gap.measure(["app"], donor, target, gap.binary_to_source(donor), target_binary)
     assert set(result["needed"]) == {"app", "tool"}, result["needed"]
     # tool must build BEFORE app, so it sits in an earlier tier.
-    order = gap.tiers(result["needed"])
+    edges = gap.build_edges(result["needed"], donor, gap.binary_to_source(donor), target_binary)
+    order = gap.tiers(edges)
     assert order[0] == ["tool"] and order[-1] == ["app"], order
 
 
@@ -172,3 +173,47 @@ def test_a_satisfied_constraint_is_not_reported():
     }
     donor_binary = {"app": "2.0-1", "libfoo-dev": "1.0-1"}
     assert gap.donor_cannot_build({"app": {}}, donor, donor_binary) == {}
+
+
+def test_tiers_are_topological_not_breadth_first():
+    """A cross-edge must still push a dependency into an earlier tier.
+
+    BFS depth was the first implementation and is only correct on a tree.
+    Measured failure: with -proposed in the donor, `wayland` and
+    `wayland-protocols` both came out at depth 2 and shared a tier, even
+    though wayland-protocols build-depends on libwayland-dev from wayland.
+    Depth is assigned by first reach, so the later cross-edge never pushed
+    wayland deeper, and the chain only worked because "wayland" sorts before
+    "wayland-protocols" within a tier.
+
+    Here `dep` is reachable at distance 1 from root AND at distance 2 via
+    mid, which is exactly the shape that collapsed.
+    """
+    edges = {
+        "root": {"mid", "dep"},
+        "mid": {"dep"},
+        "dep": set(),
+    }
+    order = gap.tiers(edges)
+    assert order == [["dep"], ["mid"], ["root"]], order
+
+
+def test_a_dependency_cycle_is_reported_rather_than_mis_ordered():
+    """An order that silently cannot work is worse than a refusal."""
+    import pytest
+    with pytest.raises(SystemExit) as excinfo:
+        gap.tiers({"a": {"b"}, "b": {"a"}})
+    assert "cycle" in str(excinfo.value)
+    assert "a" in str(excinfo.value) and "b" in str(excinfo.value)
+
+
+def test_the_ubuntu_donor_includes_proposed_and_debian_does_not_need_it():
+    """-proposed is a deliberate trade, recorded so it can be revisited after
+    GNOME 51.0 ships: without it wayland-protocols cannot be rebuilt at all."""
+    import yaml
+    manifest = yaml.safe_load((ROOT / "manifests" / "gnome51-deb.yaml").read_text())
+    assert manifest["targets"]["ubuntu"]["donor_suites"] == ["stonking", "stonking-proposed"]
+    assert any("stonking-proposed" in url
+               for url in manifest["targets"]["ubuntu"]["donor_index"])
+    # Debian stages in experimental and falls back to sid; no -proposed pocket.
+    assert manifest["targets"]["debian"]["donor_suites"] == ["experimental", "sid"]

--- a/tests/test_the_deb_chain_rebuilds_against_the_target.py
+++ b/tests/test_the_deb_chain_rebuilds_against_the_target.py
@@ -140,7 +140,7 @@ def test_the_generated_order_stays_out_of_the_build_order_namespace():
 def test_the_rendered_order_names_sources_and_exact_versions():
     entry = {
         "target_suite": "resolute",
-        "donor_suite": "stonking",
+        "donor_suites": ["stonking", "stonking-proposed"],
         "tiers": [["gtk4"], ["mutter"]],
         "packages": [
             {"source": "gtk4", "donor_version": "4.23.2+ds-1", "depth": 1},
@@ -150,7 +150,7 @@ def test_the_rendered_order_names_sources_and_exact_versions():
     text = gap.render_build_order("ubuntu", entry, ["mutter"])
     parsed = yaml.safe_load(text)
     assert parsed["target_suite"] == "resolute"
-    assert parsed["donor_suite"] == "stonking"
+    assert parsed["donor_suites"] == ["stonking", "stonking-proposed"]
     assert parsed["tiers"][0]["packages"][0] == {"source": "gtk4", "version": "4.23.2+ds-1"}
     # Deepest build-dependency first: gtk4 must build before mutter.
     assert parsed["tiers"][1]["packages"][0]["source"] == "mutter"
@@ -176,3 +176,13 @@ def test_the_mounted_output_path_is_absolute():
     resolve = text.index('out=$(cd "$out" && pwd)')
     mount = text.index('--volume "$out:/work"')
     assert resolve < mount, "the output path must be absolute before it is mounted"
+
+
+def test_every_donor_suite_gets_its_own_deb_src_line():
+    """Ubuntu needs the release pocket AND -proposed: an in-flight transition
+    can leave a source unbuildable from the release pocket alone."""
+    text = chain_text()
+    assert "for donor_suite in $DONOR_SUITES" in text
+    assert "DONOR_SUITES=" in text
+    # Still sources only, per suite.
+    assert 'printf "deb-src %s %s %s\\n"' in text


### PR DESCRIPTION
Two changes — the second found while making the first.

## 1. `-proposed` as a donor pocket

`wayland-protocols 1.49-1` in stonking build-depends `libwayland-dev (>= 1.25.0)`, and `wayland` is `1.24.0-2` in **both** stonking and resolute — `1.26.0-1` sits in stonking-proposed, unmigrated. The chain was blocked on a package nobody can rebuild from stonking alone ([run 32643256826](https://github.com/tuna-os/tunaos-packages/actions/runs/32643256826); #496 now reports it at measure time).

Adding `-proposed` resolves it the way a human backporter would: `wayland` enters the closure at `1.26.0-1` and builds first. The gap goes **16 → 17** packages and the `NOT BUILDABLE` list goes empty.

**It is a trade, and the manifest says so.** `-proposed` is a staging area: packages there can be removed or superseded, so a measured order can name a version that's gone by the time the chain runs, and the closure churns more than one from a released suite. Acceptable *here* because GNOME 51.0 hasn't shipped (2026-09-12, #107) and `-proposed` is exactly where the 51 work lands first. Revisit after release — once 51 is in stonking proper, dropping the two URLs should change versions and nothing else.

`donor_suite` becomes `donor_suites` (a list), so provenance is explicit and the chain emits one `deb-src` line per suite. Still **sources only** — a binary line for any donor pocket would resolve build-deps from the donor and produce packages that install nowhere on the target.

## 2. Tiers are now topological, not breadth-first

Adding `wayland` exposed that the tier model was only *accidentally* correct.

`wayland` and `wayland-protocols` both came out at **depth 2** and so shared a tier — even though wayland-protocols build-depends on libwayland-dev from wayland. BFS depth is assigned by first reach, so a cross-edge discovered later never pushes the dependency deeper. The chain would only have worked because `wayland` happens to sort before `wayland-protocols` inside the tier.

Layering by the actual build-dependency edges removes the luck. The order goes 3 → 4 tiers and is correct by construction:

```
tier-0  wayland, pango1.0, gdm3, gexiv2, gnome-desktop, gnome-initial-setup,
        gnome-session, gsettings-desktop-schemas, ubuntu-insights,
        xdg-desktop-portal-gnome
tier-1  wayland-protocols, gnome-settings-daemon, nautilus
tier-2  gtk4, mutter
tier-3  gnome-control-center, gnome-shell
```

A cycle is now **reported** rather than silently emitted as an order that cannot work — a bootstrap split is a human decision.

Suite: 1069 passed, 1 skipped. `bash -n` and `shellcheck -S warning` clean. Both new behaviours have tests, including the exact cross-edge shape that collapsed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_