### PR TITLE
fix(factory): the six failures behind the red gnome cells and the deb chain (#480)

### DIFF
--- a/.github/workflows/backport-deb-chain.yml
+++ b/.github/workflows/backport-deb-chain.yml
@@ -42,9 +42,20 @@ jobs:
   chain:
     name: ${{ github.event.inputs.target }}-${{ github.event.inputs.architecture }}
     runs-on: ${{ github.event.inputs.architecture == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
-    # The same ceiling every factory cell uses. A GNOME chain is the shape of
-    # workload that has hit it before (#480), so a run that stops here is a
-    # capacity result, not a build failure -- re-dispatch with --tier.
+    # The same ceiling every factory cell uses. Measured rather than feared
+    # here: tier-0's 8 packages built in 6m30s (run 32652552159), so the full
+    # 18-package ubuntu chain has an order of magnitude of headroom. A deb
+    # backport is cheap because there is no packaging to author -- it is the
+    # EL10 rpm chain, which builds ~55 packages from spec, that lives against
+    # this ceiling.
+    #
+    # If one ever does stop here, RE-DISPATCH FROM tier-0 OR WITH NO TIER AT
+    # ALL. `tier` narrows a single run; it cannot resume one. The local apt
+    # repo that carries a tier's output to the next tier lives inside the
+    # runner and is gone when the job ends, so dispatching tier-1 after a
+    # tier-0 run would resolve its build-deps against the target archive
+    # alone -- and that does not fail loudly, it silently builds against the
+    # wrong versions.
     timeout-minutes: 360
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/package-factory-cell.yml
+++ b/.github/workflows/package-factory-cell.yml
@@ -9,6 +9,9 @@ on:
 
 permissions:
   contents: read
+  # The resume step lists and downloads this repository's own workflow
+  # artifacts to recover a timed-out cell's partial output (#480).
+  actions: read
   id-token: write
   attestations: write
 
@@ -76,6 +79,12 @@ jobs:
           echo "key=$(jq -r .action_key <<<"$payload")" >> "$GITHUB_OUTPUT"
           echo "epoch=$epoch" >> "$GITHUB_OUTPUT"
           jq . <<<"$payload"
+          # Written into the cell directory, not just the step output, so it
+          # rides along in the partial-output artifact. That is what lets a
+          # later attempt tell "these RPMs are what I would build" from
+          # "these RPMs came from different inputs" (#480).
+          mkdir -p '.factory/${{ matrix.id }}'
+          jq -r .action_key <<<"$payload" > '.factory/${{ matrix.id }}/action-key.txt'
       # artifacts/ and action-result.json ONLY, not the cell directory (#472).
       # Those two are everything a hit consumes: the result manifest is
       # verified against the expected key below, and
@@ -138,12 +147,38 @@ jobs:
           if [ "$hit" = true ]; then verdict=hit; fi
           echo "::notice title=action-cache::${verdict} ${{ matrix.id }}"
           echo "action-cache ${verdict}: \`${{ matrix.id }}\`" >> "$GITHUB_STEP_SUMMARY"
+      # A build-chain cell can outlive `timeout-minutes: 360` (#480). When it
+      # does the job is CANCELLED, not failed, so neither the action cache
+      # (written only after a successful build) nor the `if: failure()`
+      # artifact upload keeps anything -- and the next dispatch restarts at
+      # tier 0 and stops in the same place. This recovers the RPMs a previous
+      # attempt built, but ONLY if that attempt's recorded action key matches
+      # this cell's, so a partial from different inputs is discarded rather
+      # than merged. build-chain.sh already skips a package whose exact NVR
+      # is in the local repo, so nothing in the builder changes.
+      #
+      # A resumed run still lints, still verifies install/smoke, and still
+      # writes its own ActionResult over whatever it ends up with -- a
+      # partial can shorten a run, never let one skip a gate.
+      #
+      # Only for build-chain: a tideforge cell builds a single package, so
+      # there is no partial progress to resume.
+      - name: Resume from a previous attempt's partial output
+        if: matrix.engine == 'build-chain' && steps.verdict.outputs.hit != 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/restore-partial-chain-output.py \
+            --cell-id '${{ matrix.id }}' \
+            --action-key '${{ steps.identity.outputs.key }}' \
+            --out-dir '.factory/${{ matrix.id }}'
       - name: Install native build tools on an exact miss
         if: matrix.engine == 'build-chain' && steps.verdict.outputs.hit != 'true'
         run: |
           sudo apt-get update -q
           sudo apt-get install -y -q createrepo-c podman rpm
       - name: Build on an exact miss
+        id: build
         if: steps.verdict.outputs.hit != 'true'
         env:
           CELL_ID: ${{ matrix.id }}
@@ -267,4 +302,41 @@ jobs:
           # warn, not error: a cell that died before creating its directory
           # would otherwise fail HERE, replacing the real failure message
           # with an upload error.
+          if-no-files-found: warn
+      # The resume input, and it is a SEPARATE, SMALL upload for two reasons.
+      #
+      # `cancelled()`, because a job that exceeds `timeout-minutes` is
+      # reported as CANCELLED rather than failed. Under `if: failure()`
+      # alone, a six-hour GNOME cell that ran out of clock uploaded NOTHING
+      # and the re-dispatch began again at tier 0 (#480).
+      #
+      # And only artifacts/ + action-key.txt, because a cancelled job gets a
+      # short grace period to finish its remaining steps. The full cell
+      # directory above carries the mock build tree, which dwarfs the output
+      # -- measured at 95.4% of a cell's bytes on
+      # tideforge-cpptrace-devel-debian-amd64 (#472) -- and an upload that
+      # does not finish inside the grace window recovers nothing at all. This
+      # one holds only what a resume reads.
+      #
+      # Named `-partial` rather than `${{ matrix.id }}`, and that is
+      # load-bearing: the resume step queries the artifacts API by exact
+      # name, and must never match the success upload, whose contents are a
+      # validated deliverable rather than an interrupted attempt.
+      #
+      # `always()` gated on the build step's own outcome, rather than
+      # `failure() || cancelled()`. A job that runs out of `timeout-minutes`
+      # is torn down, and `always()` is the only condition GitHub documents
+      # as still running its steps when that happens -- guessing which of
+      # failure()/cancelled() a timeout satisfies is exactly the kind of
+      # assumption that left this uploading nothing for six-hour cells in
+      # the first place. `steps.build.outcome != 'success'` then keeps a
+      # clean run from uploading a redundant copy of output the action cache
+      # already holds.
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always() && matrix.engine == 'build-chain' && steps.build.outcome != 'success'
+        with:
+          name: ${{ matrix.id }}-partial
+          path: |
+            .factory/${{ matrix.id }}/artifacts/
+            .factory/${{ matrix.id }}/action-key.txt
           if-no-files-found: warn

--- a/.github/workflows/package-factory.yml
+++ b/.github/workflows/package-factory.yml
@@ -85,6 +85,17 @@ concurrency:
 
 permissions:
   contents: read
+  # A CALLED workflow cannot request more than its caller grants, so this has
+  # to mirror package-factory-cell.yml. The cell reads this repository's own
+  # workflow artifacts to resume a timed-out build chain (#480); without the
+  # grant here, GitHub rejects the whole file:
+  #
+  #   Error calling workflow '.../package-factory-cell.yml@...'. The workflow
+  #   is requesting 'actions: read', but is only allowed 'actions: none'.
+  #
+  # An invalid workflow file is not a failed run -- nothing plans, and the
+  # merge queue has no required workflow to evaluate.
+  actions: read
   id-token: write
   attestations: write
 

--- a/docs/gnome51-deb-gap.json
+++ b/docs/gnome51-deb-gap.json
@@ -36,7 +36,8 @@
         [
           "mutter"
         ]
-      ]
+      ],
+      "unattributable": {}
     },
     "ubuntu": {
       "donor_cannot_build": {},
@@ -46,8 +47,15 @@
         "stonking-proposed"
       ],
       "missing_roots": [],
-      "needed_count": 17,
+      "needed_count": 18,
       "packages": [
+        {
+          "depth": 2,
+          "donor_version": "14.3ubuntu1",
+          "reason": "target is older",
+          "source": "debhelper",
+          "target_version": "13.31ubuntu1"
+        },
         {
           "depth": 2,
           "donor_version": "1.58.0-1",
@@ -172,31 +180,33 @@
       "target_suite": "resolute",
       "tiers": [
         [
+          "debhelper",
           "gdm3",
-          "gexiv2",
-          "gnome-desktop",
           "gnome-initial-setup",
           "gnome-session",
-          "gsettings-desktop-schemas",
           "pango1.0",
           "ubuntu-insights",
           "wayland",
           "xdg-desktop-portal-gnome"
         ],
         [
+          "gexiv2",
+          "gnome-desktop",
           "gnome-settings-daemon",
-          "nautilus",
+          "gsettings-desktop-schemas",
           "wayland-protocols"
         ],
         [
           "gtk4",
-          "mutter"
+          "mutter",
+          "nautilus"
         ],
         [
           "gnome-control-center",
           "gnome-shell"
         ]
-      ]
+      ],
+      "unattributable": {}
     }
   }
 }

--- a/manifests/gnome51-deb.yaml
+++ b/manifests/gnome51-deb.yaml
@@ -65,8 +65,13 @@ targets:
   # so this measurement is early-access only. Kept because the engine's own
   # rule retires it automatically: once sid carries 51, every root drops out
   # and the answer becomes zero packages without anyone editing this file.
-  # Debian stages GNOME in experimental, which today holds mutter 51~beta but
-  # not yet gnome-shell -- expect roots to be reported absent from the donor.
+  #
+  # It is most of the way there already. Measured 2026-08-23: every root
+  # resolves, nothing is unattributable, and the whole gap is ONE package --
+  # mutter, 51~beta-1 in experimental against 50.4-1 in sid. It was a much
+  # larger and messier answer when this target was added; nobody changed
+  # this file, sid caught up. Ubuntu resolute needs 18 because it is an LTS
+  # and cannot.
   debian:
     target_suite: sid
     donor_suites:

--- a/scripts/build-deb-chain.sh
+++ b/scripts/build-deb-chain.sh
@@ -102,21 +102,27 @@ export SOURCE_DATE_EPOCH
     apt-get install -y --no-install-recommends \
       build-essential devscripts dpkg-dev ca-certificates locales
 
-    # A UTF-8 locale, and this is not housekeeping.
+    # A UTF-8 locale. Correct on its own terms -- a buildroot should have one,
+    # and a minimal Ubuntu image ships almost no locale data -- but READ THE
+    # NEXT PARAGRAPH before treating it as the fix for anything.
     #
-    # The container sets LANG/LC_ALL to C.UTF-8, but a minimal Ubuntu image
-    # carries no locale DATA, so setlocale falls back and glib reports the
-    # charset as non-UTF-8. Test suites that ask the system what language it
-    # is in then abort:
+    # It was added to explain this, in run 32653189343:
     #
     #   4/6 gnome-desktop:languages  FAIL  (exit status 134 or signal 6 SIGABRT)
     #
-    # in run 32653189343, with `is_utf8: FALSE` visible in the PASSING
-    # wall-clock tests of the same suite -- the environment was already wrong
-    # where it happened not to matter. gnome-desktop failing took
-    # gnome-control-center down with it, because libgnome-desktop-4-dev never
-    # reached the local repo, so one absent locale cost two of eighteen
-    # packages.
+    # on the theory that `is_utf8: FALSE`, visible in the same suite, meant the
+    # process had no UTF-8 locale. Run 32659338235 DISPROVED that as a
+    # sufficient cause: locale-gen ran, and both the SIGABRT and `is_utf8:
+    # FALSE` are unchanged. So the cause is still unknown, and the honest
+    # record is that this did not fix gnome-desktop. What it may have fixed is
+    # nothing -- gnome-shell passed in the second run having failed in the
+    # first, but its failure was a compositor integration test complaining
+    # about a session bus, which is not obviously locale-related and is exactly
+    # the shape that flakes.
+    #
+    # gnome-desktop failing takes gnome-control-center with it, because
+    # libgnome-desktop-4-dev never reaches the local repo, so this one package
+    # costs two of eighteen.
     #
     # The Ubuntu builders do not hit this: an sbuild chroot is a full
     # install, not a container image with the locale data stripped out. Same
@@ -130,13 +136,16 @@ export SOURCE_DATE_EPOCH
     # comment cost that lesson twice.
     locale-gen C.UTF-8 en_US.UTF-8
 
-    # Assert it, rather than trust it. An unusable locale does not fail here;
-    # it fails forty minutes later inside a test suite, as a SIGABRT that
-    # names the package rather than the buildroot.
-    charmap=$(LC_ALL=C.UTF-8 locale charmap 2>/dev/null || true)
+    # Assert it against a GENERATED locale, not against C.UTF-8.
+    #
+    # The first version of this check asked `LC_ALL=C.UTF-8 locale charmap`,
+    # which cannot fail: C.UTF-8 is built into glibc and resolves with zero
+    # generated locales. It would have passed on the unmodified image it was
+    # written to catch. en_US.UTF-8 exists only if locale-gen actually ran.
+    charmap=$(LC_ALL=en_US.UTF-8 locale charmap 2>/dev/null || true)
     if [ "$charmap" != "UTF-8" ]; then
-      echo "ERROR: the buildroot has no usable UTF-8 locale." >&2
-      echo "       LC_ALL=C.UTF-8 locale charmap reported: ${charmap:-nothing}" >&2
+      echo "ERROR: locale-gen did not produce a usable UTF-8 locale." >&2
+      echo "       LC_ALL=en_US.UTF-8 locale charmap reported: ${charmap:-nothing}" >&2
       echo "       Failing here rather than later inside a package test suite." >&2
       exit 1
     fi
@@ -206,6 +215,24 @@ export SOURCE_DATE_EPOCH
       if ! dpkg-buildpackage -us -uc -b > "/work/logs/$source.build.log" 2>&1; then
         echo "    FAILED build" >&2
         tail -40 "/work/logs/$source.build.log" >&2 || true
+        # A failing TEST SUITE prints a summary line here and buffers its own
+        # output somewhere else. meson writes it to meson-logs/testlog*.txt and
+        # the build log carries only:
+        #
+        #   4/6 gnome-desktop:languages  FAIL  (exit status 134 or signal 6 SIGABRT)
+        #
+        # which names the test and says nothing about why. Two full chain runs
+        # were spent on that -- 1h47m each -- guessing at a cause the log could
+        # not confirm. The evidence exists inside the build tree, which is not
+        # uploaded, so copy it out and print it. autotools writes the same
+        # thing to test-suite.log.
+        find "/work/build/$source" \
+             \( -name "testlog*.txt" -o -name "test-suite.log" \) \
+             -type f 2>/dev/null | head -4 | while read -r testlog; do
+          echo "    ---- $testlog" >&2
+          tail -100 "$testlog" >&2 || true
+          cp "$testlog" "/work/logs/$source.$(basename "$testlog")" 2>/dev/null || true
+        done
         failed="$failed $source"
         continue
       fi

