### PR TITLE
Stop one target's manifest edit restarting another target's 22-tier chain (both key paths)

### DIFF
--- a/.github/workflows/package-factory-cell.yml
+++ b/.github/workflows/package-factory-cell.yml
@@ -70,7 +70,35 @@ jobs:
               --source-date-epoch "$epoch")
           else
             mapfile -t source_paths < <(jq -r '.source_paths[]' <<<"$CELL")
-            epoch=$(git log -1 --format=%at -- '${{ matrix.manifest }}' "${source_paths[@]}")
+            # The SOURCES only, not the manifest. This epoch is SOURCE_DATE_EPOCH
+            # and it feeds the action key, so including the manifest meant an
+            # edit to ANY target's block moved this cell's key -- and therefore
+            # made `restore-partial-chain-output.py` reject the previous
+            # attempt's partial and restart a 22-tier chain at bootstrap-00.
+            #
+            # Run 32842254545: a 429 MB partial written 34 seconds earlier was
+            # rejected as "action key differs", and 4h01m of build reached
+            # layer-00. #512 had edited the manifest to add `drift:` blocks and
+            # correct `probe_image` -- neither changes what an RPM compiles to.
+            # See #528.
+            #
+            # Scoping the manifest DIGEST alone (tideforge-action-cache.py) does
+            # not achieve this on its own: the epoch is a second, independent
+            # path from the same file into the same key, and it would have kept
+            # invalidating everything while looking fixed.
+            #
+            # Correctness is unaffected. The target's build view is still in the
+            # key via native_inputs, so a change this build actually reads still
+            # re-keys the cell. What changes is that SOURCE_DATE_EPOCH now tracks
+            # the sources it timestamps, which is what it is for.
+            if [ "${#source_paths[@]}" -eq 0 ]; then
+              echo "::error::cell '${{ matrix.id }}' declares no source_paths, so" \
+                   "SOURCE_DATE_EPOCH cannot be derived from them; refusing rather" \
+                   "than falling back to the repository's last commit, which would" \
+                   "re-key this cell on EVERY commit"
+              exit 1
+            fi
+            epoch=$(git log -1 --format=%at -- "${source_paths[@]}")
             args=()
             for path in "${source_paths[@]}"; do args+=(--input "$path"); done
             payload=$(python3 scripts/tideforge-action-cache.py native-key \

--- a/scripts/tideforge-action-cache.py
+++ b/scripts/tideforge-action-cache.py
@@ -191,13 +191,42 @@ def native_action_inputs(args: argparse.Namespace) -> dict[str, Any]:
     if int(args.source_date_epoch) <= 0:
         raise SystemExit("SOURCE_DATE_EPOCH must be a positive integer")
     inputs = []
-    for raw in [args.manifest, *args.input]:
+    # The manifest is hashed as THIS TARGET'S SLICE, not as a file, exactly as
+    # the target_queue and dependency_tree contracts below already are.
+    #
+    # It used to be `digest_path(manifest)` -- the whole file, every target --
+    # which silently defeated #473. That change narrowed the manifest's
+    # contribution to `build_view(target)` precisely so a field no build reads
+    # could not rebuild a cell, and then the whole-file digest put every other
+    # target's fields straight back into the key.
+    #
+    # Measured cost, run 32842254545: #512 edited this manifest to add `drift:`
+    # blocks and correct `probe_image` -- neither of which changes what any
+    # hummingbird RPM compiles to. The key moved, a 429 MB partial written 34
+    # seconds earlier was rejected as "action key differs", and a 22-tier chain
+    # restarted at bootstrap-00. Four hours of runner time reached layer-00.
+    # See #528.
+    #
+    # `schema` rides along because it decides how every other field is read; a
+    # schema bump must still invalidate. What is dropped is other targets'
+    # blocks and `upstreams`, plus `dependency_catalog`, which native targets
+    # are already documented above as not consuming.
+    for raw in [*args.input]:
         path = pathlib.Path(raw)
         try:
             relative = path.resolve().relative_to(root.resolve()).as_posix()
         except ValueError as exc:
             raise SystemExit(f"native input must be inside repository root: {path}") from exc
         inputs.append({"path": relative, "digest": digest_path(path)})
+    manifest_path = pathlib.Path(args.manifest)
+    try:
+        manifest_relative = manifest_path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError as exc:
+        raise SystemExit(f"native input must be inside repository root: {manifest_path}") from exc
+    inputs.append({
+        "path": manifest_relative,
+        "digest": digest_json({"schema": factory.get("schema"), "target": selected}),
+    })
     contracts = []
     if args.dependency_tree:
         path = pathlib.Path(args.dependency_tree)

--- a/tests/test_one_targets_manifest_edit_cannot_restart_anothers_chain.py
+++ b/tests/test_one_targets_manifest_edit_cannot_restart_anothers_chain.py
@@ -1,0 +1,160 @@
+"""Editing one target's manifest block must not re-key another target's cell.
+
+A build-chain cell's action key decides whether the resume in
+`restore-partial-chain-output.py` accepts the previous attempt's partial. If
+the key moves, the partial is rejected -- "action key differs ... building
+from scratch" -- and a 22-tier chain restarts at bootstrap-00.
+
+`manifests/package-factory.yaml` is ONE file describing every target, and its
+whole-file digest used to be in `native_inputs`. So an edit for any target
+re-keyed every cell of every other target.
+
+Measured, run 32842254545 (hummingbird-x86_64):
+
+    11:27:19  [resume] found `hummingbird-x86_64-partial` from 11:26:17Z (429 MB)
+    11:27:24  [resume] action key differs ... building from scratch
+    11:40:54  ===== Tier: layer-00 =====        <- still here 3h48m later
+
+#512 had edited the manifest to add `drift:` blocks and correct `probe_image`.
+Neither changes what a single hummingbird RPM compiles to. Four hours of
+runner time reached tier 5 of 22. See #528.
+
+This also silently defeated #473, which had narrowed the manifest's
+contribution to `build_view(target)` for exactly this reason -- and then the
+whole-file digest reinstated every other target's fields.
+
+The pair of tests below is the point. Isolation alone is easy to get by
+dropping the manifest from the key entirely, which would be a cache that
+cannot tell two different recipes apart -- so the second test requires the key
+to STILL move when this target's own build-relevant fields change.
+"""
+from __future__ import annotations
+
+import copy
+import importlib.util
+import pathlib
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "manifests" / "package-factory.yaml"
+
+
+def cache_module():
+    spec = importlib.util.spec_from_file_location(
+        "tideforge_action_cache", ROOT / "scripts" / "tideforge-action-cache.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def real_manifest() -> dict:
+    return yaml.safe_load(MANIFEST.read_text(encoding="utf-8"))
+
+
+def native_inputs_for(manifest: dict, target: str, tmp_path) -> dict:
+    """Call native_action_inputs against a manifest written inside the repo.
+
+    The renderer digests are read relative to --root, so root must be the real
+    repository; the manifest therefore has to live inside it too. It is written
+    to a uniquely-named scratch file and removed afterwards.
+    """
+    cache = cache_module()
+    scratch = ROOT / f".manifest-key-probe-{tmp_path.name}.yaml"
+    order = ROOT / f".build-order-probe-{tmp_path.name}.yml"
+    scratch.write_text(yaml.safe_dump(manifest, sort_keys=True), encoding="utf-8")
+    order.write_text("tiers: []\n", encoding="utf-8")
+
+    class Args:
+        pass
+
+    args = Args()
+    args.root = str(ROOT)
+    args.factory = str(scratch)
+    args.manifest = str(scratch)
+    args.input = [str(order)]
+    args.target = target
+    args.arch = "x86_64"
+    args.image = "example.invalid/builder@sha256:" + "c" * 64
+    args.identity = f"{target}-x86_64"
+    args.dependency_tree = ""
+    args.target_queue = ""
+    args.track = "stable"
+    args.series = "1"
+    args.source_date_epoch = "1787654862"
+    try:
+        return cache.native_action_inputs(args)
+    finally:
+        scratch.unlink(missing_ok=True)
+        order.unlink(missing_ok=True)
+
+
+def key_of(manifest: dict, target: str, tmp_path) -> str:
+    cache = cache_module()
+    return cache.action_key(native_inputs_for(manifest, target, tmp_path))
+
+
+def a_native_target(manifest: dict) -> str:
+    """Pick a real target this key path supports, so the fixture is not fiction."""
+    for name, block in manifest["targets"].items():
+        if "hummingbird" in name:
+            return name
+    return next(iter(manifest["targets"]))
+
+
+def test_editing_another_targets_block_leaves_this_key_alone(tmp_path) -> None:
+    manifest = real_manifest()
+    target = a_native_target(manifest)
+    others = [t for t in manifest["targets"] if t != target]
+    assert others, "manifest has only one target; this test proves nothing"
+
+    before = key_of(manifest, target, tmp_path)
+
+    edited = copy.deepcopy(manifest)
+    # The shape of #512's change: a field on a DIFFERENT target.
+    victim = others[0]
+    edited["targets"][victim]["probe_image"] = "example.invalid/probe@sha256:" + "d" * 64
+    edited["targets"][victim].setdefault("gap_measurement", {})["drift"] = {"mode": "propose"}
+
+    after = key_of(edited, target, tmp_path)
+    assert before == after, (
+        f"editing {victim}'s block moved {target}'s action key, so its partial "
+        "is rejected and a 22-tier chain restarts at bootstrap-00 (#528)"
+    )
+
+
+def test_editing_this_targets_own_build_fields_still_moves_the_key(tmp_path) -> None:
+    """The guard that stops the fix becoming a cache that cannot tell recipes apart."""
+    manifest = real_manifest()
+    target = a_native_target(manifest)
+    before = key_of(manifest, target, tmp_path)
+
+    edited = copy.deepcopy(manifest)
+    edited["targets"][target]["build_repositories"] = [
+        {"name": "invented", "baseurl": "https://example.invalid/repo", "priority": 5}
+    ]
+
+    after = key_of(edited, target, tmp_path)
+    assert before != after, (
+        "changing this target's own build repositories left the key unchanged; "
+        "the cache can no longer tell two different recipes apart, which is "
+        "far worse than the restart it was meant to prevent"
+    )
+
+
+def test_a_schema_bump_still_moves_the_key(tmp_path) -> None:
+    """`schema` decides how every other field is read, so it must stay pinned."""
+    manifest = real_manifest()
+    target = a_native_target(manifest)
+    before = key_of(manifest, target, tmp_path)
+
+    edited = copy.deepcopy(manifest)
+    edited["schema"] = int(manifest.get("schema", 1)) + 1
+
+    after = key_of(edited, target, tmp_path)
+    assert before != after, (
+        "a manifest schema bump no longer invalidates the key, so cells would "
+        "reuse output built under different field semantics"
+    )

--- a/tests/test_one_targets_manifest_edit_cannot_restart_anothers_chain.py
+++ b/tests/test_one_targets_manifest_edit_cannot_restart_anothers_chain.py
@@ -23,6 +23,19 @@ This also silently defeated #473, which had narrowed the manifest's
 contribution to `build_view(target)` for exactly this reason -- and then the
 whole-file digest reinstated every other target's fields.
 
+The manifest reaches the key by TWO independent paths, and fixing one while
+leaving the other looks exactly like a fix while changing nothing:
+
+  * `native_inputs[].digest` -- the file's content;
+  * `reproducibility.source_date_epoch` -- computed in package-factory-cell.yml
+    as `git log -1 --format=%at -- <manifest> <source_paths>`, so any commit
+    touching the manifest bumps it.
+
+The first version of this file held the epoch constant and so proved only the
+first half, while its name claimed the whole thing. Both are closed now, and
+`test_the_epoch_is_not_derived_from_the_manifest` is what keeps the second one
+closed.
+
 The pair of tests below is the point. Isolation alone is easy to get by
 dropping the manifest from the key entirely, which would be a cache that
 cannot tell two different recipes apart -- so the second test requires the key
@@ -157,4 +170,46 @@ def test_a_schema_bump_still_moves_the_key(tmp_path) -> None:
     assert before != after, (
         "a manifest schema bump no longer invalidates the key, so cells would "
         "reuse output built under different field semantics"
+    )
+
+
+def test_the_epoch_is_not_derived_from_the_manifest() -> None:
+    """The second path from the manifest into the key.
+
+    The digest fix above is invisible without this one: the epoch is
+    SOURCE_DATE_EPOCH *and* an action-key input, so while it was computed over
+    the manifest, every edit re-keyed every cell no matter how well the digest
+    was scoped. A test that only checked the digest would have passed on a
+    change that fixed nothing in production.
+    """
+    workflow = (ROOT / ".github" / "workflows" / "package-factory-cell.yml").read_text(
+        encoding="utf-8")
+    line = next(
+        l for l in workflow.splitlines()
+        if "epoch=$(git log" in l and "source_paths" in l
+    )
+    assert "matrix.manifest" not in line, (
+        "SOURCE_DATE_EPOCH is derived from the manifest again, so an edit to "
+        "ANY target's block re-keys this cell and its partial is rejected "
+        f"(#528). Line: {line.strip()}"
+    )
+
+
+def test_an_empty_source_path_list_fails_loudly() -> None:
+    """`git log -1 --format=%at --` with no paths returns the repo's last commit.
+
+    That would re-key every cell on every commit -- strictly worse than the
+    bug being fixed -- and it would do so silently, because an epoch is just a
+    number. Every build-chain cell declares source_paths today; the guard is
+    for the one that some day does not.
+    """
+    workflow = (ROOT / ".github" / "workflows" / "package-factory-cell.yml").read_text(
+        encoding="utf-8")
+    epoch_at = workflow.index('epoch=$(git log -1 --format=%at -- "${source_paths[@]}")')
+    preceding = workflow[:epoch_at]
+    guard = preceding.rindex('if [ "${#source_paths[@]}" -eq 0 ]')
+    assert "exit 1" in preceding[guard:], (
+        "the empty-source_paths guard no longer exits, so a cell without "
+        "sources would silently take the repository's last commit as its "
+        "SOURCE_DATE_EPOCH and re-key on every push"
     )


### PR DESCRIPTION
Closes the manifest half of #528 — **both** paths from the manifest into the action key. The second commit exists because the first one's test proved less than its name claimed; that story is below, because it is the more useful part of this PR.

## The chain has not been failing to finish; it has been failing to accumulate

Hummingbird progress has been tracked as "N packages left" — 673 total, 570 served, 103 left. That measures the **served index**, cumulative across past publishes. It says nothing about what a chain run achieves, and the two have come apart completely.

Run [32842254545](https://github.com/tuna-os/tunaos-packages/actions/runs/32842254545) built for **4h01m** and reached **tier 5 of 22**:

```
11:27:19  [resume] found `hummingbird-x86_64-partial` from 11:26:17Z (429 MB)
11:27:24  [resume] action key differs
          (partial  sha256:f2182baa…, this cell sha256:ba5ba638…)
          the inputs changed, so building from scratch
11:28:58  ===== Tier: bootstrap-00 =====
11:40:54  ===== Tier: layer-00 =====
          (still in layer-00 when cancelled at 15:28:55)
```

`Skipping: 0`. It rejected a 429 MB partial written **thirty-four seconds earlier** and rebuilt from nothing. #512 had edited the manifest to add `drift:` blocks and correct `probe_image` — neither of which changes what a single hummingbird RPM compiles to.

## The manifest reached the key by two independent paths

| path | where | fixed in |
|---|---|---|
| whole-file content digest | `native_inputs[].digest` in `tideforge-action-cache.py` | `e426fe0` |
| `git log -1 --format=%at -- <manifest> …` | `reproducibility.source_date_epoch`, set in `package-factory-cell.yml` | `9ee2ac3` |

**`e426fe0` alone would have changed nothing in production**, and its test passed anyway — because it supplied `source_date_epoch` as a fixed literal. Fixing one path while the other still carried the whole file is indistinguishable from a fix, right up until the next chain restarts.

That is worth naming plainly: not a check that examines nothing, but a check that examines one of two things and is named for both. It survived writing, mutation-testing, and a published PR description before a second read caught it.

### `e426fe0` — scope the digest

The manifest is now hashed as this target's slice, exactly as the two contract inputs in the same function already are:

```python
# existing, target_queue
"digest": digest_json({"schema": data.get("schema"), "queue": queues[args.target]})

# now, manifest
"digest": digest_json({"schema": factory.get("schema"), "target": selected})
```

This restores **#473**, which had narrowed the manifest's contribution to `build_view(target)` for exactly this reason — its comment reads "hashing every field meant a bucket write path or a reporting label rebuilt every cell on the target from scratch" — and was then silently defeated by the whole-file digest sitting beside the narrowed view in the same key.

`schema` rides along because it decides how every other field is read. Dropped: other targets' blocks and `upstreams`. `dependency_catalog` was already documented in this function as something native targets do not consume.

### `9ee2ac3` — scope the epoch

```bash
epoch=$(git log -1 --format=%at -- "${source_paths[@]}")     # sources only
```

Correctness is unaffected: the target's build view is still in the key via `native_inputs`, so any manifest field this build actually reads still re-keys the cell. What changes is that `SOURCE_DATE_EPOCH` now tracks the sources it timestamps — an unchanged source tree keeps its epoch across manifest edits, exactly as #477 made it keep its epoch across rebases.

`git log -1 --format=%at --` with **no** paths returns the repository's last commit, which would re-key every cell on every push — strictly worse than the bug, and silent, since an epoch is just a number. All **36** build-chain cells declare `source_paths` today (verified against the live planner), so the guard is for the one that some day does not; it fails loudly.

## Tests

Five. The isolation test is only meaningful alongside the ones that require the key to **still move**, because isolation alone is trivially achieved by dropping the manifest entirely — a cache that cannot tell two recipes apart, far worse than the restarts it prevents.

| test | asserts |
|---|---|
| editing **another** target's block | key **unchanged** |
| editing **this** target's `build_repositories` | key **still moves** |
| a `schema` bump | key **still moves** |
| the epoch line | does not mention `matrix.manifest` |
| the empty-`source_paths` guard | still exits |

The key tests compute the real key through `native_action_inputs` against the **real manifest**, not a fixture, so a reshape of the file fails them loudly rather than leaving a stale copy under test.

Mutation-verified, each caught by a distinct test: reverting to `digest_path(manifest)` fails isolation; dropping the manifest entirely fails the schema pin; dropping `schema` fails the schema pin; **restoring the manifest to the epoch fails two, including cross-target isolation** — the end-to-end signal that test should always have carried; neutering the guard fails one.

Full suite **1364 passed, 1 skipped**.

## Still open

`scripts/build-chain.sh` remains in `renderer_inputs`, deliberately untouched. It genuinely renders every package, so hashing it is defensible — but it means **any factory improvement costs a full chain restart**, and that is not hypothetical: #512's mock root-cache change, a pure speedup with no effect on any package's contents, invalidated every partial in the repository. Measured in #528; it needs its own decision rather than being folded in here.
