### PR TITLE
Correct a libunwind comment that asserts a defect I measured absent

### DIFF
--- a/packages/libunwind-devel/package.yaml
+++ b/packages/libunwind-devel/package.yaml
@@ -1,13 +1,30 @@
 schema: 1
 name: libunwind-devel
 version: "1.8.1"
-# release 2, not 1. The BROKEN build is published as libunwind-devel-1.8.1-1
-# at rpm/el10/aarch64 — the one whose libunwind.so.8 carries four undefined
-# __aarch64_* symbols and no libgcc_s in NEEDED (#469). The LIBS: -lgcc_s fix
-# below changes the bytes but not the version, so republishing at release 1
-# would ship a different artifact under an identical NVR: dnf would see no
-# upgrade, consumers holding the broken one would keep it, and two distinct
-# builds would claim the same name-version-release.
+# release 2, not 1. The LIBS: -lgcc_s fix below changes the bytes but not the
+# version, so republishing at release 1 would ship a different artifact under
+# an identical NVR: dnf would see no upgrade, consumers holding the old one
+# would keep it, and two distinct builds would claim the same
+# name-version-release. That reasoning stands on its own and is why the bump
+# is here.
+#
+# What this comment USED to say, and which is NOT true: that the published
+# libunwind-devel-1.8.1-1 at rpm/el10/aarch64 is the broken build, carrying
+# four undefined __aarch64_* symbols and no libgcc_s in NEEDED (#469).
+#
+# Measured against the served artifact after the 1.8.1-2 wave, by extracting
+# both RPMs and reading the ELF rather than the requires metadata (which does
+# not discriminate — BOTH releases declare libgcc_s.so.1()(64bit), because the
+# auto-dependency fires if ANY binary in the package needs it):
+#
+#   libunwind.so.8.1.0 and libunwind-aarch64.so.8.1.0, in BOTH 1.8.1-1 and
+#   1.8.1-2: libgcc_s.so.1 present in NEEDED, and zero undefined __aarch64_*
+#   symbols.
+#
+# So the served 1.8.1-1 already carries the fix. The likely history is that a
+# publish wave ran after #470 merged while the recipe still said release 1,
+# producing a corrected artifact under the old NVR — exactly the same-NVR
+# ambiguity described above, which is the real argument for the bump.
 release: 2
 summary: Portable stack-unwinding library development files
 description: Headers and shared libraries required to build cpptrace with signal-safe stack unwinding.


### PR DESCRIPTION
The recipe states that the published `libunwind-devel-1.8.1-1` at `rpm/el10/aarch64` is the broken build, *"carrying four undefined `__aarch64_*` symbols and no libgcc_s in NEEDED"* (#469). **That is not true of what is served.**

## Measured

After the `1.8.1-2` wave, by extracting **both** RPMs and reading the ELF. The requires metadata cannot decide this — both releases declare `libgcc_s.so.1()(64bit)`, because the auto-dependency fires if *any* binary in the package needs it. Only the library itself discriminates:

| | `libgcc_s.so.1` in NEEDED | UND `__aarch64_*` |
| --- | --- | --- |
| `libunwind.so.8.1.0` @ **1.8.1-1** | yes | 0 |
| `libunwind.so.8.1.0` @ **1.8.1-2** | yes | 0 |
| `libunwind-aarch64.so.8.1.0` @ **1.8.1-1** | yes | 0 |
| `libunwind-aarch64.so.8.1.0` @ **1.8.1-2** | yes | 0 |

The likely history is that a publish wave ran after #470 merged while the recipe still said `release: 1`, producing a corrected artifact under the old NVR.

## The release bump stays

The comment now gives the argument that actually holds: a same-NVR republish ships different bytes under an identical name-version-release, so dnf sees no upgrade and two distinct builds claim one NVR. That reasoning never depended on `1.8.1-1` being broken — and the history above is *itself* an instance of exactly that ambiguity, which makes it the better justification.

I wrote the original comment on the strength of #469 without re-measuring the served artifact. Correcting it rather than leaving a confident false claim in a recipe someone will read later.

Comment-only; no build behaviour changes. Suite: 1069 passed, 1 skipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_