### PR TITLE
fix(factory): put translations where gnome-desktop looks, per its own source (#480)

### DIFF
--- a/scripts/build-deb-chain.sh
+++ b/scripts/build-deb-chain.sh
@@ -184,6 +184,48 @@ export SOURCE_DATE_EPOCH
       echo "       Failing here rather than later inside a package test suite." >&2
       exit 1
     fi
+    # Ubuntu ships package translations in /usr/share/locale-langpack, not in
+    # /usr/share/locale. gettext finds them there via an Ubuntu patch; code
+    # that looks in its own GNOMELOCALEDIR does not.
+    #
+    # Read out of gnome-desktop 51~alpha, libgnome-desktop/gnome-languages.c,
+    # rather than guessed. collect_locales() warns only when BOTH collectors
+    # fail:
+    #
+    #   collect_locales_from_localebin()  runs `locale -a` and keeps a locale
+    #     only if add_locale() accepts it -- and add_locale rejects any locale
+    #     with no .mo under GNOMELOCALEDIR/<code>/LC_MESSAGES, trying in turn
+    #     the full name, the id, and the bare language code.
+    #   collect_locales_from_directory()  scandirs LIBLOCALEDIR for
+    #     DIRECTORIES -- and locale-gen writes a single locale-archive FILE,
+    #     so it matches nothing.
+    #
+    # Both false, so it emits the fatal warning and the test aborts. The
+    # locales were never the problem; where the catalogues live is.
+    #
+    # Presenting the langpack tree at the path the default localedir names is
+    # what an sbuild chroot effectively has and this container did not.
+    for langdir in /usr/share/locale-langpack/*/; do
+      [ -d "$langdir" ] || continue
+      lang=$(basename "$langdir")
+      mkdir -p "/usr/share/locale/$lang/LC_MESSAGES"
+      cp -n "$langdir"/LC_MESSAGES/*.mo "/usr/share/locale/$lang/LC_MESSAGES/" \
+        2>/dev/null || true
+    done
+
+    # Report the predicate gnome-desktop actually evaluates, every run, pass
+    # or fail. Four guesses at this failure were wrong while the log showed
+    # only a summary; a number here costs one line and settles it.
+    usable=0
+    for loc in $(locale -a 2>/dev/null); do
+      lang=${loc%%_*}; lang=${lang%%.*}
+      if find "/usr/share/locale/$lang/LC_MESSAGES" -name "*.mo" -print -quit \
+           2>/dev/null | grep -q . ; then
+        usable=$((usable + 1))
+      fi
+    done
+    echo "==> locales that gnome-desktop would accept: $usable"
+
     # And that translations survived. A locale with no message catalogue is
     # exactly what gnome-desktop discards, so checking only the charmap would
     # pass on the buildroot that produced the Bail out above.

--- a/tests/test_the_deb_chain_rebuilds_against_the_target.py
+++ b/tests/test_the_deb_chain_rebuilds_against_the_target.py
@@ -437,3 +437,43 @@ def test_no_find_is_piped_into_head_anywhere_in_the_chain():
         "find piped into head dies of SIGPIPE under pipefail; use -print -quit "
         "or collect to a file first:\n" + "\n".join(offenders)
     )
+
+
+def test_translations_are_presented_where_gnome_desktop_looks_for_them():
+    """Read out of gnome-desktop 51~alpha, not guessed.
+
+    libgnome-desktop/gnome-languages.c, collect_locales(), warns only when
+    BOTH collectors fail:
+
+      collect_locales_from_localebin() runs `locale -a` and keeps a locale
+        only if add_locale() accepts it. add_locale rejects any locale with
+        no .mo under GNOMELOCALEDIR/<code>/LC_MESSAGES -- trying the full
+        name, the id, and the bare language code in turn.
+      collect_locales_from_directory() scandirs LIBLOCALEDIR for DIRECTORIES,
+        and locale-gen writes a single locale-archive FILE, so it matches
+        nothing.
+
+    Both false -> the fatal warning -> the test aborts. So the locales were
+    never the problem, and `language-pack-en` was the wrong package: Ubuntu
+    puts catalogues in /usr/share/locale-langpack, which gettext finds via a
+    distro patch and GNOMELOCALEDIR does not name.
+    """
+    text = chain_text()
+    assert "/usr/share/locale-langpack/*/" in text
+    assert "/usr/share/locale/$lang/LC_MESSAGES" in text
+
+
+def test_the_buildroot_reports_the_predicate_it_is_trying_to_satisfy():
+    """A count, every run, pass or fail.
+
+    Four guesses at gnome-desktop:languages were wrong while the log showed a
+    summary line and nothing else. The condition is decidable in one loop, so
+    the buildroot states it rather than leaving the next reader to infer it
+    from a SIGABRT an hour later.
+    """
+    text = chain_text()
+    assert "locales that gnome-desktop would accept" in text
+    # Reported unconditionally -- not inside the failure branch.
+    report = text.index("locales that gnome-desktop would accept")
+    failure = text.index("the buildroot has no translation catalogues")
+    assert report < failure, "the count must print before, and independently of, any failure"


### PR DESCRIPTION
## The number

```
==> locales that gnome-desktop would accept: 23
```

Run [32678117750](https://github.com/tuna-os/tunaos-packages/actions/runs/32678117750), tier-0, 8/8 clean. That count was implicitly **zero** through four previous attempts, and nothing in any log said so.

## What was actually wrong

`gnome-desktop:languages` has been aborting the deb chain since the first full run. Four fixes were tried and all four were wrong. Rather than guess a fifth time I fetched gnome-desktop 51~alpha and read the function that prints the message.

`libgnome-desktop/gnome-languages.c`, `collect_locales()` — the warning fires only when **both** collectors fail:

| collector | what it does | why it failed here |
| --- | --- | --- |
| `collect_locales_from_localebin()` | runs `locale -a`, keeps a locale only if `add_locale()` accepts it | `add_locale` rejects any locale with no `.mo` under `GNOMELOCALEDIR/<code>/LC_MESSAGES` — trying full name, id, then bare language code |
| `collect_locales_from_directory()` | `scandir(LIBLOCALEDIR)` for **directories** | `locale-gen` writes a single locale-*archive* **file**, so it matches nothing |

Both false → `Could not read list of available locales from libc` → glib makes it fatal → `Bail out!`

Two things follow, and both correct my earlier reasoning:

**The message has two clauses and I was reading only the second.** `locale -a` was returning locales the entire time. Every one was discarded for want of catalogues. The locales were never the problem — which is exactly why three rounds of locale work changed nothing.

**`language-pack-en` was the wrong package, for a precise reason.** Ubuntu ships package translations in `/usr/share/locale-langpack/`, which gettext finds via a distro patch. `GNOMELOCALEDIR` names `/usr/share/locale`. I had been installing catalogues where the code does not look.

## The fix

Present the langpack tree at the path the default localedir names — what an sbuild chroot effectively has and a container image does not. Same family as the `ca-certificates` ordering already documented in `run-package-factory-cell.sh`: a buildroot that isn't the chroot upstream assumed.

## The part worth keeping

The buildroot now **reports the predicate every run, pass or fail** — one loop over `locale -a` applying the same condition `add_locale` applies:

```
==> locales that gnome-desktop would accept: N
```

Four guesses were made while the log showed a summary line and nothing else, at ~1h50m per round trip. The condition is decidable in ten lines. Stating it costs nothing and removes the guessing entirely.

## Also removed

`language-pack-en` stays (harmless, and a buildroot should have catalogues), but the commit no longer claims it fixes anything. The two disproved theories are recorded in-place so they aren't revived:

- *"no UTF-8 locale"* — `locale-gen` ran; the failure was unchanged.
- *"the container strips locale data via dpkg path-exclude"* — the image ships no such directives; its own diagnostics printed an empty dpkg-config section.

## Tests

`1111 passed, 1 skipped`. Two new tests: one pins the langpack→localedir presentation with the source-derived reasoning, the other asserts the count is printed **unconditionally** rather than only inside the failure branch.

Full 18-package chain dispatched at this commit. Previous best 16/18; `gnome-control-center` is a pure cascade of `gnome-desktop` and should follow in the same run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAQcBqNdm5dLgJRJgrvTZC)_