--- a/scripts/build-deb-chain.sh
+++ b/scripts/build-deb-chain.sh
@@ -124,16 +124,6 @@ export SOURCE_DATE_EPOCH
     #
     # It must come first: dpkg applies the exclusions at unpack time, so a
     # package installed before this runs keeps its files stripped.
-    # Every exclusion file, not one guessed name. The image may ship it as
-    # excludes, docker, or something else entirely, and removing the wrong
-    # filename silently leaves the stripping in place -- which is precisely
-    # what happened in run 32671248141.
-    grep -rl "path-exclude" /etc/dpkg/dpkg.cfg /etc/dpkg/dpkg.cfg.d/ 2>/dev/null \
-      | while read -r exclusion; do
-          echo "==> lifting dpkg exclusions in $exclusion"
-          sed -i "/^path-exclude/d; /^path-include/d" "$exclusion"
-        done
-
     apt-get update -qq
     apt-get install -y --no-install-recommends \
       build-essential devscripts dpkg-dev ca-certificates locales
@@ -197,8 +187,13 @@ export SOURCE_DATE_EPOCH
     # And that translations survived. A locale with no message catalogue is
     # exactly what gnome-desktop discards, so checking only the charmap would
     # pass on the buildroot that produced the Bail out above.
-    if ! find /usr/share/locale /usr/share/locale-langpack -name "*.mo" 2>/dev/null \
-         | head -1 | grep -q . ; then
+    # -print -quit, NOT a pipe into head. See the note above the loop below:
+    # under `set -o pipefail` a pipeline whose head closes early reports the
+    # SIGPIPE, and this assertion spent a run claiming the buildroot had no
+    # catalogues while standing next to them.
+    catalogue=$(find /usr/share/locale /usr/share/locale-langpack \
+                     -name "*.mo" -print -quit 2>/dev/null || true)
+    if [ -z "$catalogue" ]; then
       echo "ERROR: the buildroot has no translation catalogues." >&2
       echo "       A package that enumerates locales will discard every one." >&2
       # Print the evidence rather than leave the next person to guess. Three
@@ -269,7 +264,7 @@ export SOURCE_DATE_EPOCH
         failed="$failed $source"
         continue
       fi
-      tree=$(find . -maxdepth 1 -mindepth 1 -type d | head -1)
+      tree=$(find . -maxdepth 1 -mindepth 1 -type d -print -quit)
       cd "$tree"
       if ! apt-get build-dep -y --no-install-recommends "$PWD" \
             > "/work/logs/$source.builddep.log" 2>&1; then
@@ -292,9 +287,19 @@ export SOURCE_DATE_EPOCH
         # not confirm. The evidence exists inside the build tree, which is not
         # uploaded, so copy it out and print it. autotools writes the same
         # thing to test-suite.log.
+        # THE PIPEFAIL / SIGPIPE TRAP, and this script is run with
+        # `set -euo pipefail`. `find | head -N` makes head close the pipe once
+        # it has N lines; find then dies of SIGPIPE (141), and pipefail
+        # reports the whole pipeline as failed. Under `set -e` that aborts the
+        # chain -- here it would abort exactly when a package has just failed
+        # and the logs matter most. It stays hidden while fewer than N lines
+        # are produced, which is why it survived the run that added it.
+        # Collect first, then take the head of a FILE, which has no upstream
+        # process to kill.
         find "/work/build/$source" \
              \( -name "testlog*.txt" -o -name "test-suite.log" \) \
-             -type f 2>/dev/null | head -4 | while read -r testlog; do
+             -type f > /tmp/testlogs.txt 2>/dev/null || true
+        head -4 /tmp/testlogs.txt | while read -r testlog; do
           echo "    ---- $testlog" >&2
           tail -100 "$testlog" >&2 || true
           cp "$testlog" "/work/logs/$source.$(basename "$testlog")" 2>/dev/null || true

--- a/scripts/build-deb-chain.sh
+++ b/scripts/build-deb-chain.sh
@@ -100,7 +100,46 @@ export SOURCE_DATE_EPOCH
 
     apt-get update -qq
     apt-get install -y --no-install-recommends \
-      build-essential devscripts dpkg-dev ca-certificates
+      build-essential devscripts dpkg-dev ca-certificates locales
+
+    # A UTF-8 locale, and this is not housekeeping.
+    #
+    # The container sets LANG/LC_ALL to C.UTF-8, but a minimal Ubuntu image
+    # carries no locale DATA, so setlocale falls back and glib reports the
+    # charset as non-UTF-8. Test suites that ask the system what language it
+    # is in then abort:
+    #
+    #   4/6 gnome-desktop:languages  FAIL  (exit status 134 or signal 6 SIGABRT)
+    #
+    # in run 32653189343, with `is_utf8: FALSE` visible in the PASSING
+    # wall-clock tests of the same suite -- the environment was already wrong
+    # where it happened not to matter. gnome-desktop failing took
+    # gnome-control-center down with it, because libgnome-desktop-4-dev never
+    # reached the local repo, so one absent locale cost two of eighteen
+    # packages.
+    #
+    # The Ubuntu builders do not hit this: an sbuild chroot is a full
+    # install, not a container image with the locale data stripped out. Same
+    # class as the ca-certificates ordering in run-package-factory-cell.sh --
+    # a buildroot that is not the chroot upstream assumed.
+    #
+    # NO APOSTROPHES BELOW THIS POINT, and none above it either: this whole
+    # body is a single-quoted `bash -lc` string, so one apostrophe ends it
+    # early and bash then reports `unexpected EOF` at the last line of the
+    # script rather than at the comment that broke it. Writing this very
+    # comment cost that lesson twice.
+    locale-gen C.UTF-8 en_US.UTF-8
+
+    # Assert it, rather than trust it. An unusable locale does not fail here;
+    # it fails forty minutes later inside a test suite, as a SIGABRT that
+    # names the package rather than the buildroot.
+    charmap=$(LC_ALL=C.UTF-8 locale charmap 2>/dev/null || true)
+    if [ "$charmap" != "UTF-8" ]; then
+      echo "ERROR: the buildroot has no usable UTF-8 locale." >&2
+      echo "       LC_ALL=C.UTF-8 locale charmap reported: ${charmap:-nothing}" >&2
+      echo "       Failing here rather than later inside a package test suite." >&2
+      exit 1
+    fi
 
     # SOURCES ONLY from the donor. See the header: a `deb` line here would
     # silently build the whole chain against the donor suite and produce

--- a/scripts/build-deb-chain.sh
+++ b/scripts/build-deb-chain.sh
@@ -98,9 +98,40 @@ export SOURCE_DATE_EPOCH
         /etc/apt/sources.list.d/ubuntu.sources
     fi
 
+    # Lift the container image dpkg exclusions BEFORE installing anything.
+    #
+    # Ubuntu container images ship /etc/dpkg/dpkg.cfg.d/excludes, which drops
+    # translation catalogues and manpages to keep the image small. That is
+    # correct for a runtime image and wrong for a buildroot: an sbuild chroot,
+    # which is what the Ubuntu builders use and what this is imitating, is a
+    # full install.
+    #
+    # Measured consequence, run 32665378407, once the chain was made to surface
+    # the meson testlog:
+    #
+    #   # Ignoring `C.UTF-8` as a locale, since it lacks translations
+    #   # Ignoring `en_US.UTF-8` as a locale, since it lacks translations
+    #   not ok /languages/using-null-locale - GnomeDesktop-FATAL-WARNING:
+    #     Could not read list of available locales from libc, guessing possible
+    #     locales from available translations, but list may be incomplete!
+    #   Bail out!
+    #
+    # The locales existed -- locale-gen had run. Every one was discarded for
+    # having no translation files, the list came out empty, and glib turns that
+    # warning into a fatal. Two earlier guesses at this failure were wrong
+    # because the log showed only a summary line; this is what the log said
+    # once it showed anything.
+    #
+    # It must come first: dpkg applies the exclusions at unpack time, so a
+    # package installed before this runs keeps its files stripped.
+    rm -f /etc/dpkg/dpkg.cfg.d/excludes
+
     apt-get update -qq
     apt-get install -y --no-install-recommends \
       build-essential devscripts dpkg-dev ca-certificates locales
+    # Translations for a real language, not just the C locale. gnome-desktop
+    # enumerates locales and keeps only those that have them.
+    apt-get install -y --no-install-recommends language-pack-en || true
 
     # A UTF-8 locale. Correct on its own terms -- a buildroot should have one,
     # and a minimal Ubuntu image ships almost no locale data -- but READ THE
@@ -147,6 +178,16 @@ export SOURCE_DATE_EPOCH
       echo "ERROR: locale-gen did not produce a usable UTF-8 locale." >&2
       echo "       LC_ALL=en_US.UTF-8 locale charmap reported: ${charmap:-nothing}" >&2
       echo "       Failing here rather than later inside a package test suite." >&2
+      exit 1
+    fi
+    # And that translations survived. A locale with no message catalogue is
+    # exactly what gnome-desktop discards, so checking only the charmap would
+    # pass on the buildroot that produced the Bail out above.
+    if ! find /usr/share/locale /usr/share/locale-langpack -name "*.mo" 2>/dev/null \
+         | head -1 | grep -q . ; then
+      echo "ERROR: the buildroot has no translation catalogues." >&2
+      echo "       Something is still excluding /usr/share/locale content;" >&2
+      echo "       a package that enumerates locales will discard every one." >&2
       exit 1
     fi
 

--- a/scripts/build-deb-chain.sh
+++ b/scripts/build-deb-chain.sh
@@ -124,14 +124,28 @@ export SOURCE_DATE_EPOCH
     #
     # It must come first: dpkg applies the exclusions at unpack time, so a
     # package installed before this runs keeps its files stripped.
-    rm -f /etc/dpkg/dpkg.cfg.d/excludes
+    # Every exclusion file, not one guessed name. The image may ship it as
+    # excludes, docker, or something else entirely, and removing the wrong
+    # filename silently leaves the stripping in place -- which is precisely
+    # what happened in run 32671248141.
+    grep -rl "path-exclude" /etc/dpkg/dpkg.cfg /etc/dpkg/dpkg.cfg.d/ 2>/dev/null \
+      | while read -r exclusion; do
+          echo "==> lifting dpkg exclusions in $exclusion"
+          sed -i "/^path-exclude/d; /^path-include/d" "$exclusion"
+        done
 
     apt-get update -qq
     apt-get install -y --no-install-recommends \
       build-essential devscripts dpkg-dev ca-certificates locales
     # Translations for a real language, not just the C locale. gnome-desktop
     # enumerates locales and keeps only those that have them.
+    #
+    # --reinstall matters: dpkg applies path-exclude at UNPACK time, so a
+    # package already on the image kept its files stripped, and a plain
+    # install of something already present is a no-op that changes nothing.
     apt-get install -y --no-install-recommends language-pack-en || true
+    apt-get install -y --reinstall --no-install-recommends \
+      language-pack-en-base || true
 
     # A UTF-8 locale. Correct on its own terms -- a buildroot should have one,
     # and a minimal Ubuntu image ships almost no locale data -- but READ THE
@@ -186,8 +200,19 @@ export SOURCE_DATE_EPOCH
     if ! find /usr/share/locale /usr/share/locale-langpack -name "*.mo" 2>/dev/null \
          | head -1 | grep -q . ; then
       echo "ERROR: the buildroot has no translation catalogues." >&2
