### PR TITLE
fix(factory): the deb chain summary reads a key the report no longer has (#480)

### DIFF
--- a/.github/workflows/backport-deb-chain.yml
+++ b/.github/workflows/backport-deb-chain.yml
@@ -66,7 +66,8 @@ jobs:
           import json
           report = json.load(open('gap-${{ github.event.inputs.target }}.json'))
           entry = report['targets']['${{ github.event.inputs.target }}']
-          print(f"`{entry['target_suite']}` <- `{entry['donor_suite']}`: "
+          donors = ' + '.join(entry['donor_suites'])
+          print(f"`{entry['target_suite']}` <- `{donors}`: "
                 f"**{entry['needed_count']}** source packages, {len(entry['tiers'])} tiers")
           for index, tier in enumerate(entry['tiers']):
               print(f"- tier-{index}: {', '.join(tier)}")

--- a/tests/test_the_deb_chain_rebuilds_against_the_target.py
+++ b/tests/test_the_deb_chain_rebuilds_against_the_target.py
@@ -186,3 +186,58 @@ def test_every_donor_suite_gets_its_own_deb_src_line():
     assert "DONOR_SUITES=" in text
     # Still sources only, per suite.
     assert 'printf "deb-src %s %s %s\\n"' in text
+
+
+def _report_entry_keys() -> set[str]:
+    """The keys measure-deb-backport-gap.py actually writes per target.
+
+    Read out of the source rather than by running a measurement, because a
+    measurement needs the network. The assignment is
+    `report["targets"][name] = { ... }`, a dict of literal string keys.
+    """
+    import ast
+
+    tree = ast.parse((ROOT / "scripts" / "measure-deb-backport-gap.py").read_text())
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Dict):
+            continue
+        target = node.targets[0]
+        if not isinstance(target, ast.Subscript):
+            continue
+        inner = target.value
+        if not (isinstance(inner, ast.Subscript) and isinstance(inner.value, ast.Name)
+                and inner.value.id == "report"):
+            continue
+        return {
+            key.value for key in node.value.keys
+            if isinstance(key, ast.Constant) and isinstance(key.value, str)
+        }
+    raise AssertionError("could not find the `report['targets'][name] = {...}` assignment")
+
+
+def test_the_workflow_summary_only_reads_keys_the_report_emits():
+    """A field rename in the script must not leave the workflow reading a
+    key that no longer exists.
+
+    This is not hypothetical. `donor_suite` became `donor_suites` when Ubuntu
+    gained a second donor pocket; the script, manifest and tests were all
+    renamed together, and the workflow's inline step-summary snippet was not.
+    Run 32650470179 measured the gap correctly -- the log carries
+    `resolute <- stonking + stonking-proposed: 17 source packages, 4 tiers` --
+    and then died 16 seconds in with `KeyError: 'donor_suite'` while printing
+    that same sentence to the summary.
+
+    The measurement is the expensive part and it had already succeeded. Losing
+    a run to a typo'd key in the cosmetic step after it is the kind of failure
+    a test costs nothing to prevent, so: whatever the workflow reads off an
+    entry must be something the script puts there.
+    """
+    emitted = _report_entry_keys()
+    assert "donor_suites" in emitted, "sanity: the renamed key is the one in use"
+    read = set(re.findall(r"entry\[['\"]([A-Za-z_]+)['\"]\]", WORKFLOW.read_text()))
+    assert read, "the workflow is expected to read fields off the report entry"
+    unknown = read - emitted
+    assert not unknown, (
+        f"the workflow reads report fields the script does not emit: {sorted(unknown)}; "
+        f"emitted keys are {sorted(emitted)}"
+    )


### PR DESCRIPTION
## What happened

Deb chain run [32650470179](https://github.com/tuna-os/tunaos-packages/actions/runs/32650470179) (`target=ubuntu architecture=amd64 tier=tier-0`) failed **16 seconds in**.

The measurement itself succeeded. The log carries exactly what #500 promised:

```
ubuntu: resolute <- stonking + stonking-proposed: 17 source packages need rebuilding, 4 tiers
```

Both of #500's fixes are confirmed working by that one line — the `-proposed` donor pocket resolves, and the topological tiering produced 4 layers. Then the *next statement*, printing that same sentence to the step summary, died:

```
Traceback (most recent call last):
  File "<stdin>", line 4, in <module>
KeyError: 'donor_suite'
```

## Why

`donor_suite` became `donor_suites` in #500, when Ubuntu gained a second donor pocket. The script, the manifest and the tests were renamed together. The workflow's inline step-summary snippet was not — it is a heredoc, so no import, no lint and no test reached it.

## The fix

Join the list for display:

```python
donors = ' + '.join(entry['donor_suites'])
print(f"`{entry['target_suite']}` <- `{donors}`: ...")
```

## Guarding the class

A rename that lands everywhere except one heredoc is a shape that will recur. `test_the_workflow_summary_only_reads_keys_the_report_emits` parses the `report["targets"][name] = {...}` assignment out of `measure-deb-backport-gap.py` with `ast` and asserts every `entry['...']` the workflow reads is a key that assignment actually emits.

Verified it fails on the reintroduced bug:

```
E       assert not {'donor_suite'}
```

It reads the script's source rather than running a measurement, so it needs no network.

The measurement is the expensive half of the run and it had already succeeded. Losing a run to a typo in the cosmetic step *after* it is worth one test.

## Test suite

`1070 passed, 1 skipped`

Next: re-dispatch `backport-deb-chain.yml` at `tier-0` for ubuntu/amd64.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_