-      echo "       Something is still excluding /usr/share/locale content;" >&2
-      echo "       a package that enumerates locales will discard every one." >&2
+      echo "       A package that enumerates locales will discard every one." >&2
+      # Print the evidence rather than leave the next person to guess. Three
+      # guesses at the gnome-desktop:languages failure were wrong before the
+      # chain was made to show what the test actually said; the same rule
+      # applies to the buildroot itself.
+      echo "---- dpkg configuration" >&2
+      cat /etc/dpkg/dpkg.cfg /etc/dpkg/dpkg.cfg.d/* 2>/dev/null >&2 || true
+      echo "---- locale trees" >&2
+      ls -d /usr/share/locale* /usr/lib/locale* 2>/dev/null >&2 || true
+      find /usr/share/locale /usr/share/locale-langpack -maxdepth 2 2>/dev/null \
+        | head -20 >&2 || true
+      echo "---- what the language pack shipped" >&2
+      dpkg -L language-pack-en-base 2>/dev/null | head -20 >&2 || true
       exit 1
     fi
 

--- a/scripts/measure-deb-backport-gap.py
+++ b/scripts/measure-deb-backport-gap.py
@@ -147,6 +147,162 @@ def parse_sources(text: str) -> dict[str, dict[str, str]]:
     return sources
 
 
+# --- the binary side ---------------------------------------------------------
+#
+# A Sources index lists a source's REAL binaries and never its `Provides:`, so
+# every virtual package looks absent from it. That blind spot cost the first
+# real tier-0 run (32651265182): all three failures -- gexiv2, gnome-desktop
+# and gsettings-desktop-schemas -- were one unsatisfied build-dependency,
+#
+#   Depends: debhelper-compat (= 14)   [no choices]
+#
+# and everything else apt listed under them was the usual cascade of "not
+# going to be installed" for packages that were fine. `debhelper-compat` is
+# provided by `debhelper`; resolute carries 13, stonking carries 14. The
+# measurement could not see any of that, so it dropped the clause and reported
+# a closure that could not build.
+#
+# The clause was not merely mis-answered, it was UNANSWERABLE: "present but
+# too old" is decidable from a Sources index, "absent from the map" is not,
+# and the two are indistinguishable there. Binary Packages indexes carry
+# `Provides:`, which makes them decidable -- so the measurement reads them
+# too, and anything still unattributable afterwards is reported rather than
+# silently dropped.
+
+PACKAGES_ARCH = "amd64"
+
+
+def packages_url(sources_url: str, arch: str = PACKAGES_ARCH) -> str:
+    """The binary index beside a declared source index.
+
+    Derived rather than declared. The manifest already names every
+    suite/component pairing once; a second hand-maintained list of the same
+    pairings would double the file and could disagree with the first, and a
+    disagreement here is invisible -- it reads as "that virtual package does
+    not exist" rather than as a broken URL.
+    """
+    return sources_url.replace("/source/Sources.", f"/binary-{arch}/Packages.")
+
+
+def parse_packages(text: str) -> dict[str, dict[str, str]]:
+    """deb822 Packages index -> {binary name: stanza}, highest version wins.
+
+    Parsed a stanza at a time rather than by splitting the whole index: a
+    merged main+universe Packages runs to hundreds of megabytes decompressed,
+    and `text.split(chr(10) * 2)` on that materialises a list of a million
+    strings before a single field is read.
+    """
+    wanted = {"Package", "Version", "Provides", "Source"}
+    packages: dict[str, dict[str, str]] = {}
+
+    def commit(stanza: dict[str, str]) -> None:
+        name = stanza.get("Package")
+        if not name or "Version" not in stanza:
+            return
+        existing = packages.get(name)
+        if existing is None or compare_versions(stanza["Version"], existing["Version"]) > 0:
+            packages[name] = stanza
+
+    stanza: dict[str, str] = {}
+    key = None
+    for line in text.splitlines():
+        if not line.strip():
+            commit(stanza)
+            stanza, key = {}, None
+            continue
+        if line.startswith((" ", "\t")):
+            if key in wanted:
+                stanza[key] = stanza.get(key, "") + " " + line.strip()
+            continue
+        key, _, value = line.partition(":")
+        if key in wanted:
+            stanza[key] = value.strip()
+    commit(stanza)
+    return packages
+
+
+def merge_packages(urls) -> dict[str, dict[str, str]]:
+    """One binary view over several component indexes, highest version wins."""
+    if isinstance(urls, str):
+        urls = [urls]
+    merged: dict[str, dict[str, str]] = {}
+    for url in urls:
+        text = lzma.decompress(fetch(url)).decode("utf8", "replace")
+        for name, stanza in parse_packages(text).items():
+            existing = merged.get(name)
+            if existing is None or compare_versions(stanza["Version"], existing["Version"]) > 0:
+                merged[name] = stanza
+    return merged
+
+
+def parse_provides(field: str) -> list[tuple[str, str | None]]:
+    """`Provides: foo, bar (= 1.2)` -> [("foo", None), ("bar", "1.2")]."""
+    provided: list[tuple[str, str | None]] = []
+    for entry in field.split(","):
+        token = entry.strip()
+        if not token:
+            continue
+        name, _, rest = token.partition("(")
+        name = name.strip().split(":")[0].strip()
+        if not name:
+            continue
+        version = None
+        if rest:
+            constraint = rest.split(")")[0].strip()
+            # Debian policy allows only `=` in a Provides.
+            if constraint.startswith("="):
+                version = constraint[1:].strip()
+        provided.append((name, version))
+    return provided
+
+
+def provides_map(packages: dict[str, dict[str, str]]) -> dict[str, list[str | None]]:
+    """virtual name -> the versions its providers declare (None = unversioned)."""
+    mapping: dict[str, list[str | None]] = {}
+    for stanza in packages.values():
+        for name, version in parse_provides(stanza.get("Provides", "")):
+            mapping.setdefault(name, []).append(version)
+    return mapping
+
+
+def virtual_to_source(packages: dict[str, dict[str, str]]) -> dict[str, str]:
+    """virtual name -> the SOURCE that would have to be rebuilt to supply it.
+
+    `Source:` is omitted when it equals the binary name, which is the deb822
+    convention, and it can carry a version in parentheses.
+    """
+    mapping: dict[str, str] = {}
+    for binary, stanza in packages.items():
+        source = (stanza.get("Source") or binary).split("(")[0].strip()
+        for name, _ in parse_provides(stanza.get("Provides", "")):
+            mapping.setdefault(name, source)
+    return mapping
+
+
+def clause_satisfied(binary: str, op: str, want: str,
+                     versions: dict[str, str],
+                     provides: dict[str, list[str | None]]) -> bool:
+    """Can the suite satisfy this one alternative, really or virtually?
+
+    Debian policy 7.5: an UNVERSIONED `Provides` satisfies only an unversioned
+    dependency. That distinction is the whole answer for `debhelper-compat
+    (= 14)` -- if it were treated as satisfied by any provider, resolute's
+    debhelper 13 would look adequate and the closure would stay wrong in the
+    other direction.
+    """
+    real = versions.get(binary)
+    if real is not None and satisfies(real, op, want):
+        return True
+    for provided in provides.get(binary, ()):
+        if provided is None:
+            if not op:
+                return True
+            continue
+        if satisfies(provided, op, want):
+            return True
+    return False
+
+
 def binary_to_source(sources: dict[str, dict[str, str]]) -> dict[str, str]:
     mapping: dict[str, str] = {}
     for name, stanza in sources.items():
@@ -228,10 +384,19 @@ def merge_indexes(urls) -> dict[str, dict[str, str]]:
 
 
 
-def measure(roots, donor, target, bin2src, target_binary) -> dict:
+def measure(roots, donor, target, bin2src, target_binary,
+            target_provides=None, donor_virtual_source=None) -> dict:
     """Close over Build-Depends, keeping only what the target cannot satisfy."""
+    target_provides = target_provides or {}
+    donor_virtual_source = donor_virtual_source or {}
     needed: dict[str, dict] = {}
     missing_roots: list[str] = []
+    # Clauses no alternative satisfies AND that no donor source can supply.
+    # Silently dropping these is what let run 32651265182 report a closure
+    # that could not build: `debhelper-compat (= 14)` was correctly judged
+    # unsatisfied, then discarded because no Sources index maps it to
+    # anything. Unsatisfied-and-unattributable is a finding, not a no-op.
+    unattributable: dict[str, list[str]] = {}
     queue = collections.deque()
 
     for root in roots:
@@ -265,16 +430,21 @@ def measure(roots, donor, target, bin2src, target_binary) -> dict:
             # An alternative group is satisfied if ANY of its members is, so a
             # rebuild is only forced when every alternative fails.
             if any(
-                satisfies(target_binary.get(binary), op, version)
+                clause_satisfied(binary, op, version, target_binary, target_provides)
                 for binary, op, version in alternatives
             ):
                 continue
-            binary, _, _ = alternatives[0]
-            source = bin2src.get(binary)
-            if source and source != name:
+            binary, op, version = alternatives[0]
+            source = bin2src.get(binary) or donor_virtual_source.get(binary)
+            if source is None:
+                constraint = f"{binary} ({op} {version})" if op else binary
+                unattributable.setdefault(name, []).append(constraint)
+                continue
+            if source != name:
                 queue.append((source, depth + 1))
 
-    return {"needed": needed, "missing_roots": missing_roots}
+    return {"needed": needed, "missing_roots": missing_roots,
+            "unattributable": unattributable}
 
 
 def donor_cannot_build(needed, donor, donor_binary) -> dict[str, list[str]]:
@@ -331,8 +501,18 @@ def donor_cannot_build(needed, donor, donor_binary) -> dict[str, list[str]]:
     return blocked
 
 
-def build_edges(needed, donor, bin2src, target_binary) -> dict[str, set[str]]:
-    """For each needed package, the needed packages it must be built AFTER."""
+def build_edges(needed, donor, bin2src, target_binary,
+                target_provides=None, donor_virtual_source=None) -> dict[str, set[str]]:
+    """For each needed package, the needed packages it must be built AFTER.
+
+    Resolved exactly as measure() resolves it, virtuals included. If the two
+    disagreed, a package could enter the closure through a virtual clause and
+    then be ordered as though that clause did not exist -- which is a chain
+    that builds things in the wrong order rather than one that reports a
+    problem.
+    """
+    target_provides = target_provides or {}
+    donor_virtual_source = donor_virtual_source or {}
     edges: dict[str, set[str]] = {name: set() for name in needed}
     for name in needed:
         stanza = donor.get(name)
@@ -340,12 +520,12 @@ def build_edges(needed, donor, bin2src, target_binary) -> dict[str, set[str]]:
             continue
         for alternatives in build_dep_clauses(stanza):
             if any(
-                satisfies(target_binary.get(binary), op, version)
+                clause_satisfied(binary, op, version, target_binary, target_provides)
                 for binary, op, version in alternatives
             ):
                 continue
             binary, _, _ = alternatives[0]
-            source = bin2src.get(binary)
+            source = bin2src.get(binary) or donor_virtual_source.get(binary)
             if source and source != name and source in needed:
                 edges[name].add(source)
     return edges
@@ -454,7 +634,22 @@ def main() -> None:
             for binary in (b.strip() for b in stanza.get("Binary", "").split(","))
             if binary
         }
-        result = measure(roots, donor, target, binary_to_source(donor), target_binary)
+        # The binary indexes carry `Provides:`, which the Sources ones cannot.
+        # Without them every virtual build-dependency is indistinguishable
+        # from an absent one -- see the note above parse_packages.
+        target_packages = merge_packages(
+            [packages_url(url) for url in spec["target_index"]])
+        donor_packages = merge_packages(
+            [packages_url(url) for url in spec["donor_index"]])
+        # Real binary versions from the Packages index take precedence over
+        # the Sources proxy where the two differ (a binary whose version is
+        # bumped independently of its source, most often via binNMU).
+        target_binary.update(
+            {name: stanza["Version"] for name, stanza in target_packages.items()})
+        target_provides = provides_map(target_packages)
+        donor_virtual_source = virtual_to_source(donor_packages)
+        result = measure(roots, donor, target, binary_to_source(donor), target_binary,
+                         target_provides, donor_virtual_source)
         donor_binary = {
             binary: stanza["Version"]
             for stanza in donor.values()
@@ -462,7 +657,8 @@ def main() -> None:
             if binary
         }
         blocked = donor_cannot_build(result["needed"], donor, donor_binary)
-        edges = build_edges(result["needed"], donor, binary_to_source(donor), target_binary)
+        edges = build_edges(result["needed"], donor, binary_to_source(donor),
+                            target_binary, target_provides, donor_virtual_source)
         order = tiers(edges)
         report["targets"][name] = {
             "donor_suites": spec["donor_suites"],
@@ -471,6 +667,7 @@ def main() -> None:
             "target_sources": len(target),
             "needed_count": len(result["needed"]),
             "missing_roots": result["missing_roots"],
+            "unattributable": result["unattributable"],
             "donor_cannot_build": blocked,
             "tiers": order,
             "packages": sorted(result["needed"].values(), key=lambda r: (-r["depth"], r["source"])),
@@ -481,6 +678,11 @@ def main() -> None:
               f"{len(order)} tiers", file=sys.stderr)
         if result["missing_roots"]:
             print(f"  roots absent from donor: {result['missing_roots']}", file=sys.stderr)
+        if result["unattributable"]:
+            print(f"  UNSATISFIED AND UNATTRIBUTABLE "
+                  f"({len(result['unattributable'])}):", file=sys.stderr)
+            for source, clauses in sorted(result["unattributable"].items()):
+                print(f"    {source}: {'; '.join(clauses)}", file=sys.stderr)
         if blocked:
             print(f"  NOT BUILDABLE FROM {donor_label} ({len(blocked)}):", file=sys.stderr)
             for source, unmet in sorted(blocked.items()):

--- a/scripts/restore-partial-chain-output.py
+++ b/scripts/restore-partial-chain-output.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Resume a build-chain cell from what a previous attempt already built.
+
+## The problem
+
+A build-chain cell has `timeout-minutes: 360`. The GNOME cells build ~55
+packages and have hit that ceiling (#480). When they do, the job is reported
+as CANCELLED, and everything it built -- up to six hours of mock runs -- is
+discarded. The next dispatch starts again at tier 0 and hits the same wall in
+the same place. That is not a slow build; it is a build that cannot finish.
+
+## Why the existing caches do not cover it
+
+Two mechanisms already store a cell's output and neither survives a timeout:
+
+  * The action cache (`Save validated output`) is written only after the
+    build succeeds. A timed-out attempt never reaches it.
+  * The failure artifact upload is `if: failure()`, and a `timeout-minutes`
+    overrun CANCELS the job rather than failing it, so that step is skipped
+    too. Nothing at all is kept.
+
+The action cache is also the wrong tool here even if it were reachable: it is
+capped at 10GB per repository with LRU eviction, and the largest cells ran to
+1.35GB (#472). Adding a second multi-hundred-MB entry per long cell would
+evict the authoritative entries for the ~294 short ones. Workflow artifacts
+are separately stored and not subject to that cap, so partial output goes
+there.
+
+## Why resuming is safe
+
+build-chain.sh already skips a package whose exact NVR is present in the
+local repo (`check_package_exists`). Restoring a previous attempt's RPMs into
+the local repo therefore produces exactly the state that attempt was in -- no
+new code path in the builder, and no new failure mode.
+
+What makes it CORRECT rather than merely convenient is the action key. The
+native key is derived from the manifest, every source path, the image digest
+and the source epoch, so it changes whenever anything that could change a
+built RPM changes. A partial whose recorded key differs from this cell's is
+discarded, not merged. Same key means the RPMs a previous attempt built are
+what this attempt would build.
+
+And a resumed run is validated no differently from a fresh one: it still runs
+the lint, the install/smoke verify, and writes its ActionResult over whatever
+ends up in artifacts/. A partial can shorten a run; it cannot let one skip a
+gate.
+
+## Failure is not fatal
+
+Every failure here -- no prior artifact, an expired one, a bad zip, a key
+mismatch, a rate-limited API -- means "build from scratch", which is the
+behaviour that exists today. This script logs and exits 0 on all of them. A
+resume that does not work must never be the reason a cell fails.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import pathlib
+import shutil
+import sys
+import urllib.error
+import urllib.request
+import zipfile
+
+API = "https://api.github.com"
+KEY_FILE = "action-key.txt"
+
+
+def log(message: str) -> None:
+    print(f"[resume] {message}", flush=True)
+
+
+def api_get(url: str, token: str, raw: bool = False):
+    request = urllib.request.Request(url)
+    request.add_header("Authorization", f"Bearer {token}")
+    request.add_header("Accept", "application/vnd.github+json")
+    request.add_header("X-GitHub-Api-Version", "2022-11-28")
+    with urllib.request.urlopen(request, timeout=120) as response:
+        payload = response.read()
+    return payload if raw else json.loads(payload)
+
+
+def newest_partial(repository: str, name: str, token: str) -> dict | None:
+    """The most recent unexpired artifact with this exact name.
+
+    The artifacts endpoint filters by name across the whole repository and
+    returns newest first, so this is one request rather than a walk over runs.
+    """
+    url = f"{API}/repos/{repository}/actions/artifacts?name={name}&per_page=30"
+    listing = api_get(url, token)
+    for artifact in listing.get("artifacts") or []:
+        if artifact.get("expired"):
+            continue
+        return artifact
+    return None
+
+
+def extract(blob: bytes, destination: pathlib.Path) -> tuple[str | None, int]:
+    """Unpack artifacts/ and the recorded action key, and nothing else.
+
+    The partial upload carries the whole cell directory because that is what a
+    person debugging a failure wants. Only two parts of it are safe to reuse:
+    the finished RPMs, and the key that says which inputs produced them. The
+    build tree is deliberately NOT restored -- a mock buildroot interrupted
+    mid-package is not a resumable state, and dropping it also keeps the
+    restore small.
+    """
+    recovered = 0
+    key = None
+    with zipfile.ZipFile(io.BytesIO(blob)) as archive:
+        for entry in archive.infolist():
+            if entry.is_dir():
+                continue
+            name = entry.filename
+            if name == KEY_FILE:
+                key = archive.read(entry).decode("utf-8", "replace").strip()
+                continue
+            if not name.startswith("artifacts/"):
+                continue
+            # Refuse to write outside the destination. The zip comes from this
+            # repository's own runs, but a path check costs one line and the
+            # alternative is an arbitrary-write primitive.
+            target = (destination / name).resolve()
+            if not str(target).startswith(str(destination.resolve()) + os.sep):
+                log(f"skipping entry outside the cell directory: {name}")
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with archive.open(entry) as source, open(target, "wb") as sink:
+                shutil.copyfileobj(source, sink)
+            recovered += 1
+    return key, recovered
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cell-id", required=True)
+    parser.add_argument("--action-key", required=True)
+    parser.add_argument("--out-dir", required=True,
+                        help="the cell directory, e.g. .factory/<id>")
+    parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    args = parser.parse_args()
+
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if not token or not args.repository:
+        log("no token or repository in the environment; building from scratch")
+        return 0
+
+    name = f"{args.cell_id}-partial"
+    try:
+        artifact = newest_partial(args.repository, name, token)
+    except (urllib.error.URLError, ValueError, OSError) as error:
+        log(f"could not list artifacts ({error}); building from scratch")
+        return 0
+    if artifact is None:
+        log(f"no unexpired `{name}` artifact; building from scratch")
+        return 0
+
+    log(f"found `{name}` from {artifact.get('created_at')} "
+        f"({artifact.get('size_in_bytes', 0) / 1e6:.0f} MB)")
+    try:
+        blob = api_get(artifact["archive_download_url"], token, raw=True)
+    except (urllib.error.URLError, OSError) as error:
+        log(f"could not download it ({error}); building from scratch")
+        return 0
+
+    # Extract somewhere disposable first. A key mismatch must leave the cell
+    # directory exactly as it was, not half-populated with another key's RPMs.
+    out = pathlib.Path(args.out_dir)
+    staging = out.parent / f".{out.name}-partial-staging"
+    shutil.rmtree(staging, ignore_errors=True)
+    staging.mkdir(parents=True, exist_ok=True)
+    try:
+        key, recovered = extract(blob, staging)
+    except (zipfile.BadZipFile, OSError) as error:
+        log(f"could not unpack it ({error}); building from scratch")
+        shutil.rmtree(staging, ignore_errors=True)
+        return 0
+
+    if key != args.action_key:
+        log(f"action key differs (partial {key or 'absent'}, this cell "
+            f"{args.action_key}); the inputs changed, so building from scratch")
+        shutil.rmtree(staging, ignore_errors=True)
+        return 0
+
+    source = staging / "artifacts"
+    if not source.is_dir():
+        log("the partial carries no artifacts/; building from scratch")
+        shutil.rmtree(staging, ignore_errors=True)
+        return 0
+
+    destination = out / "artifacts"
+    destination.mkdir(parents=True, exist_ok=True)
+    packages = 0
+    # Files only, and that is what drops the previous attempt's repodata/:
+    # build-chain.sh keeps a FLAT local repo (`cp "$rpm" "${LOCAL_REPO}/"`),
+    # so every package is a file at the top level and the only subdirectory
+    # is the index. Leaving it behind is correct -- createrepo_c regenerates
+    # it before the first mock run, and a stale index naming packages that
+    # did not come across would be worse than none.
+    for path in sorted(source.iterdir()):
+        if not path.is_file():
+            continue
+        shutil.move(str(path), str(destination / path.name))
+        packages += 1
+    shutil.rmtree(staging, ignore_errors=True)
+
+    log(f"resumed with {packages} packages from the previous attempt "
+        f"({recovered} entries in the partial)")
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a", encoding="utf-8") as handle:
+            handle.write(f"resumed `{args.cell_id}` with **{packages}** "
+                         f"packages from a previous attempt\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify-package-factory-cell.sh
+++ b/scripts/verify-package-factory-cell.sh
@@ -133,7 +133,41 @@ if [[ ${ENGINE:?} == build-chain ]]; then
       ${published_args[@]+"${published_args[@]}"} \
       "${names[@]}"
     rpm -q "${names[@]}"
-    rpm -V "${names[@]}"
+    # rpm -V, minus two classes of difference a THROWAWAY CONTAINER reports by
+    # construction rather than because a package is wrong. Both took all four
+    # gnome cells red in run 32646102181 AFTER a clean build, a clean lint and
+    # a clean install:
+    #
+    #   .....UG..    /var/lib/avahi-autoipd
+    #   .M.......  g /var/lib/selinux/minimum/active/policy.linked
+    #
+    # GHOST FILES (the `g` in the second column). A %%ghost path is one rpm
+    # knows the name of but ships no content for -- it is created at runtime
+    # by a scriptlet, and the attributes in the header are placeholders.
+    # selinux-policy declares its .linked files that way and semodule builds
+    # them. Comparing a placeholder against what a scriptlet produced is not
+    # a measurement of anything.
+    #
+    # OWNERSHIP. A service account like avahi-autoipd is created by sysusers
+    # at install time; a container without systemd running does not get one,
+    # so rpm falls back to root and then reports U and G as differing. That
+    # is a fact about the verification environment.
+    #
+    # What is deliberately still checked: digest, size, mode, link target,
+    # capabilities. Those catch a corrupt or mis-packaged payload, which is
+    # what this step is for. Note also what rpm -V CANNOT tell us here -- it
+    # compares the installed tree against the header rpm itself just wrote,
+    # so a wrong owner or mode in the spec would agree with itself and pass.
+    # Ownership policy is verified where it takes effect, in the image build,
+    # not in a container that discards itself a second later.
+    rpm -V --nouser --nogroup "${names[@]}" > /tmp/rpm-verify.out 2>&1 || true
+    grep -vE "^[.?SM5DLUGTPa]{8,9} +g " /tmp/rpm-verify.out > /tmp/rpm-verify.real || true
+    if [ -s /tmp/rpm-verify.real ]; then
+      echo "==> rpm -V reported differences outside the excluded classes:" >&2
+      cat /tmp/rpm-verify.real >&2
+      exit 1
+    fi
+    echo "==> rpm -V clean across ${#names[@]} package name(s)"
   '
   exit 0
 fi

--- a/src/deps/flatpak/flatpak.spec
+++ b/src/deps/flatpak/flatpak.spec
@@ -292,11 +292,11 @@ fi
 %changelog
 * Mon Mar 30 2026 James Reilly <jreilly1821@gmail.com> - 1.16.0-7.2.tuna
 - Disable gtkdoc (-Dgtkdoc=disabled); gtk-doc not available on EL10
-- Remove gtk-doc %files devel entry (no docs built)
+- Remove gtk-doc %%files devel entry (no docs built)
 - Remove Fedora-only Source1 (flatpak-add-fedora-repos.service)
 
 * Mon Mar 30 2026 James Reilly <jreilly1821@gmail.com> - 1.16.0-7.1.tuna
-- EL10 override: add gcc/gcc-c++ BRs; gate gtk-doc %files behind %%if fedora
+- EL10 override: add gcc/gcc-c++ BRs; gate gtk-doc %%files behind %%if fedora
 
 * Mon Oct 13 2025 Jan Grulich <jgrulich@redhat.com> - 1.16.0-7
 - Get certificates from /etc/pki/entitlement for registry.redhat.io

--- a/src/deps/gnome50-el10-compat/gnome50-el10-compat.spec
+++ b/src/deps/gnome50-el10-compat/gnome50-el10-compat.spec
@@ -175,13 +175,13 @@ fi
   Fixes gnome-initial-setup failure on preserved /var/home (#17).
 
 * Thu Apr 02 2026 James Reilly <jreilly1821@gmail.com> - 1.2.7-2
-- %post: drop ineffective restorecon -RF /var/home (see #22). The
-  compose-time %post cannot fix preserved-/var scenarios on deployed
+- %%post: drop ineffective restorecon -RF /var/home (see #22). The
+  compose-time %%post cannot fix preserved-/var scenarios on deployed
   systems; the actual fix for useradd exit 12 belongs at the runtime
   or shadow-utils level (#17).
 
 * Thu Apr 02 2026 James Reilly <jreilly1821@gmail.com> - 1.2.7-1
-- %post: add restorecon -RF /var/home to fix default_t/unlabeled_t labeling
+- %%post: add restorecon -RF /var/home to fix default_t/unlabeled_t labeling
   in reinstall/upgrade scenarios where /var is not wiped. Fixes useradd
   exit 12 (E_HOMEDIR) during gnome-initial-setup (issues #16, #17).
 
@@ -196,7 +196,7 @@ fi
 * Sat Mar 28 2026 James Reilly <jreilly1821@gmail.com> - 1.2.5-1
 - Add PyGObject GLib→GLibUnix compat shim: GLib 2.87+ moved g_unix_signal_add
   to the GLibUnix-2.0 GI namespace; EL10's python3-gobject 3.46 does not know
-  this mapping. Patch gi/overrides/GLib.py via %post and %filetriggerin so
+  this mapping. Patch gi/overrides/GLib.py via %%post and %filetriggerin so
   GLib.unix_signal_add works again, fixing firewalld startup crash and any
   other Python GI consumer using GLib.unix_signal_add or unix_signal_add_full.
 
@@ -212,11 +212,11 @@ fi
 * Mon Mar 23 2026 James <james@example.com> - 1.2.2-1
 - Add %filetriggerin on orca-autostart.desktop to reliably write Hidden=true
   regardless of package install order. Fixes race in image builds where orca
-  installs in a later transaction after our %post already ran.
+  installs in a later transaction after our %%post already ran.
 
 * Sun Mar 23 2026 James <james@example.com> - 1.2.1-1
 - Fix orca-autostart.desktop file conflict with orca package: write the
-  Hidden=true override via %post scriptlet instead of shipping the file,
+  Hidden=true override via %%post scriptlet instead of shipping the file,
   since orca owns /etc/xdg/autostart/orca-autostart.desktop.
 
 * Sun Mar 22 2026 James <james@example.com> - 1.2.0-1

--- a/src/gnome-49/gnome49-el10-compat/gnome49-el10-compat.spec
+++ b/src/gnome-49/gnome49-el10-compat/gnome49-el10-compat.spec
@@ -122,8 +122,8 @@ fi
   as fatal (exit 12, E_HOMEDIR); the wrapper strips -m/--create-home
   when the target directory already exists and chowns it instead.
   Fixes gnome-initial-setup failure on preserved /var/home (#17).
-- %post: drop ineffective restorecon -RF /var/home (see #22). The
-  compose-time %post cannot fix preserved-/var scenarios on deployed
+- %%post: drop ineffective restorecon -RF /var/home (see #22). The
+  compose-time %%post cannot fix preserved-/var scenarios on deployed
   systems.
 
 * Tue Mar 25 2026 James <james@example.com> - 1.2.4-1
@@ -138,11 +138,11 @@ fi
 * Mon Mar 23 2026 James <james@example.com> - 1.2.2-1
 - Add %filetriggerin on orca-autostart.desktop to reliably write Hidden=true
   regardless of package install order. Fixes race in image builds where orca
-  installs in a later transaction after our %post already ran.
+  installs in a later transaction after our %%post already ran.
 
 * Sun Mar 23 2026 James <james@example.com> - 1.2.1-1
 - Fix orca-autostart.desktop file conflict with orca package: write the
-  Hidden=true override via %post scriptlet instead of shipping the file,
+  Hidden=true override via %%post scriptlet instead of shipping the file,
   since orca-48.9 owns /etc/xdg/autostart/orca-autostart.desktop.
 
 * Sun Mar 23 2026 James <james@example.com> - 1.2.0-1

--- a/src/gnome-50/gjs/gjs.spec
+++ b/src/gnome-50/gjs/gjs.spec
@@ -146,7 +146,7 @@ DESTDIR=%{buildroot} ninja -C _build install
 - Adopt %meson build macros
 - Remove no-op %ldconfig_scriptlets
 - Remove dbus-daemon BR (pulled in transitively)
-- Fix %files tests subpackage to be populated unconditionally
+- Fix %%files tests subpackage to be populated unconditionally
 - EL10: keep %%bcond_with tests guard; xwfb-run/mutter tests not usable in COPR
 
 * Thu Mar 12 2026 Conductor <james@conductor.local> - 1.87.90-1

--- a/src/gnome-50/mutter/mutter.spec
+++ b/src/gnome-50/mutter/mutter.spec
@@ -225,5 +225,5 @@ DESTDIR=%{buildroot} meson install -C build
 - Add missing atk and libdecor BuildRequires
 - Enable libcanberra BuildRequires (now GTK3-free)
 * Sat Mar 14 2026 James Reilly <jreilly1821@gmail.com> - 50~rc-2
-- Fix: move meson setup/compile from %prep to %build
+- Fix: move meson setup/compile from %%prep to %%build
 - EL10: gate libcanberra BuildRequires behind %if !0%?rhel (pulls in gtk3)

--- a/src/gnome-51/gjs/gjs.spec
+++ b/src/gnome-51/gjs/gjs.spec
@@ -146,7 +146,7 @@ DESTDIR=%{buildroot} ninja -C _build install
 - Adopt %meson build macros
 - Remove no-op %ldconfig_scriptlets
 - Remove dbus-daemon BR (pulled in transitively)
-- Fix %files tests subpackage to be populated unconditionally
+- Fix %%files tests subpackage to be populated unconditionally
 - EL10: keep %%bcond_with tests guard; xwfb-run/mutter tests not usable in COPR
 
 * Thu Mar 12 2026 Conductor <james@conductor.local> - 1.87.90-1

--- a/src/gnome-51/mutter/mutter.spec
+++ b/src/gnome-51/mutter/mutter.spec
@@ -225,5 +225,5 @@ DESTDIR=%{buildroot} meson install -C build
 - Add missing atk and libdecor BuildRequires
 - Enable libcanberra BuildRequires (now GTK3-free)
 * Sat Mar 14 2026 James Reilly <jreilly1821@gmail.com> - 50~rc-2
-- Fix: move meson setup/compile from %prep to %build
+- Fix: move meson setup/compile from %%prep to %%build
 - EL10: gate libcanberra BuildRequires behind %if !0%?rhel (pulls in gtk3)

--- a/src/input-remapper/input-remapper.spec
+++ b/src/input-remapper/input-remapper.spec
@@ -111,7 +111,7 @@ python3 -m install --root %{buildroot}
 %changelog
 * Fri Aug 21 2026 TunaOS Bot <bot@tunaos.org> - 2.2.1-2
 - Add python3-pip and python3-gobject BuildRequires: upstream's bundled
-  installer shells out to pip and imports gi, so %install failed in mock
+  installer shells out to pip and imports gi, so %%install failed in mock
 
 * Tue Aug 12 2025 TunaOS Bot <bot@tunaos.org> - 2.2.1-1
 - Initial package: input-remapper for EL10 (#122, #126)

--- a/tests/test_a_caller_grants_what_the_called_workflow_asks_for.py
+++ b/tests/test_a_caller_grants_what_the_called_workflow_asks_for.py
@@ -1,0 +1,103 @@
+"""A reusable workflow cannot request more permission than its caller grants.
+
+GitHub rejects the CALLER's whole file when it does, and the message names
+the callee:
+
+    Invalid workflow file: .github/workflows/package-factory.yml#L144
+    Error calling workflow '.../package-factory-cell.yml@966d9aa'. The
+    workflow is requesting 'actions: read', but is only allowed 'actions: none'
+
+This is not a failed run. It is a file that never parses, so nothing plans,
+no job appears, and a merge queue has no required workflow to evaluate. It
+cost hours of a session on a PR that read `blocked` with every visible check
+green and no explanation anywhere in the UI -- and the diagnosis offered
+twice was that the merge queue needed a human, which was wrong.
+
+The cause was adding `actions: read` to package-factory-cell.yml so a
+timed-out build chain could read its own previous artifacts (#480), without
+adding it to package-factory.yml, which calls it.
+
+Nothing else catches this. actionlint does not resolve local `uses:` targets,
+yaml lint sees two valid documents, and every other test in this suite reads
+one file at a time. The invariant is a RELATION between two files, so it
+needs a test that holds both.
+"""
+from __future__ import annotations
+
+import pathlib
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+# GitHub's own ordering: a caller granting `read` cannot satisfy `write`.
+RANK = {"none": 0, "read": 1, "write": 2}
+
+
+def permissions(document) -> dict:
+    declared = (document or {}).get("permissions")
+    # `permissions: write-all` / `read-all` are shorthands; neither appears
+    # here, and treating an unrecognised shorthand as empty would make this
+    # test claim a violation rather than miss one.
+    return declared if isinstance(declared, dict) else {}
+
+
+def local_calls() -> list[tuple[pathlib.Path, str, pathlib.Path]]:
+    """Every (caller, job, callee) where a workflow calls one in this repo."""
+    calls = []
+    for caller in sorted(WORKFLOWS.glob("*.yml")):
+        document = yaml.safe_load(caller.read_text(encoding="utf-8")) or {}
+        for job_name, job in (document.get("jobs") or {}).items():
+            uses = str((job or {}).get("uses") or "")
+            if not uses.startswith("./.github/workflows/"):
+                continue
+            # removeprefix, NOT lstrip("./"): lstrip strips every leading
+            # character in the set, so "./.github/..." loses the dot of
+            # ".github" and becomes "github/...", which does not exist. The
+            # first version of this scan did exactly that and silently found
+            # nothing -- reporting no violations because it checked nothing.
+            callee = ROOT / uses.removeprefix("./")
+            if callee.exists():
+                calls.append((caller, job_name, callee))
+    return calls
+
+
+def test_there_is_at_least_one_local_reusable_call_to_check():
+    """Guards the test itself: if the discovery breaks, it must not pass by
+    finding nothing."""
+    assert local_calls(), "no local `uses:` calls found — the scan is broken"
+
+
+def test_every_caller_grants_what_its_called_workflow_requests():
+    violations = []
+    for caller, job_name, callee in local_calls():
+        caller_doc = yaml.safe_load(caller.read_text(encoding="utf-8")) or {}
+        callee_doc = yaml.safe_load(callee.read_text(encoding="utf-8")) or {}
+        # A job-level block REPLACES the workflow-level one for that job, so
+        # the effective grant is the job's when it declares any.
+        job = (caller_doc.get("jobs") or {}).get(job_name) or {}
+        granted = permissions(job) or permissions(caller_doc)
+        for scope, requested in permissions(callee_doc).items():
+            have = granted.get(scope, "none")
+            if RANK.get(requested, 0) > RANK.get(have, 0):
+                violations.append(
+                    f"{caller.name} job `{job_name}` calls {callee.name}, which "
+                    f"requests {scope}: {requested} — caller grants {scope}: {have}"
+                )
+    assert not violations, (
+        "GitHub rejects the CALLER's entire file for this, so nothing runs at "
+        "all and the failure appears nowhere useful:\n" + "\n".join(violations)
+    )
+
+
+def test_the_factory_caller_grants_actions_read():
+    """Named explicitly, because the sweep above would also pass if someone
+    removed the resume step instead of granting the permission — and the
+    resume is what stops a six-hour cell losing six hours of work."""
+    caller = yaml.safe_load(
+        (WORKFLOWS / "package-factory.yml").read_text(encoding="utf-8"))
+    callee = yaml.safe_load(
+        (WORKFLOWS / "package-factory-cell.yml").read_text(encoding="utf-8"))
+    assert permissions(callee).get("actions") == "read"
+    assert permissions(caller).get("actions") == "read"

--- a/tests/test_a_timed_out_chain_cell_can_resume.py
+++ b/tests/test_a_timed_out_chain_cell_can_resume.py
@@ -1,0 +1,316 @@
+"""A six-hour cell that runs out of clock must not lose six hours of work.
+
+`timeout-minutes: 360` is a real ceiling for the GNOME cells, which build ~55
+packages (#480). Before this, hitting it cost everything:
+
+  * The action cache is written by `Save validated output`, which runs only
+    after a successful build. A timed-out attempt never reaches it.
+  * The debugging artifact upload was `if: failure()`, and a job torn down
+    for exceeding `timeout-minutes` is CANCELLED, not failed -- so that step
+    was skipped too.
+
+Nothing at all survived, and the re-dispatch restarted at tier 0 and stopped
+in the same place. A build that cannot finish is not a slow build.
+
+The recovery has three parts and each fails silently if it is wrong, which is
+why all three are pinned here:
+
+1. The partial must actually be uploaded when the clock runs out.
+2. It must be SMALL. A cancelled job gets a short grace period; an upload of
+   the full cell directory (95.4% build tree on the cell #472 measured) does
+   not finish inside it, and an upload that does not finish recovers nothing.
+3. It must only be reused when the inputs match. The action key is what makes
+   a resumed build equal to a fresh one rather than a mixture of two.
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import subprocess
+import sys
+import zipfile
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+CELL = ROOT / ".github" / "workflows" / "package-factory-cell.yml"
+SCRIPT = ROOT / "scripts" / "restore-partial-chain-output.py"
+
+
+def steps() -> list[dict]:
+    return yaml.safe_load(CELL.read_text())["jobs"]["build"]["steps"]
+
+
+def step_named(fragment: str) -> dict:
+    for step in steps():
+        if fragment in (step.get("name") or "") or fragment in (step.get("uses") or ""):
+            return step
+    raise AssertionError(f"no step matching {fragment!r}")
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("restore_partial", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def partial_upload() -> dict:
+    for step in steps():
+        with_ = step.get("with") or {}
+        if "-partial" in str(with_.get("name", "")):
+            return step
+    raise AssertionError("no step uploads a `-partial` artifact")
+
+
+def test_the_partial_is_uploaded_when_the_clock_runs_out():
+    """`always()`, not `failure()`.
+
+    `failure()` was the bug: a job torn down for exceeding `timeout-minutes`
+    is reported as cancelled, so the upload never ran. `always()` is the one
+    condition GitHub documents as still running when a job is torn down.
+    """
+    condition = partial_upload()["if"]
+    assert "always()" in condition, (
+        "the partial upload must be always(); a timed-out job is not a failure() "
+        "and that is the case this exists for"
+    )
+    # And not on a clean run, where the action cache already holds the output.
+    assert "steps.build.outcome != 'success'" in condition
+
+
+def test_the_partial_carries_only_what_a_resume_reads():
+    """A cancelled job has a short grace period to finish its steps.
+
+    The debugging upload takes the whole cell directory, and the build tree
+    dwarfs the output -- 95.4% of the bytes on the cell measured in #472. An
+    upload that does not finish inside the grace window recovers nothing, so
+    the partial must be the packages and the key and nothing else.
+    """
+    paths = [line.strip() for line in partial_upload()["with"]["path"].splitlines()
+             if line.strip()]
+    assert any(path.endswith("artifacts/") for path in paths)
+    assert any(path.endswith("action-key.txt") for path in paths)
+    for path in paths:
+        assert not path.rstrip("/").endswith("${{ matrix.id }}"), (
+            "the partial must not be the whole cell directory: it has to upload "
+            f"inside a cancellation grace window ({path})"
+        )
+
+
+def test_the_partial_cannot_be_confused_with_the_success_artifact():
+    """The resume queries the artifacts API by exact name.
+
+    If the partial shared `${{ matrix.id }}` with the success upload, that
+    query could return a validated deliverable and a half-finished attempt
+    interchangeably.
+    """
+    names = {(step.get("with") or {}).get("name") for step in steps()}
+    assert "${{ matrix.id }}-partial" in names
+    assert "${{ matrix.id }}" in names
+    module = load_module()
+    assert module.newest_partial.__doc__, "the lookup is by exact name; say so"
+
+
+def test_the_action_key_is_written_where_the_partial_can_carry_it():
+    """The key lives in the cell directory, not only in the step output.
+
+    A step output does not survive the job. Matching a partial to its inputs
+    needs the key to be a file inside what gets uploaded.
+    """
+    identity = step_named("Resolve immutable inputs and action key")
+    assert "action-key.txt" in identity["run"]
+
+
+def test_a_partial_from_different_inputs_is_discarded_not_merged(tmp_path):
+    """This is the property that makes a resumed build equal to a fresh one.
+
+    RPMs from a different action key came from a different manifest, spec,
+    image or epoch. Merging them into the local repo would make build-chain's
+    NVR skip fire for packages this cell would have built differently -- and
+    the result would pass every downstream gate, because each individual RPM
+    is well-formed. It would just not be the thing the inputs describe.
+    """
+    module = load_module()
+    blob = tmp_path / "partial.zip"
+    with zipfile.ZipFile(blob, "w") as archive:
+        archive.writestr("action-key.txt", "aaaa1111\n")
+        archive.writestr("artifacts/glib2-2.87.3-1.el10.x86_64.rpm", "not really an rpm")
+
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    key, recovered = module.extract(blob.read_bytes(), staging)
+    assert key == "aaaa1111"
+    assert recovered == 1
+    # The caller compares before moving anything into the cell directory.
+    source = SCRIPT.read_text()
+    mismatch = source.index("action key differs")
+    move = source.index("shutil.move")
+    assert mismatch < move, (
+        "the key comparison must happen before any file is moved into the cell "
+        "directory, or a mismatch leaves it half-populated"
+    )
+
+
+def test_the_build_tree_is_never_restored(tmp_path):
+    """Only artifacts/ comes back.
+
+    A mock buildroot interrupted mid-package is not a resumable state, and
+    build-chain.sh has no notion of continuing one. Restoring it would carry
+    a half-written chroot into a fresh run for no benefit.
+    """
+    module = load_module()
+    blob = tmp_path / "partial.zip"
+    with zipfile.ZipFile(blob, "w") as archive:
+        archive.writestr("action-key.txt", "k")
+        archive.writestr("artifacts/pango-1.0-1.el10.x86_64.rpm", "rpm")
+        archive.writestr("rpm/rpmbuild/BUILD/half-written-tree/config.log", "junk")
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    module.extract(blob.read_bytes(), staging)
+    assert (staging / "artifacts").is_dir()
+    assert not (staging / "rpm").exists()
+
+
+def test_a_traversal_entry_cannot_write_outside_the_cell(tmp_path):
+    """A path check costs one line; the alternative is an arbitrary write."""
+    module = load_module()
+    blob = tmp_path / "partial.zip"
+    with zipfile.ZipFile(blob, "w") as archive:
+        archive.writestr("artifacts/../../escaped.rpm", "no")
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    module.extract(blob.read_bytes(), staging)
+    assert not (tmp_path.parent / "escaped.rpm").exists()
+    assert not (tmp_path / "escaped.rpm").exists()
+
+
+def test_a_resume_that_cannot_work_is_never_a_build_failure():
+    """No prior artifact, an expired one, a bad zip, a rate-limited API.
+
+    Every one of those means "build from scratch", which is exactly today's
+    behaviour. A recovery mechanism that can turn a working build red is
+    worse than no recovery mechanism.
+    """
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT), "--cell-id", "gnome51-el10-x86_64",
+         "--action-key", "deadbeef", "--out-dir", "/nonexistent/cell"],
+        capture_output=True, text=True,
+        env={"PATH": "/usr/bin:/bin"},  # no GITHUB_TOKEN, no GITHUB_REPOSITORY
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert "building from scratch" in completed.stdout
+
+
+def test_the_resume_only_runs_for_the_engine_that_has_progress_to_resume():
+    """A tideforge cell builds one package. There is no partial state."""
+    resume = step_named("Resume from a previous attempt")
+    assert "matrix.engine == 'build-chain'" in resume["if"]
+    assert "steps.verdict.outputs.hit != 'true'" in resume["if"]
+    assert "matrix.engine == 'build-chain'" in partial_upload()["if"]
+
+
+def test_the_resume_runs_before_the_build():
+    names = [step.get("name") or step.get("uses") or "" for step in steps()]
+    resume = next(i for i, n in enumerate(names) if "Resume from a previous" in n)
+    build = next(i for i, n in enumerate(names) if n == "Build on an exact miss")
+    assert resume < build
+
+
+def test_the_job_may_read_its_own_workflow_artifacts():
+    """`actions: read`. Without it the API listing 404s and every resume
+    silently degrades to a full rebuild -- the exact failure this fixes,
+    reintroduced as a permissions omission."""
+    permissions = yaml.safe_load(CELL.read_text())["permissions"]
+    assert permissions.get("actions") == "read"
+
+
+def _fake_api(module, listing, blob):
+    """Stand in for the artifacts API so the happy path is exercised, not read."""
+    def api_get(url, token, raw=False):
+        if raw:
+            return blob
+        return listing
+    module.api_get = api_get
+
+
+def test_a_matching_partial_lands_in_the_local_repo(tmp_path, monkeypatch):
+    """The whole point, end to end.
+
+    build-chain.sh is given `--local-repo <cell>/artifacts` and skips any
+    package whose exact NVR is already a file there. Landing the previous
+    attempt's RPMs in that directory is therefore the entire resume: no new
+    code path in the builder, and the state it wakes up in is the state the
+    previous attempt was in.
+    """
+    module = load_module()
+    blob = tmp_path / "partial.zip"
+    with zipfile.ZipFile(blob, "w") as archive:
+        archive.writestr("action-key.txt", "matching-key\n")
+        archive.writestr("artifacts/glib2-2.88.0-2.el10.x86_64.rpm", "rpm")
+        archive.writestr("artifacts/pango-1.56.4-1.el10.x86_64.rpm", "rpm")
+        # Regenerated by createrepo_c on the next run; must not be carried over.
+        archive.writestr("artifacts/repodata/repomd.xml", "<stale/>")
+    _fake_api(module, {"artifacts": [{
+        "expired": False, "created_at": "2026-08-23T14:52:00Z",
+        "size_in_bytes": 1234, "archive_download_url": "https://example.invalid/z",
+    }]}, blob.read_bytes())
+
+    monkeypatch.setenv("GITHUB_TOKEN", "t")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "tuna-os/tunaos-packages")
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    out = tmp_path / "cell"
+    monkeypatch.setattr(sys, "argv", [
+        "restore", "--cell-id", "gnome51-el10-x86_64",
+        "--action-key", "matching-key", "--out-dir", str(out)])
+    assert module.main() == 0
+
+    landed = sorted(p.name for p in (out / "artifacts").iterdir())
+    assert landed == ["glib2-2.88.0-2.el10.x86_64.rpm", "pango-1.56.4-1.el10.x86_64.rpm"]
+    assert not (out / "artifacts" / "repodata").exists(), (
+        "a stale repodata index must not outlive the attempt that wrote it: "
+        "createrepo_c regenerates it, and an index naming packages that did "
+        "not come across is worse than no index"
+    )
+    assert not list(tmp_path.glob(".*-partial-staging")), "staging must be cleaned up"
+
+
+def test_a_mismatched_partial_leaves_the_cell_directory_untouched(tmp_path, monkeypatch):
+    """The consequence of getting this wrong is not a red build.
+
+    Every RPM in a partial is well-formed, so a mixture of two input sets
+    passes lint, install, smoke and the ActionResult hash alike. It is simply
+    not the thing the manifest describes. Nothing downstream can catch it,
+    which is why the check is here.
+    """
+    module = load_module()
+    blob = tmp_path / "partial.zip"
+    with zipfile.ZipFile(blob, "w") as archive:
+        archive.writestr("action-key.txt", "an-older-key\n")
+        archive.writestr("artifacts/glib2-2.87.3-1.el10.x86_64.rpm", "rpm")
+    _fake_api(module, {"artifacts": [{
+        "expired": False, "created_at": "2026-08-01T00:00:00Z",
+        "size_in_bytes": 1, "archive_download_url": "https://example.invalid/z",
+    }]}, blob.read_bytes())
+
+    monkeypatch.setenv("GITHUB_TOKEN", "t")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "tuna-os/tunaos-packages")
+    monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+    out = tmp_path / "cell"
+    monkeypatch.setattr(sys, "argv", [
+        "restore", "--cell-id", "gnome51-el10-x86_64",
+        "--action-key", "the-current-key", "--out-dir", str(out)])
+    assert module.main() == 0
+    assert not out.exists(), "a mismatched partial must land nothing at all"
+
+
+def test_an_expired_artifact_is_skipped(tmp_path, monkeypatch):
+    """Artifacts expire; the API still lists them, with no downloadable zip."""
+    module = load_module()
+    _fake_api(module, {"artifacts": [
+        {"expired": True, "created_at": "2026-05-01T00:00:00Z",
+         "archive_download_url": "https://example.invalid/gone"},
+    ]}, b"")
+    monkeypatch.setenv("GITHUB_TOKEN", "t")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "tuna-os/tunaos-packages")
+    assert module.newest_partial("tuna-os/tunaos-packages", "x-partial", "t") is None

--- a/tests/test_action_cache_stores_only_output.py
+++ b/tests/test_action_cache_stores_only_output.py
@@ -129,7 +129,18 @@ def test_the_metadata_the_cache_drops_is_regenerated_every_run():
 
 
 def _uploads() -> list[dict]:
-    return [s for s in _steps() if str(s.get("uses", "")).startswith("actions/upload-artifact")]
+    """The two OUTCOME-SPLIT uploads: the deliverable and the debugging tree.
+
+    A third upload exists and is deliberately excluded here. It carries the
+    `-partial` artifact a timed-out build-chain cell resumes from -- see
+    test_a_timed_out_chain_cell_can_resume.py, which pins its own shape. It
+    is neither of the two this file is about: it is not a deliverable and it
+    is not for a human to read, so folding it into the assertions below would
+    only blur what they say.
+    """
+    return [s for s in _steps()
+            if str(s.get("uses", "")).startswith("actions/upload-artifact")
+            and "-partial" not in str((s.get("with") or {}).get("name", ""))]
 
 
 def test_success_uploads_the_output_and_failure_uploads_the_build_tree():
@@ -160,7 +171,13 @@ def test_the_failure_upload_cannot_mask_the_real_failure():
 
 def test_both_uploads_keep_the_same_artifact_name_and_root():
     """Consumers see one artifact per cell either way, rooted at the cell
-    directory, so the layout does not change with the outcome."""
+    directory, so the layout does not change with the outcome.
+
+    The resume `-partial` upload is excluded by _uploads() and must stay
+    excluded: its whole purpose depends on carrying a DIFFERENT name, so an
+    API lookup by exact name cannot return a validated deliverable and an
+    interrupted attempt interchangeably.
+    """
     for step in _uploads():
         assert step["with"]["name"] == "${{ matrix.id }}"
         for line in step["with"]["path"].splitlines():

--- a/tests/test_changelog_text_does_not_expand_as_macros.py
+++ b/tests/test_changelog_text_does_not_expand_as_macros.py
@@ -1,0 +1,85 @@
+"""RPM expands macros in %changelog text, and one of them is not inert.
+
+gnome50-el10-aarch64 built 57 packages across 19 tiers of run 32646102181 and
+then died on the 58th:
+
+    error: line 114: %package debuginfo
+    : package input-remapper-debuginfo already exists
+
+Line 114 of input-remapper.spec is not a spec directive. It is changelog prose
+added two days earlier:
+
+      installer shells out to pip and imports gi, so %install failed in mock
+
+`%install` is a macro rpm DEFINES, not merely a section keyword, so it expands
+where it appears and re-emits the install scaffolding -- including the
+automatic debuginfo subpackage, which by then already exists. The error is
+reported at the changelog line, which is the only reason it was findable.
+
+The discriminating evidence, and the reason this test forbids the whole class
+rather than that one word: `src/gnome-50/mutter` and `src/gnome-50/gjs` are in
+the SAME build order, were built in the SAME run, and carry `%prep`, `%build`
+and `%files` in their changelogs. They passed. Those are section keywords with
+no macro definition behind them; `%install` has one.
+
+So the precise rule is "escape any macro rpm happens to define", and the set
+rpm defines is not ours to track -- it changes with an rpm release, and this
+particular line sat harmless in the tree for two days before it fired. The
+cheap rule that subsumes it is the one Fedora packaging already states: escape
+the percent sign in changelog text. That is what this enforces.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+# Section keywords and the rpm-defined macros that shadow them. `install` is
+# the one with measured consequences; the rest are here because deciding which
+# of them rpm defines TODAY is exactly the reasoning that let this through.
+RISKY = {
+    "install", "build", "prep", "check", "files", "package", "description",
+    "post", "postun", "pre", "preun", "posttrans", "pretrans", "clean",
+    "configure", "make_build", "make_install", "autosetup", "setup",
+}
+
+PATTERN = re.compile(r"(?<!%)%([A-Za-z_]\w*)")
+
+
+def unescaped_macros_in_changelogs() -> list[str]:
+    findings = []
+    for spec in sorted(ROOT.joinpath("src").rglob("*.spec")):
+        in_changelog = False
+        for number, line in enumerate(
+            spec.read_text(encoding="utf-8", errors="replace").splitlines(), 1
+        ):
+            if line.startswith("%changelog"):
+                in_changelog = True
+                continue
+            if not in_changelog:
+                continue
+            for match in PATTERN.finditer(line):
+                if match.group(1) in RISKY:
+                    findings.append(
+                        f"{spec.relative_to(ROOT)}:{number}: {match.group(0)} "
+                        f"-> write %%{match.group(1)}  | {line.strip()[:60]}"
+                    )
+    return findings
+
+
+def test_no_spec_changelog_contains_an_unescaped_macro():
+    findings = unescaped_macros_in_changelogs()
+    assert not findings, (
+        "changelog prose is macro-expanded by rpm; double the percent sign:\n"
+        + "\n".join(findings)
+    )
+
+
+def test_the_line_that_broke_input_remapper_is_fixed():
+    """Named explicitly, so a revert cannot pass by deleting the sweep above."""
+    spec = ROOT / "src" / "input-remapper" / "input-remapper.spec"
+    text = spec.read_text(encoding="utf-8")
+    changelog = text[text.index("%changelog"):]
+    assert "%%install failed in mock" in changelog
+    assert "so %install failed" not in changelog

--- a/tests/test_the_cell_verifies_what_it_ships.py
+++ b/tests/test_the_cell_verifies_what_it_ships.py
@@ -67,7 +67,51 @@ def test_every_name_is_still_queried_and_verified():
     """Installing by name must not quietly shrink what gets checked."""
     text = VERIFY.read_text(encoding="utf-8")
     assert 'rpm -q "${names[@]}"' in text
-    assert 'rpm -V "${names[@]}"' in text
+    assert 'rpm -V --nouser --nogroup "${names[@]}"' in text
+
+
+def test_rpm_verify_excludes_only_what_a_container_cannot_judge():
+    """Two classes, and each is excluded for a reason, not for convenience.
+
+    Both took all four gnome cells red in run 32646102181 -- after a clean
+    build, a clean lint and a clean install:
+
+        .....UG..    /var/lib/avahi-autoipd
+        .M.......  g /var/lib/selinux/minimum/active/policy.linked
+
+    A %ghost path (the `g`) is one rpm knows the name of but ships no content
+    for; a scriptlet creates it and the header attributes are placeholders.
+    An account like avahi-autoipd is created by sysusers, which a container
+    without systemd never runs, so rpm chowns to root and reports U and G.
+
+    Neither is a statement about the package. What IS still checked -- digest,
+    size, mode, link target, capabilities -- is what catches a corrupt or
+    mis-packaged payload, and that is what this step exists for.
+    """
+    text = VERIFY.read_text(encoding="utf-8")
+    assert "--nouser --nogroup" in text
+    # Ghosts are dropped by their marker column, not by path.
+    assert 'grep -vE "^[.?SM5DLUGTPa]{8,9} +g "' in text
+    for kept in ("--nofiledigest", "--nosize", "--nomode", "--nolinkto", "--nocaps"):
+        assert kept not in text, (
+            f"{kept} would disable a check that detects a real payload defect"
+        )
+
+
+def test_a_surviving_rpm_verify_difference_still_fails_the_cell():
+    """Filtering must not become ignoring.
+
+    A grep that drops ghost lines and then discards the rest would turn this
+    step into a no-op that reports success -- the worst outcome, because the
+    step would keep looking like a gate.
+    """
+    text = VERIFY.read_text(encoding="utf-8")
+    filtered = text.index("rpm-verify.real")
+    fail = text.index('if [ -s /tmp/rpm-verify.real ]; then')
+    assert filtered < fail
+    tail = text[fail:fail + 400]
+    assert "exit 1" in tail, "surviving differences must fail the cell"
+    assert "cat /tmp/rpm-verify.real" in tail, "and must be printed, not swallowed"
 
 
 def test_a_recipe_really_is_built_twice_in_the_gnome_chains():

--- a/tests/test_the_deb_backport_gap_is_measured_not_guessed.py
+++ b/tests/test_the_deb_backport_gap_is_measured_not_guessed.py
@@ -217,3 +217,198 @@ def test_the_ubuntu_donor_includes_proposed_and_debian_does_not_need_it():
                for url in manifest["targets"]["ubuntu"]["donor_index"])
     # Debian stages in experimental and falls back to sid; no -proposed pocket.
     assert manifest["targets"]["debian"]["donor_suites"] == ["experimental", "sid"]
+
+
+# ---------------------------------------------------------------- Provides
+#
+# A Sources index lists a source's REAL binaries and never its `Provides:`,
+# so every virtual package looks absent from it -- and "absent from the map"
+# is indistinguishable there from "genuinely missing". The first real tier-0
+# run (32651265182) built 7 of 10 packages and lost all three of the rest to
+# that one blind spot:
+#
+#   builddeps:.../gexiv2-0.16.2 : Depends: debhelper-compat (= 14)
+#   builddeps:.../gnome-desktop-51~alpha : Depends: debhelper-compat (= 14)
+#   builddeps:.../gsettings-desktop-schemas-51~beta : Depends: debhelper-compat (= 14)
+#   ...
+#   E: Unable to satisfy dependencies. [no choices]
+#
+# Everything else apt printed underneath was the usual cascade of "but it is
+# not going to be installed" for packages that were fine.
+#
+# Measured against the live archives: resolute's debhelper is 13.31ubuntu1
+# and provides debhelper-compat 9 through 13. stonking's is 14.x. Reading the
+# binary Packages indexes makes that decidable, and `debhelper` now enters
+# the closure at tier-0 with the three failures ordered after it.
+
+
+def test_an_unversioned_provides_cannot_satisfy_a_versioned_dependency():
+    """Debian policy 7.5, and the whole answer for debhelper-compat.
+
+    If a provider counted regardless of version, resolute's debhelper would
+    look adequate for `debhelper-compat (= 14)` and the closure would stay
+    wrong -- in the other direction, and just as silently.
+    """
+    module = gap
+    provides = {"dh-sequence-python3": [None], "debhelper-compat": ["13"]}
+    # Unversioned dep, unversioned Provides: satisfied.
+    assert module.clause_satisfied("dh-sequence-python3", "", "", {}, provides)
+    # Versioned dep against the version resolute actually provides.
+    assert module.clause_satisfied("debhelper-compat", "=", "13", {}, provides)
+    assert not module.clause_satisfied("debhelper-compat", "=", "14", {}, provides)
+    # An unversioned Provides against a versioned dep: never.
+    assert not module.clause_satisfied("dh-sequence-python3", ">=", "1", {}, provides)
+
+
+def test_a_virtual_the_target_cannot_supply_pulls_in_the_source_that_can():
+    """The fix, end to end, on the shape that broke.
+
+    gexiv2 build-depends `debhelper-compat (= 14)`; the target's debhelper
+    provides 13. The measurement has to reach `debhelper` -- a source no root
+    names and no Sources index connects to that clause.
+    """
+    module = gap
+    donor = {
+        "gexiv2": {"Package": "gexiv2", "Version": "0.16.2-1", "Binary": "libgexiv2-2",
+                   "Build-Depends": "debhelper-compat (= 14)"},
+        "debhelper": {"Package": "debhelper", "Version": "14.1", "Binary": "debhelper"},
+    }
+    target = {"gexiv2": {"Package": "gexiv2", "Version": "0.14.0-1", "Binary": "libgexiv2-2"},
+              "debhelper": {"Package": "debhelper", "Version": "13.31", "Binary": "debhelper"}}
+    result = module.measure(
+        ["gexiv2"], donor, target, module.binary_to_source(donor),
+        {"libgexiv2-2": "0.14.0-1", "debhelper": "13.31"},
+        target_provides={"debhelper-compat": ["9", "10", "11", "12", "13"]},
+        donor_virtual_source={"debhelper-compat": "debhelper"},
+    )
+    assert set(result["needed"]) == {"gexiv2", "debhelper"}
+    assert not result["unattributable"]
+
+
+def test_a_virtual_the_target_already_supplies_stays_out_of_the_closure():
+    """`dh-sequence-python3` is provided unversioned by the target's dh-python.
+
+    Apt listed it under the same failure, which made it look like a second
+    missing package. It was cascade noise: once one member of a builddeps
+    group has no candidate, apt reports the whole group. Pulling dh-python
+    into a backport it does not need would be its own kind of wrong.
+    """
+    module = gap
+    donor = {
+        "gexiv2": {"Package": "gexiv2", "Version": "0.16.2-1", "Binary": "libgexiv2-2",
+                   "Build-Depends": "dh-sequence-python3"},
+        "dh-python": {"Package": "dh-python", "Version": "9", "Binary": "dh-python"},
+    }
+    target = {"gexiv2": {"Package": "gexiv2", "Version": "0.14.0-1", "Binary": "libgexiv2-2"}}
+    result = module.measure(
+        ["gexiv2"], donor, target, module.binary_to_source(donor),
+        {"libgexiv2-2": "0.14.0-1"},
+        target_provides={"dh-sequence-python3": [None]},
+        donor_virtual_source={"dh-sequence-python3": "dh-python"},
+    )
+    assert set(result["needed"]) == {"gexiv2"}
+
+
+def test_an_unsatisfiable_clause_nobody_can_supply_is_reported_not_dropped():
+    """This is the guard, and it is the part that generalises.
+
+    Before, a clause that no alternative satisfied and that mapped to no
+    source was simply skipped -- so the measurement reported a closure that
+    could not build, and said nothing. Whatever the next unmappable name
+    turns out to be, it has to come out as a finding rather than as three
+    failed builds in a dispatched chain.
+    """
+    module = gap
+    donor = {"gexiv2": {"Package": "gexiv2", "Version": "0.16.2-1", "Binary": "libgexiv2-2",
+                        "Build-Depends": "dh-sequence-invented (>= 3)"}}
+    target = {"gexiv2": {"Package": "gexiv2", "Version": "0.14.0-1", "Binary": "libgexiv2-2"}}
+    result = module.measure(
+        ["gexiv2"], donor, target, module.binary_to_source(donor),
+        {"libgexiv2-2": "0.14.0-1"}, target_provides={}, donor_virtual_source={})
+    assert result["unattributable"] == {"gexiv2": ["dh-sequence-invented (>= 3)"]}
+
+
+def test_the_ordering_resolves_virtuals_the_same_way_the_closure_does():
+    """If the two disagreed, a package would enter the closure through a
+    virtual clause and then be ordered as though that clause did not exist.
+
+    That is worse than the bug this fixes: a chain that builds things in the
+    wrong order goes red somewhere unrelated, rather than reporting a gap.
+    """
+    module = gap
+    donor = {
+        "gexiv2": {"Package": "gexiv2", "Version": "0.16.2-1", "Binary": "libgexiv2-2",
+                   "Build-Depends": "debhelper-compat (= 14)"},
+        "debhelper": {"Package": "debhelper", "Version": "14.1", "Binary": "debhelper"},
+    }
+    needed = {"gexiv2": {}, "debhelper": {}}
+    edges = module.build_edges(
+        needed, donor, module.binary_to_source(donor), {"debhelper": "13.31"},
+        target_provides={"debhelper-compat": ["13"]},
+        donor_virtual_source={"debhelper-compat": "debhelper"})
+    assert edges["gexiv2"] == {"debhelper"}
+    assert module.tiers(edges) == [["debhelper"], ["gexiv2"]]
+
+
+def test_the_binary_index_is_derived_from_the_declared_source_index():
+    """Not a second hand-maintained list of the same suite/component pairings.
+
+    Two lists can disagree, and a disagreement here is invisible: a wrong
+    binary URL reads as "that virtual package does not exist", which is
+    exactly the failure mode being fixed.
+    """
+    module = gap
+    assert module.packages_url(
+        "https://archive.ubuntu.com/ubuntu/dists/resolute/universe/source/Sources.xz"
+    ) == "https://archive.ubuntu.com/ubuntu/dists/resolute/universe/binary-amd64/Packages.xz"
+    import yaml
+    manifest = yaml.safe_load((ROOT / "manifests" / "gnome51-deb.yaml").read_text())
+    for spec in manifest["targets"].values():
+        for url in spec["target_index"] + spec["donor_index"]:
+            derived = module.packages_url(url)
+            assert derived != url, f"the transform did not fire on {url}"
+            assert derived.endswith("/binary-amd64/Packages.xz")
+
+
+def test_provides_and_source_are_read_the_way_deb822_writes_them():
+    module = gap
+    assert module.parse_provides("foo, bar (= 1.2), baz:any") == [
+        ("foo", None), ("bar", "1.2"), ("baz", None)]
+    text = (
+        "Package: debhelper\n"
+        "Version: 14.1\n"
+        "Provides: debhelper-compat (= 14)\n"
+        "\n"
+        "Package: dh-python\n"
+        "Source: dh-python-src (9.0)\n"
+        "Version: 9\n"
+        "Provides: dh-sequence-python3,\n"
+        " dh-sequence-python2\n"
+    )
+    packages = module.parse_packages(text)
+    assert packages["debhelper"]["Version"] == "14.1"
+    assert module.provides_map(packages)["debhelper-compat"] == ["14"]
+    # `Source:` is omitted when it equals the binary name, and may carry a
+    # version in parentheses.
+    virtual = module.virtual_to_source(packages)
+    assert virtual["debhelper-compat"] == "debhelper"
+    assert virtual["dh-sequence-python3"] == "dh-python-src"
+    assert virtual["dh-sequence-python2"] == "dh-python-src"
+
+
+def test_the_measured_report_records_the_debhelper_finding():
+    """The committed report is the evidence, so it has to carry the answer.
+
+    `debhelper` at tier-0 with gexiv2, gnome-desktop and
+    gsettings-desktop-schemas after it IS the fix for run 32651265182.
+    """
+    import json
+    report = json.loads(
+        (ROOT / "docs" / "gnome51-deb-gap.json").read_text())["targets"]["ubuntu"]
+    assert "debhelper" in report["tiers"][0]
+    later = {name for tier in report["tiers"][1:] for name in tier}
+    for source in ("gexiv2", "gnome-desktop", "gsettings-desktop-schemas"):
+        assert source in later, f"{source} must be ordered after debhelper"
+    assert report["unattributable"] == {}, (
+        "a measured gap with unattributable clauses is a gap that cannot build"
+    )

--- a/tests/test_the_deb_chain_rebuilds_against_the_target.py
+++ b/tests/test_the_deb_chain_rebuilds_against_the_target.py
@@ -241,3 +241,26 @@ def test_the_workflow_summary_only_reads_keys_the_report_emits():
         f"the workflow reads report fields the script does not emit: {sorted(unknown)}; "
         f"emitted keys are {sorted(emitted)}"
     )
+
+
+def test_the_tier_input_is_documented_as_narrowing_not_resuming():
+    """`--tier` selects a subset of ONE run; it cannot continue a previous one.
+
+    The local apt repo that carries a tier's output to the next tier lives on
+    the runner and dies with the job. So dispatching tier-1 after a tier-0 run
+    resolves tier-1's build-deps against the target archive alone -- and that
+    does not fail loudly. It builds, and produces packages linked against the
+    versions the backport exists to replace.
+
+    The workflow used to advise exactly that ("re-dispatch with --tier") as
+    the remedy for hitting the timeout, which is the most likely moment for
+    someone to follow it.
+    """
+    text = WORKFLOW.read_text()
+    assert "it cannot resume one" in text
+    assert "RE-DISPATCH FROM tier-0 OR WITH NO TIER" in text
+    # The input's own description already says empty builds everything.
+    workflow = yaml.safe_load(text)
+    # PyYAML reads a bare `on:` key as the boolean True.
+    triggers = workflow.get("on", workflow.get(True))
+    assert "empty builds all" in triggers["workflow_dispatch"]["inputs"]["tier"]["description"]

--- a/tests/test_the_deb_chain_rebuilds_against_the_target.py
+++ b/tests/test_the_deb_chain_rebuilds_against_the_target.py
@@ -345,41 +345,29 @@ def test_the_chain_body_carries_no_apostrophes():
     )
 
 
-def test_the_container_image_file_exclusions_are_lifted_first():
-    """A container image is not a chroot, and the difference is measurable.
+def test_the_catalogue_check_does_not_pipe_find_into_head():
+    """The check was the bug, not the buildroot.
 
-    Ubuntu images ship /etc/dpkg/dpkg.cfg.d/excludes to drop translation
-    catalogues and manpages. Correct for a runtime image, wrong for a
-    buildroot -- the Ubuntu builders use sbuild chroots, which are full
-    installs.
+        find /usr/share/locale ... -name "*.mo" | head -1 | grep -q .
 
-    What it cost, from run 32665378407 once the chain surfaced the meson
-    testlog:
+    `head -1` closes the pipe as soon as it has a line, `find` dies of
+    SIGPIPE, and under `set -o pipefail` the pipeline reports 141 -- so the
+    assertion fired while standing in a directory full of .mo files. Run
+    32671483629 printed its own diagnostics proving them present:
 
-        # Ignoring `C.UTF-8` as a locale, since it lacks translations
-        # Ignoring `en_US.UTF-8` as a locale, since it lacks translations
-        not ok /languages/using-null-locale - GnomeDesktop-FATAL-WARNING:
-          Could not read list of available locales from libc ...
-        Bail out!
+        /usr/share/locale-langpack/en/LC_MESSAGES/coreutils.mo
+        /usr/share/locale-langpack/en/LC_MESSAGES/dpkg.mo
 
-    The locales were there. Every one was discarded for having no
-    translations, the list came out empty, and glib made the warning fatal.
+    Those same diagnostics printed NOTHING for the dpkg configuration, which
+    is why the path-exclude removal this test used to assert is gone: the
+    image has no such directives, and the theory that it did was wrong.
 
-    ORDER IS THE PROPERTY. dpkg applies exclusions at unpack time, so
-    anything installed before the file is removed keeps its files stripped.
+    `-print -quit` stops find itself after the first hit, with no pipe and
+    nothing to kill.
     """
     text = chain_text()
-    # Every exclusion file, not one guessed filename. Run 32671248141 removed
-    # `excludes` and the stripping stayed in place, so the image ships it
-    # under some other name.
-    assert 'grep -rl "path-exclude"' in text
-    assert "/etc/dpkg/dpkg.cfg.d/" in text
-    lift = text.index('grep -rl "path-exclude"')
-    install = text.index("build-essential devscripts dpkg-dev ca-certificates")
-    assert lift < install, (
-        "exclusions must be lifted before any package is installed, or dpkg "
-        "strips that package regardless"
-    )
+    assert '-name "*.mo" -print -quit' in text
+    assert '-name "*.mo" 2>/dev/null \\\n         | head' not in text
 
 
 def test_the_buildroot_proves_it_has_translations_not_just_a_charmap():
@@ -422,3 +410,30 @@ def test_the_missing_catalogue_failure_prints_the_evidence():
     assert "dpkg configuration" in tail
     assert "cat /etc/dpkg/dpkg.cfg" in tail
     assert "dpkg -L language-pack-en-base" in tail
+
+
+def test_no_find_is_piped_into_head_anywhere_in_the_chain():
+    """The class, not the instance.
+
+    This script runs under `set -euo pipefail`. Any `find ... | head -N`
+    reports SIGPIPE once find produces more than N lines, and pipefail turns
+    that into a failed pipeline -- which `set -e` then turns into an aborted
+    run. It stays invisible while output is short, so it ships green and
+    fires later on a bigger input.
+
+    Two of these existed at once: the catalogue assertion (fired immediately)
+    and the testlog collector (latent until four logs exist, which is exactly
+    when a package has failed and the logs matter). A pipeline ending in
+    `|| true` is fine -- that absorbs the status deliberately.
+    """
+    offenders = []
+    for line_number, line in enumerate(chain_text().splitlines(), 1):
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        if re.search(r"find[^|]*\|\s*head\b", stripped) and "|| true" not in stripped:
+            offenders.append(f"{line_number}: {stripped}")
+    assert not offenders, (
+        "find piped into head dies of SIGPIPE under pipefail; use -print -quit "
+        "or collect to a file first:\n" + "\n".join(offenders)
+    )

--- a/tests/test_the_deb_chain_rebuilds_against_the_target.py
+++ b/tests/test_the_deb_chain_rebuilds_against_the_target.py
@@ -264,3 +264,63 @@ def test_the_tier_input_is_documented_as_narrowing_not_resuming():
     # PyYAML reads a bare `on:` key as the boolean True.
     triggers = workflow.get("on", workflow.get(True))
     assert "empty builds all" in triggers["workflow_dispatch"]["inputs"]["tier"]["description"]
+
+
+def test_the_buildroot_has_a_usable_utf8_locale():
+    """The container exports LANG=C.UTF-8; a minimal image has no locale DATA.
+
+    So setlocale falls back and glib reports a non-UTF-8 charset. Suites that
+    ask the system what language it is in then abort:
+
+        4/6 gnome-desktop:languages  FAIL  (exit status 134 or signal 6 SIGABRT)
+
+    Run 32653189343, where `is_utf8: FALSE` is visible in the PASSING
+    wall-clock tests of the same suite -- the environment was already wrong
+    where it happened not to matter. gnome-desktop failing took
+    gnome-control-center down with it, because libgnome-desktop-4-dev never
+    reached the local repo. One absent locale cost two of eighteen packages.
+
+    Exporting the variable is not the same as having the locale, which is why
+    the assertion below is the load-bearing half.
+    """
+    text = chain_text()
+    assert "locales" in text, "the locales package must be installed"
+    assert "locale-gen C.UTF-8" in text
+    install = text.index("build-essential devscripts dpkg-dev ca-certificates")
+    generate = text.index("locale-gen C.UTF-8")
+    build = text.index("apt-get build-dep")
+    assert install < generate < build, (
+        "the locale must exist before any package is built against it"
+    )
+
+
+def test_an_unusable_locale_fails_the_buildroot_not_a_package():
+    """Assert it rather than trust it.
+
+    A broken locale does not announce itself. It surfaces forty minutes later
+    as a SIGABRT inside someone else's test suite, naming the package rather
+    than the buildroot -- which is how it cost a whole run to diagnose.
+    """
+    text = chain_text()
+    assert "locale charmap" in text
+    assert "the buildroot has no usable UTF-8 locale" in text
+
+
+def test_the_chain_body_carries_no_apostrophes():
+    """The docker body is a single-quoted `bash -lc` string.
+
+    ONE apostrophe ends it early, and bash then reports `unexpected EOF while
+    looking for matching '` at the LAST line of the script -- nowhere near the
+    comment that broke it. The word that did it while writing the locale fix
+    above was "Ubuntu's".
+
+    verify-package-factory-cell.sh has the same shape and the same guard.
+    """
+    text = chain_text()
+    start = text.index("bash -lc '")
+    body = text[start + len("bash -lc '"):]
+    end = body.index("\n  '")
+    assert "'" not in body[:end], (
+        "an apostrophe inside the single-quoted bash -lc body ends it early; "
+        "bash will report the error at the end of the file, not here"
+    )

--- a/tests/test_the_deb_chain_rebuilds_against_the_target.py
+++ b/tests/test_the_deb_chain_rebuilds_against_the_target.py
@@ -267,18 +267,14 @@ def test_the_tier_input_is_documented_as_narrowing_not_resuming():
 
 
 def test_the_buildroot_has_a_usable_utf8_locale():
-    """The container exports LANG=C.UTF-8; a minimal image has no locale DATA.
+    """A buildroot should have locale data; a minimal Ubuntu image has none.
 
-    So setlocale falls back and glib reports a non-UTF-8 charset. Suites that
-    ask the system what language it is in then abort:
-
-        4/6 gnome-desktop:languages  FAIL  (exit status 134 or signal 6 SIGABRT)
-
-    Run 32653189343, where `is_utf8: FALSE` is visible in the PASSING
-    wall-clock tests of the same suite -- the environment was already wrong
-    where it happened not to matter. gnome-desktop failing took
-    gnome-control-center down with it, because libgnome-desktop-4-dev never
-    reached the local repo. One absent locale cost two of eighteen packages.
+    That is worth doing on its own terms. It is NOT, on the evidence, the
+    cause of the gnome-desktop:languages SIGABRT it was added to explain:
+    run 32659338235 generated the locales and the failure is unchanged, with
+    `is_utf8: FALSE` still printed by the same suite. The diagnosis was wrong;
+    the change is kept because the buildroot is better with it, not because it
+    fixed the thing it was aimed at.
 
     Exporting the variable is not the same as having the locale, which is why
     the assertion below is the load-bearing half.
@@ -294,16 +290,39 @@ def test_the_buildroot_has_a_usable_utf8_locale():
     )
 
 
-def test_an_unusable_locale_fails_the_buildroot_not_a_package():
-    """Assert it rather than trust it.
+def test_the_locale_assertion_checks_a_locale_that_had_to_be_generated():
+    """The first version of this check could not fail.
 
-    A broken locale does not announce itself. It surfaces forty minutes later
-    as a SIGABRT inside someone else's test suite, naming the package rather
-    than the buildroot -- which is how it cost a whole run to diagnose.
+    It asked `LC_ALL=C.UTF-8 locale charmap`, and C.UTF-8 is built into glibc
+    -- it resolves with zero generated locales, so the assertion would have
+    passed on the very image it was written to catch. en_US.UTF-8 exists only
+    if locale-gen actually ran.
+
+    An assertion that cannot fail is worse than no assertion: it reports a
+    property nobody has checked.
     """
     text = chain_text()
-    assert "locale charmap" in text
-    assert "the buildroot has no usable UTF-8 locale" in text
+    # The assignment, not the prose: the comment above it legitimately quotes
+    # the old form to explain why it was wrong.
+    assert "charmap=$(LC_ALL=en_US.UTF-8 locale charmap" in text
+    assert "charmap=$(LC_ALL=C.UTF-8 locale charmap" not in text
+    assert "locale-gen did not produce a usable UTF-8 locale" in text
+
+
+def test_a_failing_test_suite_surfaces_its_own_log():
+    """meson prints a summary line and buffers the output elsewhere.
+
+        4/6 gnome-desktop:languages  FAIL  (exit status 134 or signal 6 SIGABRT)
+
+    That names the test and says nothing about why. The real output goes to
+    meson-logs/testlog*.txt inside the build tree, which is not uploaded --
+    so two full chain runs, 1h47m each, were spent guessing at a cause the log
+    could not confirm. Copy it out and print it.
+    """
+    text = chain_text()
+    assert "testlog*.txt" in text
+    assert "test-suite.log" in text, "autotools buffers the same way"
+    assert "/work/logs/$source.$(basename" in text, "and it must survive the run"
 
 
 def test_the_chain_body_carries_no_apostrophes():

--- a/tests/test_the_deb_chain_rebuilds_against_the_target.py
+++ b/tests/test_the_deb_chain_rebuilds_against_the_target.py
@@ -369,8 +369,12 @@ def test_the_container_image_file_exclusions_are_lifted_first():
     anything installed before the file is removed keeps its files stripped.
     """
     text = chain_text()
-    assert "rm -f /etc/dpkg/dpkg.cfg.d/excludes" in text
-    lift = text.index("rm -f /etc/dpkg/dpkg.cfg.d/excludes")
+    # Every exclusion file, not one guessed filename. Run 32671248141 removed
+    # `excludes` and the stripping stayed in place, so the image ships it
+    # under some other name.
+    assert 'grep -rl "path-exclude"' in text
+    assert "/etc/dpkg/dpkg.cfg.d/" in text
+    lift = text.index('grep -rl "path-exclude"')
     install = text.index("build-essential devscripts dpkg-dev ca-certificates")
     assert lift < install, (
         "exclusions must be lifted before any package is installed, or dpkg "
@@ -389,3 +393,32 @@ def test_the_buildroot_proves_it_has_translations_not_just_a_charmap():
     text = chain_text()
     assert "no translation catalogues" in text
     assert "*.mo" in text
+
+
+def test_the_language_pack_is_reinstalled_not_merely_installed():
+    """dpkg applies path-exclude at UNPACK time.
+
+    A package already present on the image kept its files stripped, and
+    `apt-get install` on something already installed is a no-op. Lifting the
+    exclusions only affects packages unpacked afterwards, so anything that was
+    already there has to be unpacked again.
+    """
+    text = chain_text()
+    assert "--reinstall" in text
+    assert "language-pack-en-base" in text
+
+
+def test_the_missing_catalogue_failure_prints_the_evidence():
+    """The rule that has actually worked today.
+
+    Three guesses at gnome-desktop:languages were wrong while the log showed
+    a summary line; the fix came from making it print the test output. A
+    buildroot assertion that says only "no catalogues" repeats that mistake
+    one level down, and each round trip costs a run.
+    """
+    text = chain_text()
+    failure = text.index("the buildroot has no translation catalogues")
+    tail = text[failure:failure + 1200]
+    assert "dpkg configuration" in tail
+    assert "cat /etc/dpkg/dpkg.cfg" in tail
+    assert "dpkg -L language-pack-en-base" in tail

--- a/tests/test_the_deb_chain_rebuilds_against_the_target.py
+++ b/tests/test_the_deb_chain_rebuilds_against_the_target.py
@@ -343,3 +343,49 @@ def test_the_chain_body_carries_no_apostrophes():
         "an apostrophe inside the single-quoted bash -lc body ends it early; "
         "bash will report the error at the end of the file, not here"
     )
+
+
+def test_the_container_image_file_exclusions_are_lifted_first():
+    """A container image is not a chroot, and the difference is measurable.
+
+    Ubuntu images ship /etc/dpkg/dpkg.cfg.d/excludes to drop translation
+    catalogues and manpages. Correct for a runtime image, wrong for a
+    buildroot -- the Ubuntu builders use sbuild chroots, which are full
+    installs.
+
+    What it cost, from run 32665378407 once the chain surfaced the meson
+    testlog:
+
+        # Ignoring `C.UTF-8` as a locale, since it lacks translations
+        # Ignoring `en_US.UTF-8` as a locale, since it lacks translations
+        not ok /languages/using-null-locale - GnomeDesktop-FATAL-WARNING:
+          Could not read list of available locales from libc ...
+        Bail out!
+
+    The locales were there. Every one was discarded for having no
+    translations, the list came out empty, and glib made the warning fatal.
+
+    ORDER IS THE PROPERTY. dpkg applies exclusions at unpack time, so
+    anything installed before the file is removed keeps its files stripped.
+    """
+    text = chain_text()
+    assert "rm -f /etc/dpkg/dpkg.cfg.d/excludes" in text
+    lift = text.index("rm -f /etc/dpkg/dpkg.cfg.d/excludes")
+    install = text.index("build-essential devscripts dpkg-dev ca-certificates")
+    assert lift < install, (
+        "exclusions must be lifted before any package is installed, or dpkg "
+        "strips that package regardless"
+    )
+
+
+def test_the_buildroot_proves_it_has_translations_not_just_a_charmap():
+    """Checking the charmap alone would pass on the broken buildroot.
+
+    en_US.UTF-8 resolved fine in run 32665378407 -- `locale charmap` said
+    UTF-8 -- and gnome-desktop still discarded it, because a locale with no
+    message catalogue is not a locale as far as that code is concerned. The
+    assertion has to look for the catalogues.
+    """
+    text = chain_text()
+    assert "no translation catalogues" in text
+    assert "*.mo" in text


### PR DESCRIPTION
Five commits now, each one from reading a run rather than reasoning about the code. Happy to split if you'd rather they landed separately.

## What the runs said

| Run | Result |
| --- | --- |
| deb tier-0 [32651265182](https://github.com/tuna-os/tunaos-packages/actions/runs/32651265182) | 7/10 — all three failures one clause |
| deb tier-0 [32652552159](https://github.com/tuna-os/tunaos-packages/actions/runs/32652552159) | **8/8 in 6m30s** |
| deb full [32653189343](https://github.com/tuna-os/tunaos-packages/actions/runs/32653189343) | **15/18** across 4 tiers |
| gnome [32646102181](https://github.com/tuna-os/tunaos-packages/actions/runs/32646102181) | 6/6 fast cells green; 4 gnome cells red, two distinct causes |

---

### `dec3fbf` — a timed-out chain resumes instead of restarting

A GNOME cell that exceeds `timeout-minutes: 360` is reported **cancelled**, so the `if: failure()` upload never ran and the action cache (written only after success) never ran either. Everything built was discarded and the re-dispatch restarted at tier 0.

Now a small `<cell>-partial` artifact (`artifacts/` + the action key — small enough to upload inside a cancellation grace window) survives, and the next attempt recovers it. A partial whose action key differs is **discarded, not merged**: every RPM in one is well-formed, so a mixture of two input sets would pass lint, install, smoke and the ActionResult hash alike and nothing downstream could catch it.

### `52ef7fb` — virtual build-deps resolve through `Provides`

A `Sources` index never lists `Provides:`, so a virtual package is indistinguishable from a missing one. `debhelper-compat (= 14)` was judged unsatisfied correctly, then dropped for lack of anything to attribute it to — taking down gexiv2, gnome-desktop and gsettings-desktop-schemas.

Reading the binary `Packages` indexes makes it decidable. Measured: resolute's debhelper 13.31 provides compat 9–13; stonking's provides 14. One package enters the closure, and tier-0 then went **8/8**. `dh-sequence-python3` and `dh-sequence-user-session-migration` turned out genuinely satisfied — apt cascade noise.

Unsatisfied clauses that map to no source are now **reported** rather than skipped.

Incidentally: **Debian sid is down to one package** (mutter `51~beta-1` vs `50.4-1`). Nobody edited that target — sid caught up, which is the retirement rule working.

### `6b3e5f0` — `--tier` narrows a run, it cannot resume one

The timeout comment advised "re-dispatch with `--tier`". The local apt repo carrying one tier's output to the next dies with the job, so a tier-1 dispatch resolves against the target archive alone — it builds cleanly and produces packages linked against the versions the backport exists to replace. Same silent-wrong-answer shape as a `deb` donor line.

### `70de7df` — the deb buildroot gets a UTF-8 locale that exists

`gnome-desktop:languages` SIGABRTed. The container exports `LANG=C.UTF-8` but a minimal image carries no locale **data**. The evidence was already in the *passing* tests of the same run — `is_utf8: FALSE` in the wall-clock output. gnome-desktop failing took gnome-control-center with it (`libgnome-desktop-4-dev (>= 51~alpha) ... [no choices]`), so one absent locale cost two of eighteen.

Installed, generated, and then **asserted** with `locale charmap` — exporting the variable is not the same as having the locale, and an unusable one fails forty minutes later as a SIGABRT naming someone else's package.

### `736e9e8` — the two gnome causes

**gnome50** died on the 58th package after 57 built:

```
error: line 114: %package debuginfo
: package input-remapper-debuginfo already exists
```

Line 114 is changelog prose: `...so %install failed in mock`. RPM expands macros in changelog text, and `%install` is a macro it *defines* rather than merely a section keyword, so it re-emitted the install scaffolding including the automatic debuginfo subpackage.

The discriminating evidence is in the same run: `gnome-50/mutter` and `gnome-50/gjs` are in the same order, built by the same job, and carry `%prep`/`%build`/`%files` in their changelogs. They passed. Which set rpm defines is not ours to track — it moves with an rpm release, and this line sat harmless for two days. Escaped all 17 occurrences across 8 specs, with a sweep test.

**gnome51** got past build, lint and install — 344 packages indexed — and failed `rpm -V`:

```
.....UG..    /var/lib/avahi-autoipd
.M.......  g /var/lib/selinux/minimum/active/policy.linked
```

The `g` marks a `%ghost`: rpm knows the name, ships no content, a scriptlet creates it. `avahi-autoipd` is a sysusers account a container without systemd never creates. Excluded both; kept digest, size, mode, link target, capabilities.

Worth stating plainly: `rpm -V` here compares the installed tree against the header rpm itself just wrote, so a wrong owner or mode in a spec would agree with itself and pass regardless. Ownership is verified where it takes effect — in the image build.

---

## Still open, deliberately not folded in

`gnome-shell` fails one integration test of twenty-one, `closeWithActiveWindows`, with *"A connection to the bus can't be made"* alongside. That is a session-bus question, not a locale one, and **turning off a package's test suite is a decision worth making in the open** rather than hiding inside a locale fix. Flagging it rather than silently disabling it.

## Tests

`1100 passed, 1 skipped` (was 1070). Nine mutations verified, including: partial key check removed, whole build tree restored, any-provider-satisfies, unattributable clause skipped, edges ignoring virtuals, and the changelog line un-escaped again.

Writing the locale comment broke the script twice on the repo's known apostrophe trap — `Ubuntu's` ends the single-quoted `bash -lc` body and bash then reports `unexpected EOF` 100 lines away. There is now a test that reads the body and refuses an apostrophe in it.