### PR TITLE
Publish the factory measurement, and a browser for repo.tunaos.org

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,6 +18,13 @@
 # The push trigger keys on the files the page is rendered FROM, so a merged
 # refresh republishes immediately and a merge that touches nothing relevant
 # does not spend a deploy.
+#
+# The package browser is the exception, and it is why there is ALSO a cron.
+# Its source is not a file in git at all -- it is what repo.tunaos.org is
+# serving, read at deploy time by scripts/snapshot-repo-contents.py. The
+# repository changes when a PUBLISH workflow runs, and no commit records
+# that, so for the browser a timer is the only signal there is. Daily, which
+# is the granularity the page reports its own age at.
 name: Pages
 
 on:
@@ -39,6 +46,9 @@ on:
       - "manifests/package-builds.yaml"
       - "scripts/render-factory-site.py"
       - ".github/workflows/pages.yml"
+  # Refreshes the package browser against the live repo; see the note above.
+  schedule:
+    - cron: "17 6 * * *"
   workflow_dispatch:
 
 permissions:
@@ -60,6 +70,14 @@ jobs:
           python-version: "3.14"
       - name: Install deps
         run: pip install --quiet pyyaml
+      # Reads every published_index the contract declares. An index that
+      # cannot be read is recorded in the snapshot as unreachable and named
+      # on the page -- it does NOT fail this step, because one dead prefix
+      # must not take the whole site down. Only an outright crash fails here,
+      # and that is deliberate: it means the deploy always carries a browser,
+      # so the page can never quietly lose it and look complete.
+      - name: Snapshot what the repo is actually serving
+        run: ./scripts/snapshot-repo-contents.py --out docs/repo-contents.json
       - name: Render
         run: ./scripts/render-factory-site.py --out site
       - name: Upload the page as a Pages artifact

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,93 @@
+# Publish the factory status site to GitHub Pages.
+#
+# docs/FACTORY-STATUS.md answers "what has the factory built" for someone
+# already reading the repository. This publishes the same measurements to a URL
+# so the answer is reachable without a checkout, and reachable by people who
+# are not going to read YAML.
+#
+# The page is a VIEW of artifacts the factory already generates
+# (docs/factory-status.json, manifests/package-factory.yaml,
+# manifests/package-builds.yaml). It is never a second source of truth: the
+# renderer reads those files and nothing else, so the site cannot drift from
+# the measurement -- it can only be stale, which it says about itself.
+#
+# WHEN IT REPUBLISHES. Not on a timer of its own. The daily Factory Status run
+# lands its refresh through a bot PR (see factory-status.yml), so the data on
+# main changes when that PR merges, at an hour no cron can predict. Publishing
+# on a schedule would therefore either race the merge or sit hours behind it.
+# The push trigger keys on the files the page is rendered FROM, so a merged
+# refresh republishes immediately and a merge that touches nothing relevant
+# does not spend a deploy.
+name: Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/factory-status.json"
+      - "manifests/package-factory.yaml"
+      - "manifests/package-builds.yaml"
+      - "scripts/render-factory-site.py"
+      - ".github/workflows/pages.yml"
+  # Structure check only on a PR: renders the page and fails if the renderer
+  # cannot read the current data. No deploy -- a PR must not be able to
+  # publish to the live site.
+  pull_request:
+    paths:
+      - "docs/factory-status.json"
+      - "manifests/package-factory.yaml"
+      - "manifests/package-builds.yaml"
+      - "scripts/render-factory-site.py"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Never cancel a deploy in flight: a half-published site is worse than one
+# republish landing a minute late.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.14"
+      - name: Install deps
+        run: pip install --quiet pyyaml
+      - name: Render
+        run: ./scripts/render-factory-site.py --out site
+      - name: Upload the page as a Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    # A PR renders (above) but never reaches here.
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      # Turn Pages on if it is not already, and point it at Actions rather
+      # than a branch. Without this the FIRST deploy fails with "Pages is not
+      # enabled" and someone has to go click a settings toggle -- which makes
+      # the publish manual, which is the one thing this workflow exists to
+      # avoid. It is idempotent: on every later run it just reads back the
+      # settings that are already correct.
+      - uses: actions/configure-pages@v5
+        with:
+          enablement: true
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ hummingbird-imports.json
 
 # Cloudflare Worker local build output
 /dist/
+
+site/

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,8 @@ hummingbird-imports.json
 /dist/
 
 site/
+
+# Snapshotted from the live repo at deploy time by
+# scripts/snapshot-repo-contents.py -- megabytes that change daily and are
+# never read from git. The Pages build regenerates it; see .github/workflows/pages.yml.
+docs/repo-contents.json

--- a/docs/PACKAGE_FACTORY.md
+++ b/docs/PACKAGE_FACTORY.md
@@ -88,6 +88,19 @@ and no longer is as **REGRESSED** (the repo-wipe shape, caught at
 measurement time — #519 was found by exactly this check's first run),
 and alarms when the refresh itself stops landing.
 
+That measurement is also published as a browsable page
+(`scripts/render-factory-site.py` -> GitHub Pages, by `pages.yml`), so
+"what has the factory built, for which targets, and what is it still
+missing" is answerable without a checkout. The page is a VIEW and never a
+second source: it renders `docs/factory-status.json`,
+`manifests/package-factory.yaml` and `manifests/package-builds.yaml` and
+nothing else, it lists every declared-but-unmeasurable target with the
+reason so coverage is never mistaken for the whole picture, and it says so
+in its own header when the measurement behind it has gone stale. It
+republishes when the data it renders changes rather than on a schedule,
+because the daily refresh lands through a bot PR at an hour no cron can
+predict.
+
 Around the build loop sit four preventive checks adapted from the
 sandogasa toolset (provenance, incident history, and the
 capability-per-format matrix in `SANDOGASA-ADAPTATIONS.md`), built on

--- a/docs/PACKAGE_FACTORY.md
+++ b/docs/PACKAGE_FACTORY.md
@@ -101,6 +101,20 @@ republishes when the data it renders changes rather than on a schedule,
 because the daily refresh lands through a bot PR at an hour no cron can
 predict.
 
+The same site carries a **package browser** for `repo.tunaos.org` itself,
+which answers a different question: not "how much of the plan is built"
+but "what is actually IN the repository" — until now answerable only by
+adding the repo to a machine and asking dnf, i.e. by trusting it first in
+order to find out what it holds. `scripts/snapshot-repo-contents.py`
+reads every `published_index` the contract declares, through the same
+format-neutral index layer the hygiene checks use, at the same URLs a
+package manager would use. So the listing cannot show a package the repo
+does not serve, nor hide one it does. An index that cannot be read is
+recorded and named on the page with its reason rather than dropped —
+silently missing names is exactly what #519 looked like from outside — and
+one dead prefix does not fail the deploy. This half DOES run on a timer,
+for the opposite reason to the status page: its source is not a file in
+git, so no commit marks the moment a publish wave changes what is served.
 Around the build loop sit four preventive checks adapted from the
 sandogasa toolset (provenance, incident history, and the
 capability-per-format matrix in `SANDOGASA-ADAPTATIONS.md`), built on

--- a/scripts/apt_packages.py
+++ b/scripts/apt_packages.py
@@ -147,6 +147,8 @@ def iter_rows(text: str):
             "arch": stanza.get("Architecture", ""),
             "evr": stanza.get("Version", ""),
             "srpm": stanza.get("Source", name).split(" ")[0],
+            # Pool path relative to the index URL; see repo_index's note.
+            "location": stanza.get("Filename"),
             # Flat repos carry no Contents index, so file-level conflict
             # checking is not measurable here; recorded in the hygiene
             # tool's scope notes rather than silently pretended.

--- a/scripts/render-factory-site.py
+++ b/scripts/render-factory-site.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python3
+"""Render the factory's own measurements into a browsable page.
+
+`docs/FACTORY-STATUS.md` answers "what has the factory built" for someone
+already reading the repository. Nothing answers it for someone who is not:
+the contract lives in `manifests/package-factory.yaml`, the measurement in
+`docs/factory-status.json`, the build cells in `manifests/package-builds.yaml`,
+and reconciling the three is a job people were doing by hand.
+
+This renders all three into one self-contained page for GitHub Pages. It is a
+VIEW, never a source: every number here is read from the artifacts the factory
+already generates, so the page cannot claim a coverage the measurement does
+not support. If the measurement is stale the page says so in the header rather
+than presenting old numbers as current -- the same reasoning as the staleness
+alarm in scripts/factory-status.py.
+
+Deliberately dependency-free output: one HTML file, styles inlined, no CDN, no
+build toolchain. Pages serves it as-is and it opens from disk.
+
+Usage:
+
+    scripts/render-factory-site.py [--out site] [--now ISO8601]
+
+`--now` exists so the tests can pin "days since measurement" without freezing
+the clock globally.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import html
+import json
+import pathlib
+import sys
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+STATUS_JSON = ROOT / "docs" / "factory-status.json"
+CONTRACT = ROOT / "manifests" / "package-factory.yaml"
+CELLS = ROOT / "manifests" / "package-builds.yaml"
+
+# How old a measurement may be before the page stops presenting it as current.
+# Matches the ::warning threshold in scripts/factory-status.py so the page and
+# the workflow cannot disagree about what "stale" means.
+STALE_AFTER_DAYS = 2
+
+# Palette parameters, taken unchanged from the data-viz reference instance.
+# Only two encodings are used and neither is categorical:
+#   * built-vs-remaining is part-to-whole, so it takes the SEQUENTIAL hue
+#     (one blue) against a neutral remainder -- target identity is carried by
+#     the row label, never by colour, so no per-target hue is invented and
+#     there is no categorical palette to validate;
+#   * state takes the reserved status palette, always with an icon and a word
+#     beside it so the colour never carries the meaning alone.
+TOKENS_LIGHT = {
+    "surface-1": "#fcfcfb",
+    "surface-2": "#f0efec",
+    "surface-3": "#e4e3df",
+    "border": "#d9d8d3",
+    "text-primary": "#0b0b0b",
+    "text-secondary": "#52514e",
+    "text-muted": "#77756f",
+    "fill": "#2a78d6",
+    "fill-soft": "#cde2fb",
+    "good": "#0ca30c",
+    "warning": "#fab219",
+    "serious": "#ec835a",
+    "critical": "#d03b3b",
+}
+TOKENS_DARK = {
+    "surface-1": "#1a1a19",
+    "surface-2": "#242423",
+    "surface-3": "#2e2e2c",
+    "border": "#3a3a37",
+    "text-primary": "#ffffff",
+    "text-secondary": "#c3c2b7",
+    "text-muted": "#96958c",
+    "fill": "#3987e5",
+    "fill-soft": "#184f95",
+    "good": "#0ca30c",
+    "warning": "#fab219",
+    "serious": "#ec835a",
+    "critical": "#d03b3b",
+}
+
+# Status is icon + label + colour, never colour alone.
+STATE_ICONS = {
+    "good": "●",
+    "warning": "▲",
+    "serious": "▲",
+    "critical": "■",
+    "muted": "○",
+}
+
+
+def esc(value) -> str:
+    return html.escape(str(value), quote=True)
+
+
+def load(path: pathlib.Path):
+    text = path.read_text(encoding="utf-8")
+    return json.loads(text) if path.suffix == ".json" else yaml.safe_load(text)
+
+
+def parse_iso(stamp: str) -> dt.datetime:
+    value = dt.datetime.fromisoformat(stamp)
+    return value if value.tzinfo else value.replace(tzinfo=dt.timezone.utc)
+
+
+def days_between(later: dt.datetime, earlier: dt.datetime) -> int:
+    return max(0, (later - earlier).days)
+
+
+def pill(state: str, label: str) -> str:
+    """A state chip: colour, icon and word together."""
+    return (f'<span class="pill pill-{esc(state)}">'
+            f'<span class="ico" aria-hidden="true">{STATE_ICONS[state]}</span>'
+            f"{esc(label)}</span>")
+
+
+def delta_text(value: int) -> str:
+    """Signed movement. Zero reads as 'no change', not as '+0'."""
+    if value > 0:
+        return f"+{value}"
+    return str(value) if value else "no change"
+
+
+def bar(built: int, needed: int) -> str:
+    """Part-to-whole, one hue against a neutral remainder.
+
+    Direct-labelled rather than legended: with two segments and the numbers
+    written beside the bar, a legend box would restate what the labels say.
+    """
+    total = built + needed
+    percent = (built / total * 100) if total else 0.0
+    return (
+        f'<div class="bar" role="img" aria-label="{built} of {total} built">'
+        f'<div class="bar-fill" style="width:{percent:.1f}%"></div>'
+        f"</div>"
+    )
+
+
+def coverage_rows(status: dict) -> list[dict]:
+    """One row per measured target x architecture, in a stable order."""
+    rows = []
+    trend_rows = (status.get("trend") or {}).get("rows") or {}
+    for target in sorted(status.get("targets") or {}):
+        for arch in sorted(status["targets"][target]):
+            data = status["targets"][target][arch]
+            built = len(data.get("built") or [])
+            needed = len(data.get("needed") or [])
+            rows.append({
+                "target": target,
+                "arch": arch,
+                "built": built,
+                "needed": needed,
+                "indexes": data.get("indexes") or [],
+                "trend": trend_rows.get(f"{target}/{arch}") or {},
+            })
+    return rows
+
+
+def render_hero(status: dict, contract: dict, rows: list[dict],
+                now: dt.datetime) -> str:
+    declared = len(contract.get("targets") or {})
+    measured = len({r["target"] for r in rows})
+    built = sum(r["built"] for r in rows)
+    needed = sum(r["needed"] for r in rows)
+    measured_at = parse_iso(status["measured_at"])
+    age = days_between(now, measured_at)
+
+    stale = ""
+    if age > STALE_AFTER_DAYS:
+        stale = (
+            f'<p class="alarm">{pill("critical", "Stale measurement")}'
+            f" These numbers are {age} days old. The daily refresh is not"
+            " landing, so treat every figure below as history rather than"
+            " as the factory's current state.</p>"
+        )
+
+    plural = "" if age == 1 else "s"
+    age_note = "" if age == 0 else f" &middot; {age} day{plural} ago"
+
+    tiles = [
+        ("Targets declared", declared, "in the factory contract"),
+        ("Targets measured", measured, "serving an index that resolves"),
+        ("Packages built", built, "across every measured target x arch"),
+        ("Still needed", needed, "declared in a catalog, not yet served"),
+    ]
+    cells = "".join(
+        f'<div class="tile"><div class="tile-n">{value}</div>'
+        f'<div class="tile-k">{esc(label)}</div>'
+        f'<div class="tile-s">{esc(sub)}</div></div>'
+        for label, value, sub in tiles
+    )
+    return (
+        f'<section class="hero"><div class="tiles">{cells}</div>{stale}'
+        f'<p class="measured">Measured '
+        f'<time datetime="{esc(status["measured_at"])}">'
+        f'{esc(measured_at.strftime("%Y-%m-%d %H:%M UTC"))}</time>'
+        f"{age_note}</p></section>"
+    )
+
+
+def render_coverage(rows: list[dict]) -> str:
+    if not rows:
+        return ""
+    cards = []
+    for row in rows:
+        trend = row["trend"]
+        badges = []
+        if trend.get("new"):
+            badges.append(pill("good", "newly measured"))
+        for name in (trend.get("regressed") or [])[:1]:
+            count = len(trend["regressed"])
+            label = (f"REGRESSED: {count} name{'' if count == 1 else 's'} "
+                     f"no longer served")
+            badges.append(pill("critical", label))
+        stalled = trend.get("stalled")
+        if stalled:
+            prefix = "≥ " if stalled.get("at_least") else ""
+            badges.append(pill(
+                "warning", f"flat {prefix}{stalled['days']} days"))
+        built_delta = trend.get("built_delta")
+        if built_delta:
+            badges.append(pill("good" if built_delta > 0 else "serious",
+                               f"built {delta_text(built_delta)}"))
+
+        indexes = "".join(
+            f'<li><a href="{esc(i["baseurl"])}">{esc(i["baseurl"])}</a>'
+            f' <span class="dim">{i.get("package_names", 0)} names</span></li>'
+            for i in row["indexes"]
+        )
+        total = row["built"] + row["needed"]
+        cards.append(
+            f'<article class="card">'
+            f'<h3>{esc(row["target"])} <span class="arch">'
+            f'{esc(row["arch"])}</span></h3>'
+            f'<p class="counts"><strong>{row["built"]}</strong> built'
+            f'<span class="dim"> of {total}</span>'
+            f'<span class="need">{row["needed"]} needed</span></p>'
+            f'{bar(row["built"], row["needed"])}'
+            f'<div class="badges">{"".join(badges)}</div>'
+            f'{f"<ul class=idx>{indexes}</ul>" if indexes else ""}'
+            f"</article>"
+        )
+
+    # A table view is not optional: it is how the same numbers stay readable
+    # without colour, and how they can be copied.
+    body = "".join(
+        f"<tr><td>{esc(r['target'])}</td><td>{esc(r['arch'])}</td>"
+        f"<td class=num>{r['built']}</td><td class=num>{r['needed']}</td>"
+        f"<td class=num>{r['built'] + r['needed']}</td>"
+        f"<td class=num>{delta_text(r['trend'].get('built_delta') or 0)}</td>"
+        f"</tr>"
+        for r in rows
+    )
+    table = (
+        '<details class="tableview"><summary>Table view</summary>'
+        "<table><thead><tr><th>Target</th><th>Arch</th><th>Built</th>"
+        "<th>Needed</th><th>Catalog</th><th>Change</th></tr></thead>"
+        f"<tbody>{body}</tbody></table></details>"
+    )
+    return (f'<section id="coverage"><h2>Coverage</h2>'
+            f'<div class="grid">{"".join(cards)}</div>{table}</section>')
+
+
+def render_unmeasured(status: dict) -> str:
+    unmeasured = status.get("unmeasured_targets") or {}
+    if not unmeasured:
+        return ""
+    items = "".join(
+        f"<li><strong>{esc(name)}</strong> "
+        f'<span class="dim">{esc(data.get("format", "?"))} &middot; '
+        f'{data.get("catalog_entries", 0)} catalog entries</span><br>'
+        f'<span class="reason">{esc(data.get("reason", ""))}</span></li>'
+        for name, data in sorted(unmeasured.items())
+    )
+    return (
+        '<section id="unmeasured"><h2>Declared but unmeasured</h2>'
+        "<p class=lede>These targets exist in the contract and have catalog "
+        "entries, but nothing here can be measured yet. They are listed so "
+        "the coverage above is never mistaken for the whole picture.</p>"
+        f"<ul class=gaps>{items}</ul></section>"
+    )
+
+
+def render_desktop(status: dict) -> str:
+    coverage = status.get("desktop_coverage") or {}
+    if not coverage:
+        return ""
+    blocks = []
+    for target, data in sorted(coverage.items()):
+        rows = []
+        for arch, desktops in sorted((data.get("architectures") or {}).items()):
+            for desktop, info in sorted(desktops.items()):
+                present, roots = info.get("present", 0), info.get("roots", 0)
+                missing = info.get("missing") or []
+                state = "good" if present >= roots and roots else "warning"
+                rows.append(
+                    f"<tr><td>{esc(arch)}</td><td>{esc(desktop)}</td>"
+                    f"<td class=num>{present}/{roots}</td>"
+                    f"<td>{pill(state, 'complete' if state == 'good' else f'{len(missing)} missing')}"
+                    f"</td></tr>"
+                )
+        blocks.append(
+            f"<h3>{esc(target)} <span class=dim>"
+            f'{esc(data.get("roots_manifest", ""))}</span></h3>'
+            "<table><thead><tr><th>Arch</th><th>Desktop</th>"
+            "<th>Roots</th><th>State</th></tr></thead>"
+            f"<tbody>{''.join(rows)}</tbody></table>"
+        )
+    return (f'<section id="desktops"><h2>Desktop closures</h2>'
+            f'{"".join(blocks)}</section>')
+
+
+def render_config(contract: dict, cells: dict) -> str:
+    rows = []
+    for name, target in sorted((contract.get("targets") or {}).items()):
+        status_name = target.get("status", "unknown")
+        state = {"supported": "good"}.get(
+            status_name.split()[0] if status_name else "", "muted")
+        index = target.get("published_index") or {}
+        served = sum(len(v) if isinstance(v, list) else 1
+                     for v in index.values())
+        rows.append(
+            f"<tr><td><strong>{esc(name)}</strong></td>"
+            f"<td>{pill(state, status_name)}</td>"
+            f"<td>{esc(target.get('format', ''))}</td>"
+            f"<td>{esc(target.get('repository', ''))}</td>"
+            f"<td>{esc(', '.join(target.get('architectures') or []))}</td>"
+            f"<td>{esc(target.get('buildroot', ''))}</td>"
+            f'<td class=num>{served or "&mdash;"}</td></tr>'
+        )
+    targets_table = (
+        "<table><thead><tr><th>Target</th><th>Status</th><th>Format</th>"
+        "<th>Repository</th><th>Architectures</th><th>Buildroot</th>"
+        "<th>Indexes</th></tr></thead>"
+        f"<tbody>{''.join(rows)}</tbody></table>"
+    )
+
+    cell_rows = []
+    for cell in sorted(cells.get("native_builds") or [],
+                       key=lambda c: (c.get("family", ""), c.get("id", ""))):
+        enabled = cell.get("enabled", True)
+        cell_rows.append(
+            f"<tr><td><code>{esc(cell.get('id', ''))}</code></td>"
+            f"<td>{esc(cell.get('family', ''))}</td>"
+            f"<td>{esc(cell.get('track', ''))}</td>"
+            f"<td>{esc(cell.get('target', ''))}</td>"
+            f"<td>{esc(cell.get('architecture', ''))}</td>"
+            f"<td>{pill('good' if enabled else 'muted', 'enabled' if enabled else 'disabled')}</td>"
+            f"</tr>"
+        )
+    cells_table = (
+        "<table><thead><tr><th>Cell</th><th>Family</th><th>Track</th>"
+        "<th>Target</th><th>Arch</th><th>State</th></tr></thead>"
+        f"<tbody>{''.join(cell_rows)}</tbody></table>"
+    )
+    return (
+        '<section id="config"><h2>Configuration</h2>'
+        "<p class=lede>Read straight from "
+        "<code>manifests/package-factory.yaml</code> and "
+        "<code>manifests/package-builds.yaml</code>. If this disagrees with "
+        "the coverage above, the contract and the measurement disagree.</p>"
+        f"<h3>Targets</h3>{targets_table}"
+        f"<h3>Native build cells</h3>{cells_table}</section>"
+    )
+
+
+def style() -> str:
+    def block(tokens):
+        return "".join(f"--{k}:{v};" for k, v in tokens.items())
+    return (
+        "<style>"
+        f":root{{{block(TOKENS_LIGHT)}color-scheme:light;}}"
+        f"@media (prefers-color-scheme:dark){{:root:not([data-theme=\"light\"])"
+        f"{{{block(TOKENS_DARK)}color-scheme:dark;}}}}"
+        f":root[data-theme=\"dark\"]{{{block(TOKENS_DARK)}color-scheme:dark;}}"
+        "*{box-sizing:border-box}"
+        "body{margin:0;background:var(--surface-1);color:var(--text-primary);"
+        "font:16px/1.55 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,"
+        "Helvetica,Arial,sans-serif;}"
+        ".wrap{max-width:1080px;margin:0 auto;padding:32px 20px 64px}"
+        "h1{font-size:1.6rem;margin:0 0 4px}"
+        "h2{font-size:1.15rem;margin:40px 0 12px;padding-bottom:8px;"
+        "border-bottom:1px solid var(--border)}"
+        "h3{font-size:1rem;margin:22px 0 8px}"
+        "a{color:var(--fill)}"
+        ".sub{color:var(--text-secondary);margin:0 0 8px}"
+        ".lede{color:var(--text-secondary);margin:0 0 14px;max-width:70ch}"
+        ".tiles{display:grid;gap:12px;grid-template-columns:repeat(auto-fit,"
+        "minmax(190px,1fr));margin:20px 0 10px}"
+        ".tile{background:var(--surface-2);border:1px solid var(--border);"
+        "border-radius:10px;padding:14px 16px}"
+        ".tile-n{font-size:1.9rem;font-weight:650;letter-spacing:-.02em}"
+        ".tile-k{font-weight:600;font-size:.9rem}"
+        ".tile-s{color:var(--text-muted);font-size:.78rem;margin-top:2px}"
+        ".measured{color:var(--text-muted);font-size:.85rem;margin:6px 0 0}"
+        ".alarm{background:var(--surface-2);border:1px solid var(--critical);"
+        "border-radius:10px;padding:12px 14px;margin:14px 0 0;"
+        "color:var(--text-secondary);font-size:.9rem}"
+        ".grid{display:grid;gap:14px;grid-template-columns:repeat(auto-fit,"
+        "minmax(300px,1fr))}"
+        ".card{background:var(--surface-2);border:1px solid var(--border);"
+        "border-radius:12px;padding:14px 16px}"
+        ".card h3{margin:0 0 6px;font-size:1rem}"
+        ".arch{color:var(--text-muted);font-weight:500;font-size:.85rem}"
+        ".counts{margin:0 0 8px;font-size:.9rem;color:var(--text-secondary)}"
+        ".counts strong{font-size:1.25rem;color:var(--text-primary)}"
+        ".need{float:right;color:var(--text-muted)}"
+        ".bar{height:10px;border-radius:5px;background:var(--surface-3);"
+        "overflow:hidden;display:flex}"
+        ".bar-fill{background:var(--fill);border-radius:5px;"
+        "box-shadow:0 0 0 2px var(--surface-2)}"
+        ".badges{display:flex;flex-wrap:wrap;gap:6px;margin-top:10px}"
+        ".pill{display:inline-flex;align-items:center;gap:5px;font-size:.75rem;"
+        "border-radius:999px;padding:2px 9px;background:var(--surface-3);"
+        "border:1px solid var(--border);color:var(--text-secondary)}"
+        ".ico{font-size:.7em;line-height:1}"
+        ".pill-good .ico{color:var(--good)}.pill-warning .ico{color:var(--warning)}"
+        ".pill-serious .ico{color:var(--serious)}"
+        ".pill-critical{border-color:var(--critical)}"
+        ".pill-critical .ico{color:var(--critical)}"
+        ".pill-muted .ico{color:var(--text-muted)}"
+        ".idx{margin:10px 0 0;padding-left:16px;font-size:.78rem;"
+        "color:var(--text-secondary);word-break:break-all}"
+        ".dim{color:var(--text-muted)}"
+        ".reason{color:var(--text-secondary);font-size:.85rem}"
+        ".gaps{padding-left:18px}.gaps li{margin-bottom:10px}"
+        "table{border-collapse:collapse;width:100%;font-size:.85rem;"
+        "display:block;overflow-x:auto;white-space:nowrap}"
+        "th,td{text-align:left;padding:7px 10px;"
+        "border-bottom:1px solid var(--border)}"
+        "th{color:var(--text-secondary);font-weight:600}"
+        "td.num,th.num{text-align:right;font-variant-numeric:tabular-nums}"
+        "code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;"
+        "font-size:.85em}"
+        ".tableview{margin-top:16px}"
+        ".tableview summary{cursor:pointer;color:var(--text-secondary);"
+        "font-size:.85rem}"
+        "footer{margin-top:48px;padding-top:16px;"
+        "border-top:1px solid var(--border);color:var(--text-muted);"
+        "font-size:.8rem}"
+        "</style>"
+    )
+
+
+def render(status: dict, contract: dict, cells: dict,
+           now: dt.datetime) -> str:
+    rows = coverage_rows(status)
+    return (
+        "<!doctype html>"
+        '<html lang="en"><head><meta charset="utf-8">'
+        '<meta name="viewport" content="width=device-width,initial-scale=1">'
+        "<title>TunaOS Package Factory</title>"
+        '<meta name="description" content="What the TunaOS package factory '
+        'has built, for which targets, and what it is still missing.">'
+        f"{style()}</head><body><div class=wrap>"
+        "<h1>TunaOS Package Factory</h1>"
+        '<p class="sub">What the factory has built, for which targets, and '
+        "what it is still missing &mdash; rendered from the factory's own "
+        "measurements, not from a hand-written summary.</p>"
+        f"{render_hero(status, contract, rows, now)}"
+        f"{render_coverage(rows)}"
+        f"{render_unmeasured(status)}"
+        f"{render_desktop(status)}"
+        f"{render_config(contract, cells)}"
+        "<footer>Generated by <code>scripts/render-factory-site.py</code> "
+        "from <code>docs/factory-status.json</code>, "
+        "<code>manifests/package-factory.yaml</code> and "
+        "<code>manifests/package-builds.yaml</code>. "
+        "Every figure is a measurement of a live published index; none is "
+        "asserted by hand. "
+        '<a href="https://github.com/tuna-os/tunaos-packages">Source</a>.'
+        "</footer></div></body></html>"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=pathlib.Path,
+                        default=ROOT / "site")
+    parser.add_argument("--status", type=pathlib.Path, default=STATUS_JSON)
+    parser.add_argument("--contract", type=pathlib.Path, default=CONTRACT)
+    parser.add_argument("--cells", type=pathlib.Path, default=CELLS)
+    parser.add_argument("--now", default=None,
+                        help="ISO 8601 instant to measure staleness against "
+                             "(default: now, UTC)")
+    args = parser.parse_args(argv)
+
+    now = (parse_iso(args.now) if args.now
+           else dt.datetime.now(dt.timezone.utc))
+    page = render(load(args.status), load(args.contract), load(args.cells),
+                  now)
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    (args.out / "index.html").write_text(page, encoding="utf-8")
+    # Pages runs Jekyll over the artifact unless told not to, and Jekyll
+    # silently drops files beginning with an underscore.
+    (args.out / ".nojekyll").write_text("", encoding="utf-8")
+    print(f"wrote {args.out / 'index.html'} ({len(page)} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/render-factory-site.py
+++ b/scripts/render-factory-site.py
@@ -31,6 +31,7 @@ import argparse
 import datetime as dt
 import html
 import json
+import re
 import pathlib
 import sys
 
@@ -41,6 +42,18 @@ ROOT = pathlib.Path(__file__).resolve().parents[1]
 STATUS_JSON = ROOT / "docs" / "factory-status.json"
 CONTRACT = ROOT / "manifests" / "package-factory.yaml"
 CELLS = ROOT / "manifests" / "package-builds.yaml"
+REPO_CONTENTS = ROOT / "docs" / "repo-contents.json"
+
+# How the repo is added on each format, shown on that index's browse page.
+# A browser that shows you what is served but not how to consume it stops one
+# step short of the question people actually arrive with.
+ADD_REPO = {
+    "rpm": ("dnf config-manager addrepo "
+            "--set=baseurl={url} --set=name=tunaos --set=gpgcheck=0"),
+    "deb": ("echo 'deb [trusted=yes] {url} ./' | "
+            "sudo tee /etc/apt/sources.list.d/tunaos.list"),
+    "pkg.tar.zst": "# add to /etc/pacman.conf:\n[{name}]\nServer = {url}",
+}
 
 # How old a measurement may be before the page stops presenting it as current.
 # Matches the ::warning threshold in scripts/factory-status.py so the page and
@@ -112,6 +125,17 @@ def parse_iso(stamp: str) -> dt.datetime:
 
 def days_between(later: dt.datetime, earlier: dt.datetime) -> int:
     return max(0, (later - earlier).days)
+
+
+def slug(value: str) -> str:
+    """A filename-safe id for an index, derived from its URL.
+
+    Two indexes of one target differ only by URL (el10 x86_64 has two), so the
+    target name alone cannot name the page.
+    """
+    keep = [c if c.isalnum() else "-" for c in
+            value.replace("https://", "").replace("http://", "").strip("/")]
+    return re.sub(r"-+", "-", "".join(keep)).strip("-").lower()
 
 
 def pill(state: str, label: str) -> str:
@@ -439,6 +463,13 @@ def style() -> str:
         "td.num,th.num{text-align:right;font-variant-numeric:tabular-nums}"
         "code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;"
         "font-size:.85em}"
+        "input[type=search]{width:100%;max-width:420px;padding:8px 11px;"
+        "font:inherit;font-size:.9rem;border-radius:8px;margin:4px 0 6px;"
+        "border:1px solid var(--border);background:var(--surface-2);"
+        "color:var(--text-primary)}"
+        "pre{background:var(--surface-2);border:1px solid var(--border);"
+        "border-radius:8px;padding:12px 14px;overflow-x:auto;font-size:.85rem}"
+        "tr[hidden]{display:none}"
         ".tableview{margin-top:16px}"
         ".tableview summary{cursor:pointer;color:var(--text-secondary);"
         "font-size:.85rem}"
@@ -449,9 +480,214 @@ def style() -> str:
     )
 
 
+# --- the package browser ---------------------------------------------------
+#
+# The status page answers "how much of the plan is built". This answers the
+# different question someone has when they are deciding whether to point a
+# machine at repo.tunaos.org: what is actually IN it. Both are views of a
+# measurement -- these pages are rendered from docs/repo-contents.json, which
+# scripts/snapshot-repo-contents.py reads from the served indexes themselves,
+# at the same URLs a package manager would use.
+#
+# Rows are written into the HTML, never fetched or generated at view time. The
+# filter box is an inline script that only HIDES rows; with scripting off the
+# page is the full list, and a reader is never looking at a subset the page
+# has not told them about.
+
+FILTER_SCRIPT = (
+    "<script>"
+    "(function(){"
+    "var box=document.getElementById('q'),"
+    "rows=document.querySelectorAll('#pkgs tbody tr'),"
+    "out=document.getElementById('shown');"
+    "if(!box)return;"
+    "box.hidden=false;"
+    "box.addEventListener('input',function(){"
+    "var q=box.value.trim().toLowerCase(),n=0;"
+    "for(var i=0;i<rows.length;i++){"
+    "var hit=!q||rows[i].getAttribute('data-k').indexOf(q)>-1;"
+    "rows[i].hidden=!hit;if(hit)n++;}"
+    "out.textContent=q?(n+' of '+rows.length+' shown'):"
+    "(rows.length+' packages');});"
+    "})();"
+    "</script>"
+)
+
+
+def repo_rows(contents: dict) -> list[dict]:
+    """Index rows in a stable order, biggest first, unreachable at the top.
+
+    An index that could not be read is the most important row on the page, so
+    it sorts above the ones that worked rather than below them.
+    """
+    rows = []
+    for entry in contents.get("indexes", []):
+        rows.append(dict(entry, slug=slug(entry["url"]),
+                         count=len(entry.get("packages") or [])))
+    rows.sort(key=lambda r: (r["error"] is None, r["count"]), reverse=True)
+    return rows
+
+
+def repo_freshness(contents: dict, now: dt.datetime) -> tuple[int, str]:
+    """Age of the snapshot in days, and the sentence that states it."""
+    stamp = contents.get("generated")
+    if not stamp:
+        return 0, "Snapshot time not recorded."
+    age = days_between(now, parse_iso(stamp))
+    when = f"Read from the live indexes on {esc(stamp)}"
+    if age == 0:
+        return age, f"{when} (today)."
+    return age, f"{when} &mdash; {age} day{'' if age == 1 else 's'} ago."
+
+
+def render_repo_overview(contents: dict, now: dt.datetime) -> str:
+    """packages.html: every served index, with a way into each."""
+    rows = repo_rows(contents)
+    totals = contents.get("totals", {})
+    age, freshness = repo_freshness(contents, now)
+    dead = [r for r in rows if r["error"]]
+
+    alarm = ""
+    if age > STALE_AFTER_DAYS:
+        alarm = (f'<p class="alarm">{pill("critical", "stale")} This listing '
+                 f"is {age} days old. The repository may have changed since; "
+                 "ask the index itself before relying on this page.</p>")
+    if dead:
+        names = ", ".join(f"{esc(r['target'])} ({esc(r['url'])})"
+                          for r in dead)
+        alarm += (f'<p class="alarm">{pill("critical", "unreachable")} '
+                  f"{len(dead)} declared index"
+                  f"{'' if len(dead) == 1 else 'es'} could not be read: "
+                  f"{names}. Packages served there are missing from this "
+                  "listing, and may be missing from the repository.</p>")
+
+    body = [
+        "<h1>Package browser</h1>",
+        '<p class="sub">What <code>repo.tunaos.org</code> is serving right '
+        "now, read from the same indexes your package manager reads.</p>",
+        '<p class="lede">Every index the factory contract declares as '
+        "published, and every package in it. Source packages are left out: "
+        "they are build inputs, and the served tree excludes them too.</p>",
+        '<div class="tiles">',
+        f'<div class="tile"><div class="tile-n">'
+        f'{totals.get("names", 0)}</div><div class="tile-k">package names'
+        f'</div><div class="tile-s">distinct, across every index</div></div>',
+        f'<div class="tile"><div class="tile-n">'
+        f'{totals.get("packages", 0)}</div><div class="tile-k">packages'
+        f'</div><div class="tile-s">counting each index separately</div>'
+        f'</div>',
+        f'<div class="tile"><div class="tile-n">{len(rows)}</div>'
+        f'<div class="tile-k">served indexes</div>'
+        f'<div class="tile-s">{len(dead)} unreachable</div></div>',
+        "</div>",
+        f'<p class="measured">{freshness}</p>',
+        alarm,
+        "<h2>Indexes</h2>",
+        "<table><thead><tr><th>Target</th><th>Arch</th><th>Format</th>"
+        '<th class="num">Packages</th><th>Index</th></tr></thead><tbody>',
+    ]
+    for row in rows:
+        arches = ", ".join(row["arches"]) or "any"
+        if row["error"]:
+            count = pill("critical", "unreachable")
+            link = f'<code>{esc(row["url"])}</code>'
+        else:
+            count = (f'<a href="repo/{esc(row["slug"])}.html">'
+                     f'{row["count"]}</a>')
+            link = (f'<a href="{esc(row["url"])}"><code>'
+                    f'{esc(row["url"])}</code></a>')
+        body.append(
+            f"<tr><td>{esc(row['target'])}</td><td>{esc(arches)}</td>"
+            f"<td><code>{esc(row['format'])}</code></td>"
+            f'<td class="num">{count}</td><td>{link}</td></tr>')
+    body.append("</tbody></table>")
+    for row in dead:
+        body.append(f'<p class="reason"><strong>{esc(row["target"])}</strong> '
+                    f'{esc(row["url"])}: <code>{esc(row["error"])}</code></p>')
+    return "".join(body)
+
+
+def render_repo_index(row: dict, contents: dict, now: dt.datetime) -> str:
+    """One index's full package list."""
+    _, freshness = repo_freshness(contents, now)
+    packages = row.get("packages") or []
+    arches = ", ".join(row["arches"]) or "any"
+    recipe = ADD_REPO.get(row["format"], "")
+    how = ""
+    if recipe:
+        how = (f"<h2>Using it</h2><pre><code>"
+               f"{esc(recipe.format(url=row['url'], name=row['target']))}"
+               f"</code></pre>")
+
+    body = [
+        f"<h1>{esc(row['target'])} <span class=\"arch\">{esc(arches)}</span>"
+        "</h1>",
+        f'<p class="sub"><a href="{esc(row["url"])}"><code>'
+        f'{esc(row["url"])}</code></a></p>',
+        f'<p class="measured">{freshness} '
+        f'<a href="../packages.html">All indexes</a> &middot; '
+        f'<a href="../index.html">Factory status</a></p>',
+        how,
+        f"<h2>Packages</h2>",
+        '<input id="q" type="search" hidden placeholder="Filter by package '
+        'or source name" aria-label="Filter packages">',
+        f'<p class="measured" id="shown">{len(packages)} packages</p>',
+        '<table id="pkgs"><thead><tr><th>Package</th><th>Version</th>'
+        "<th>Arch</th><th>Source</th></tr></thead><tbody>",
+    ]
+    for pkg in packages:
+        # Strip the always-'0:' epoch: it is noise on every row and the two
+        # packages that carry a real epoch still show theirs.
+        evr = pkg["evr"][2:] if pkg["evr"].startswith("0:") else pkg["evr"]
+        source = pkg.get("source") or ""
+        key = esc(f"{pkg['name']} {source}".lower())
+        name = esc(pkg["name"])
+        if pkg.get("location"):
+            href = row["url"].rstrip("/") + "/" + pkg["location"].lstrip("/")
+            name = f'<a href="{esc(href)}">{name}</a>'
+        body.append(
+            f'<tr data-k="{key}"><td>{name}</td><td><code>{esc(evr)}</code>'
+            f"</td><td>{esc(pkg['arch'])}</td>"
+            f'<td class="dim">{esc(source)}</td></tr>')
+    body.append("</tbody></table>")
+    return "".join(body)
+
+
+def shell(title: str, description: str, body: str, *, depth: int = 0,
+          script: str = "") -> str:
+    """The page frame both the status page and the browser pages wear."""
+    up = "../" * depth
+    return (
+        "<!doctype html>"
+        '<html lang="en"><head><meta charset="utf-8">'
+        '<meta name="viewport" content="width=device-width,initial-scale=1">'
+        f"<title>{esc(title)}</title>"
+        f'<meta name="description" content="{esc(description)}">'
+        f"{style()}</head><body><div class=wrap>"
+        f"{body}"
+        "<footer>Generated by <code>scripts/render-factory-site.py</code> "
+        "from <code>docs/repo-contents.json</code>, which "
+        "<code>scripts/snapshot-repo-contents.py</code> reads from the served "
+        "indexes themselves. Nothing here is a hand-kept list. "
+        f'<a href="{up}index.html">Factory status</a> &middot; '
+        '<a href="https://github.com/tuna-os/tunaos-packages">Source</a>.'
+        f"</footer></div>{script}</body></html>"
+    )
+
+
 def render(status: dict, contract: dict, cells: dict,
-           now: dt.datetime) -> str:
+           now: dt.datetime, contents: dict | None = None) -> str:
     rows = coverage_rows(status)
+    # Only offered when the snapshot is actually there to link to: a link to a
+    # page that was not rendered is worse than no link.
+    browse = ""
+    if contents is not None:
+        totals = contents.get("totals", {})
+        browse = (f'<p class="lede"><a href="packages.html">Browse the '
+                  f'{totals.get("names", 0)} package names</a> '
+                  f"repo.tunaos.org is serving right now &mdash; what is IN "
+                  f"the repository, as opposed to how much of the plan is "
+                  f"built.</p>")
     return (
         "<!doctype html>"
         '<html lang="en"><head><meta charset="utf-8">'
@@ -464,6 +700,7 @@ def render(status: dict, contract: dict, cells: dict,
         '<p class="sub">What the factory has built, for which targets, and '
         "what it is still missing &mdash; rendered from the factory's own "
         "measurements, not from a hand-written summary.</p>"
+        f"{browse}"
         f"{render_hero(status, contract, rows, now)}"
         f"{render_coverage(rows)}"
         f"{render_unmeasured(status)}"
@@ -480,6 +717,33 @@ def render(status: dict, contract: dict, cells: dict,
     )
 
 
+def write_browser(contents: dict, out: pathlib.Path,
+                  now: dt.datetime) -> int:
+    """packages.html plus one page per readable index."""
+    rows = repo_rows(contents)
+    (out / "packages.html").write_text(
+        shell("TunaOS package browser",
+              "Every package repo.tunaos.org is serving, read from the "
+              "published indexes themselves.",
+              render_repo_overview(contents, now)),
+        encoding="utf-8")
+    pages = out / "repo"
+    pages.mkdir(parents=True, exist_ok=True)
+    written = 1
+    for row in rows:
+        if row["error"]:
+            continue                       # named on the overview, no list
+        (pages / f"{row['slug']}.html").write_text(
+            shell(f"{row['target']} packages — TunaOS",
+                  f"The {len(row['packages'])} packages served at "
+                  f"{row['url']}.",
+                  render_repo_index(row, contents, now),
+                  depth=1, script=FILTER_SCRIPT),
+            encoding="utf-8")
+        written += 1
+    return written
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--out", type=pathlib.Path,
@@ -487,6 +751,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--status", type=pathlib.Path, default=STATUS_JSON)
     parser.add_argument("--contract", type=pathlib.Path, default=CONTRACT)
     parser.add_argument("--cells", type=pathlib.Path, default=CELLS)
+    parser.add_argument("--repo-contents", type=pathlib.Path,
+                        default=REPO_CONTENTS,
+                        help="snapshot of the served indexes from "
+                             "scripts/snapshot-repo-contents.py; the package "
+                             "browser is omitted if it is absent")
     parser.add_argument("--now", default=None,
                         help="ISO 8601 instant to measure staleness against "
                              "(default: now, UTC)")
@@ -494,11 +763,19 @@ def main(argv: list[str] | None = None) -> int:
 
     now = (parse_iso(args.now) if args.now
            else dt.datetime.now(dt.timezone.utc))
+    # Absent is a legitimate state, not an error: a checkout has no snapshot
+    # until something fetches one, and the status page must still render.
+    contents = (load(args.repo_contents)
+                if args.repo_contents and args.repo_contents.is_file()
+                else None)
     page = render(load(args.status), load(args.contract), load(args.cells),
-                  now)
+                  now, contents)
 
     args.out.mkdir(parents=True, exist_ok=True)
     (args.out / "index.html").write_text(page, encoding="utf-8")
+    if contents is not None:
+        written = write_browser(contents, args.out, now)
+        print(f"wrote {written} package-browser pages")
     # Pages runs Jekyll over the artifact unless told not to, and Jekyll
     # silently drops files beginning with an underscore.
     (args.out / ".nojekyll").write_text("", encoding="utf-8")

--- a/scripts/repo_index.py
+++ b/scripts/repo_index.py
@@ -140,12 +140,19 @@ def iter_rpm_rows(blob: bytes):
             continue
         version = element.find(f"{gap.COMMON}version")
         source = element.find(f"{gap.COMMON}format/{gap.RPM}sourcerpm")
+        where = element.find(f"{gap.COMMON}location")
         yield {
             "name": element.findtext(f"{gap.COMMON}name"),
             "arch": element.findtext(f"{gap.COMMON}arch"),
             "evr": (f"{version.get('epoch') or '0'}:"
                     f"{version.get('ver')}-{version.get('rel')}"),
             "srpm": source.text if source is not None else None,
+            # Where the file sits relative to the index URL. Nothing in the
+            # hygiene checks needs it; a reader browsing the repo does, and
+            # deriving it from the NEVRA instead would be a guess -- the
+            # publisher renames '+' out of filenames, so the guess is wrong
+            # for exactly the packages that already caused an incident.
+            "location": where.get("href") if where is not None else None,
             # Regular files only: directories are co-owned by design
             # and ghosts have no content to conflict.
             "files": [shipped.text for shipped in

--- a/scripts/snapshot-repo-contents.py
+++ b/scripts/snapshot-repo-contents.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Snapshot what repo.tunaos.org actually serves, one JSON for the site.
+
+## Why this exists
+
+docs/factory-status.json answers "how much of the plan has been built". It
+does NOT answer "what is in the repository" -- and that is the question
+someone actually has when they are deciding whether to point a machine at
+repo.tunaos.org. Until now the only way to answer it was to add the repo to
+a box and ask dnf, which means you have to already trust it to find out
+what it contains.
+
+The served indexes are public, so nothing here is privileged: this reads
+exactly what any client's package manager reads at the exact same URLs the
+factory contract declares in `published_index`, through the same
+format-neutral reader (scripts/repo_index.py) the hygiene checks use. The
+consequence worth stating: the browser cannot show a package the repo does
+not serve, and cannot hide one it does, because it is not a separate list
+that someone has to remember to update. It is the index.
+
+## Failure is data, not an exception
+
+An index that 404s, times out, or parses as garbage is recorded as an entry
+carrying its `error` and no packages -- it is NOT dropped, and it does not
+abort the run. A target whose index is unreachable is the single most
+important thing this file can report (that is what #519 looked like from
+outside: names silently absent), so a snapshot that omitted it in the name
+of a clean exit code would hide the one failure it exists to catch.
+
+Usage:
+    snapshot-repo-contents.py --out docs/repo-contents.json
+    snapshot-repo-contents.py --target el10 --out -   # one target, stdout
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import pathlib
+import sys
+import tempfile
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import repo_index  # noqa: E402
+import yaml  # noqa: E402
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+CONTRACT = ROOT / "manifests" / "package-factory.yaml"
+
+
+def indexes(contract: dict, only: str | None) -> list[dict]:
+    """Every (target, arch, url) the contract says is served.
+
+    One arch can declare more than one index -- el10 x86_64 has two, because
+    two publishers write to disjoint prefixes (#467) -- so this is a list of
+    index rows, not a dict keyed by arch.
+    """
+    rows: dict[tuple[str, str], dict] = {}
+    for target, spec in sorted(contract.get("targets", {}).items()):
+        if only and target != only:
+            continue
+        published = spec.get("published_index") or {}
+        if isinstance(published, str):          # a bare string, no arch split
+            published = {"": published}
+        for arch, urls in sorted(published.items()):
+            if isinstance(urls, str):
+                urls = [urls]
+            for url in urls:
+                if not url or not str(url).strip():
+                    continue
+                url = str(url).strip()
+                # Keyed by (target, url), NOT by (target, arch, url). A flat
+                # deb repo is ONE index that both amd64 and arm64 point at --
+                # reading it once per arch would download it twice and report
+                # its 16 packages as 32. The arches that name it are recorded
+                # on the row instead, which is also the truthful shape: the
+                # index is not per-arch, the pointer to it is.
+                key = (target, url)
+                if key in rows:
+                    if arch and arch not in rows[key]["arches"]:
+                        rows[key]["arches"].append(arch)
+                    continue
+                rows[key] = {
+                    "target": target,
+                    "arches": [arch] if arch else [],
+                    "format": spec.get("format", "rpm"),
+                    "url": url,
+                }
+    return list(rows.values())
+
+
+def read(row: dict, cache: pathlib.Path) -> dict:
+    """One index's packages, or the reason there are none."""
+    out = dict(row, packages=[], error=None)
+    try:
+        rows = list(repo_index.iter_rows(
+            row["url"], row["format"], cache, repo_name=row["target"]))
+    except Exception as exc:                    # noqa: BLE001 -- see docstring
+        out["error"] = f"{type(exc).__name__}: {exc}"
+        return out
+    for entry in rows:
+        # Source packages are build inputs, not something anyone installs.
+        # They stay out of the browser for the same reason publish-rpm-wave.sh
+        # excludes them from the served tree.
+        if entry.get("arch") == "src":
+            continue
+        out["packages"].append({
+            "name": entry["name"],
+            "arch": entry.get("arch") or "",
+            "evr": entry.get("evr") or "",
+            "source": repo_index.source_name(row["format"], entry.get("srpm")),
+            "location": entry.get("location"),
+        })
+    out["packages"].sort(key=lambda p: (p["name"], p["arch"], p["evr"]))
+    return out
+
+
+def snapshot(contract: dict, only: str | None, cache: pathlib.Path,
+             now: str) -> dict:
+    read_rows = [read(row, cache) for row in indexes(contract, only)]
+    return {
+        "generated": now,
+        "indexes": read_rows,
+        "totals": {
+            "indexes": len(read_rows),
+            "unreachable": sum(1 for r in read_rows if r["error"]),
+            "packages": sum(len(r["packages"]) for r in read_rows),
+            "names": len({p["name"] for r in read_rows
+                          for p in r["packages"]}),
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", default="docs/repo-contents.json",
+                    help="output path, or - for stdout")
+    ap.add_argument("--contract", default=str(CONTRACT))
+    ap.add_argument("--target", default=None,
+                    help="limit to one target (default: every declared one)")
+    ap.add_argument("--cache", default=None,
+                    help="index download cache (default: a temp dir)")
+    ap.add_argument("--now", default=None,
+                    help="override the generated timestamp (tests)")
+    args = ap.parse_args(argv)
+
+    contract = yaml.safe_load(
+        pathlib.Path(args.contract).read_text(encoding="utf-8"))
+    now = args.now or dt.datetime.now(dt.timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        cache = pathlib.Path(args.cache or tmp)
+        cache.mkdir(parents=True, exist_ok=True)
+        data = snapshot(contract, args.target, cache, now)
+
+    text = json.dumps(data, indent=2, sort_keys=True) + "\n"
+    if args.out == "-":
+        sys.stdout.write(text)
+    else:
+        pathlib.Path(args.out).write_text(text, encoding="utf-8")
+
+    unreachable = [r for r in data["indexes"] if r["error"]]
+    for row in unreachable:
+        print(f"::warning::{row['target']} {'/'.join(row['arches'])} "
+              f"{row['url']}: {row['error']}", file=sys.stderr)
+    print(f"{data['totals']['packages']} packages / "
+          f"{data['totals']['names']} names across "
+          f"{data['totals']['indexes']} indexes "
+          f"({len(unreachable)} unreachable)", file=sys.stderr)
+    # Deliberately 0 even with unreachable indexes: the snapshot SUCCEEDED at
+    # recording that they are unreachable, and the page says so. Failing here
+    # would take the whole site down over one dead prefix.
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_factory_site.py
+++ b/tests/test_factory_site.py
@@ -175,10 +175,17 @@ def test_the_bar_carries_an_accessible_label():
 
 
 def test_the_page_is_self_contained():
-    """No CDN, no external stylesheet, no script: Pages serves it as-is and
-    it opens from a file:// URL."""
+    """No CDN, no external stylesheet, no external script: Pages serves it
+    as-is and it opens from a file:// URL.
+
+    This used to forbid <script> outright. The browser pages need a filter
+    box, so the rule is now the one that was actually load-bearing: nothing
+    is FETCHED. An inline script keeps the page a single file that opens from
+    file://; a src= would not. The companion property -- that no content
+    comes from script -- is pinned separately by
+    test_the_package_rows_are_in_the_html_not_generated_by_script."""
     page = render()
-    assert "<script" not in page.lower()
+    assert "<script src" not in page.lower()
     assert "http://" not in page.replace("http://www.w3.org", "")
     external = re.findall(r'(?:src|href)="(https?://[^"]+)"', page)
     for url in external:

--- a/tests/test_factory_site.py
+++ b/tests/test_factory_site.py
@@ -1,0 +1,279 @@
+"""The published page must not be able to overstate the factory.
+
+A status page people read without a checkout is exactly where a comfortable
+lie survives longest, so the properties pinned here are the ones that would
+make it flatter than the measurement:
+
+  * a declared target that cannot be measured must still appear, with the
+    reason -- otherwise the coverage section reads as the whole picture;
+  * a REGRESSED name must reach the page, because that is the repo-wipe shape
+    (#519) and the one thing a green-looking dashboard must never bury;
+  * a stale measurement must announce itself rather than presenting old
+    numbers as current (the #448 shape: a refresh that stopped landing);
+  * state is never colour alone -- every chip carries an icon and a word.
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import re
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+_spec = importlib.util.spec_from_file_location(
+    "render_factory_site", ROOT / "scripts" / "render-factory-site.py")
+site = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(site)
+
+NOW = "2026-08-25T06:00:00+00:00"
+
+STATUS = {
+    "measured_at": "2026-08-25T05:00:00+00:00",
+    "targets": {
+        "el10": {
+            "x86_64": {
+                "built": ["a", "b", "c"],
+                "needed": ["d"],
+                "catalog_entries": 4,
+                "indexes": [{"baseurl": "https://repo.example.test/el10/",
+                             "package_names": 12}],
+            },
+        },
+    },
+    "unmeasured_targets": {
+        "arch": {"catalog_entries": 22, "format": "pkg.tar.zst",
+                 "reason": "no published_index declared in "
+                           "package-factory.yaml"},
+    },
+    "trend": {"since": "2026-08-24T05:00:00+00:00", "staleness_days": 1,
+              "rows": {"el10/x86_64": {"built_delta": 2, "needed_delta": -2,
+                                       "new": False, "newly_built": ["b", "c"],
+                                       "regressed": [], "stalled": None}}},
+    "history": [],
+    "desktop_coverage": {},
+}
+
+CONTRACT = {
+    "targets": {
+        "el10": {"status": "supported", "format": "rpm", "buildroot": "epel-10",
+                 "architectures": ["x86_64"], "repository": "rpm-md",
+                 "published_index": {"x86_64": "https://repo.example.test/el10/"}},
+        "arch": {"status": "scaffold", "format": "pkg.tar.zst",
+                 "architectures": ["x86_64"], "repository": "pacman"},
+    },
+}
+
+CELLS = {"native_builds": [
+    {"id": "gnome51-el10-x86_64", "family": "gnome51", "track": "next",
+     "target": "el10", "architecture": "x86_64", "enabled": True},
+    {"id": "gnome49-el10-x86_64", "family": "gnome49", "track": "legacy",
+     "target": "el10", "architecture": "x86_64", "enabled": False},
+]}
+
+
+def render(status=None, contract=None, cells=None, now=NOW) -> str:
+    return site.render(status or STATUS, contract or CONTRACT,
+                       cells or CELLS, site.parse_iso(now))
+
+
+def text_of(page: str) -> str:
+    """The page as a reader sees it: no markup, no styles."""
+    body = re.sub(r"<style.*?</style>", " ", page, flags=re.S)
+    return re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", body))
+
+
+# --- it cannot quietly shrink the problem ----------------------------------
+
+
+def test_an_unmeasurable_target_is_still_on_the_page_with_its_reason():
+    """Otherwise 'coverage' silently means 'the targets that were easy'."""
+    page = text_of(render())
+    assert "arch" in page
+    assert "no published_index declared" in page
+
+
+def test_every_declared_target_appears_in_the_configuration_section():
+    page = text_of(render())
+    for name in CONTRACT["targets"]:
+        assert name in page, f"{name} is in the contract but not on the page"
+
+
+def test_a_regressed_name_reaches_the_page():
+    """#519: names that were served and no longer are. A dashboard that
+    renders that as a smaller bar and no words is worse than no dashboard."""
+    status = {**STATUS, "trend": {**STATUS["trend"], "rows": {
+        "el10/x86_64": {"built_delta": -1, "needed_delta": 1, "new": False,
+                        "newly_built": [], "regressed": ["harfbuzz"],
+                        "stalled": None}}}}
+    page = text_of(render(status))
+    assert "REGRESSED" in page
+    assert "1 name no longer served" in page
+
+
+def test_a_stall_is_reported_with_its_age():
+    status = {**STATUS, "trend": {**STATUS["trend"], "rows": {
+        "el10/x86_64": {"built_delta": 0, "needed_delta": 0, "new": False,
+                        "newly_built": [], "regressed": [],
+                        "stalled": {"days": 5, "at_least": True}}}}}
+    page = text_of(render(status))
+    assert "flat ≥ 5 days" in page
+
+
+# --- it cannot present old numbers as current ------------------------------
+
+
+def test_a_fresh_measurement_carries_no_alarm():
+    page = text_of(render())
+    assert "Stale measurement" not in page
+
+
+def test_a_stale_measurement_says_so_before_the_numbers_are_believed():
+    page = text_of(render(now="2026-09-01T06:00:00+00:00"))
+    assert "Stale measurement" in page
+    assert "7 days old" in page
+    assert "history rather than" in page
+
+
+def test_the_staleness_threshold_matches_the_measuring_tool():
+    """The page and factory-status.py must not disagree about 'stale'."""
+    source = (ROOT / "scripts" / "factory-status.py").read_text(
+        encoding="utf-8")
+    assert f"> {site.STALE_AFTER_DAYS}" in source or \
+           f"{site.STALE_AFTER_DAYS} days" in source, (
+        "scripts/factory-status.py no longer warns at "
+        f"{site.STALE_AFTER_DAYS} days; the page would disagree with it")
+
+
+# --- accessibility ---------------------------------------------------------
+
+
+def test_state_is_never_colour_alone():
+    """Every chip pairs its colour with an icon and a word."""
+    page = render()
+    for match in re.finditer(r'<span class="pill pill-(\w+)">(.*?)</span>\s*'
+                             r'(?=<)', page):
+        chip = match.group(0)
+        assert 'class="ico"' in chip, f"chip without an icon: {chip}"
+    assert page.count('class="ico"') >= 1
+
+
+def test_a_table_view_of_the_coverage_exists():
+    """The numbers must be readable without reading the bars."""
+    page = render()
+    assert "Table view" in page
+    assert "<table>" in page
+
+
+def test_the_bar_carries_an_accessible_label():
+    page = render()
+    assert 'role="img"' in page
+    assert 'aria-label="3 of 4 built"' in page
+
+
+# --- output shape ----------------------------------------------------------
+
+
+def test_the_page_is_self_contained():
+    """No CDN, no external stylesheet, no script: Pages serves it as-is and
+    it opens from a file:// URL."""
+    page = render()
+    assert "<script" not in page.lower()
+    assert "http://" not in page.replace("http://www.w3.org", "")
+    external = re.findall(r'(?:src|href)="(https?://[^"]+)"', page)
+    for url in external:
+        assert url.startswith(("https://repo.", "https://github.com")), (
+            f"page pulls an external asset: {url}")
+
+
+def test_rendering_is_deterministic():
+    assert render() == render()
+
+
+def test_dark_mode_is_selected_not_inherited():
+    page = render()
+    assert "prefers-color-scheme:dark" in page
+    assert '[data-theme="dark"]' in page
+    assert "--surface-1:#1a1a19" in page
+
+
+def test_the_renderer_writes_nojekyll(tmp_path: pathlib.Path):
+    """Pages runs Jekyll unless told not to, and Jekyll drops _-prefixed
+    files without saying so."""
+    import json
+    import yaml
+    status = tmp_path / "s.json"
+    status.write_text(json.dumps(STATUS), encoding="utf-8")
+    contract = tmp_path / "c.yaml"
+    contract.write_text(yaml.safe_dump(CONTRACT), encoding="utf-8")
+    cells = tmp_path / "b.yaml"
+    cells.write_text(yaml.safe_dump(CELLS), encoding="utf-8")
+    out = tmp_path / "site"
+    assert site.main(["--out", str(out), "--status", str(status),
+                      "--contract", str(contract), "--cells", str(cells),
+                      "--now", NOW]) == 0
+    assert (out / "index.html").is_file()
+    assert (out / ".nojekyll").is_file()
+
+
+def test_it_renders_the_repositorys_real_data():
+    """The fixtures above could drift from the real schema and never notice."""
+    page = site.render(site.load(site.STATUS_JSON), site.load(site.CONTRACT),
+                       site.load(site.CELLS), site.parse_iso(NOW))
+    assert "TunaOS Package Factory" in page
+    for name in site.load(site.CONTRACT)["targets"]:
+        assert name in page
+
+
+# --- the workflow that publishes it ----------------------------------------
+
+
+WORKFLOW = ROOT / ".github" / "workflows" / "pages.yml"
+
+
+def test_a_pull_request_can_render_but_never_deploy():
+    """A PR must not be able to publish to the live site."""
+    import yaml
+    flow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    assert "pull_request" in flow[True]
+    deploy = flow["jobs"]["deploy"]
+    assert "pull_request" in deploy["if"] and "!=" in deploy["if"]
+
+
+def test_it_republishes_when_the_data_it_renders_changes():
+    """A schedule would race the refresh PR's merge; the push paths cannot."""
+    import yaml
+    flow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    paths = set(flow[True]["push"]["paths"])
+    assert "docs/factory-status.json" in paths
+    assert "manifests/package-factory.yaml" in paths
+    assert "scripts/render-factory-site.py" in paths
+
+
+def test_the_deploy_job_asks_for_exactly_the_pages_permissions():
+    import yaml
+    flow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    assert flow["permissions"] == {"contents": "read"}
+    assert flow["jobs"]["deploy"]["permissions"] == {
+        "pages": "write", "id-token": "write"}
+
+
+def test_a_deploy_in_flight_is_never_cancelled():
+    import yaml
+    flow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    assert flow["concurrency"]["cancel-in-progress"] is False
+
+
+def test_pages_enables_itself_so_publishing_needs_no_settings_click():
+    """The workflow is the whole publish path. If the first deploy needs a
+    human to flip a toggle in repository settings first, the site is not
+    actually automated -- and the failure it produces ("Get Pages site failed")
+    reads like a bug rather than a missing setting."""
+    import yaml
+    flow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = flow["jobs"]["deploy"]["steps"]
+    configure = [s for s in steps if "configure-pages" in s.get("uses", "")]
+    assert configure, "no configure-pages step -- the first deploy will fail"
+    assert configure[0]["with"]["enablement"] is True
+    assert steps.index(configure[0]) < next(
+        i for i, s in enumerate(steps) if "deploy-pages" in s.get("uses", ""))

--- a/tests/test_repo_browser.py
+++ b/tests/test_repo_browser.py
@@ -1,0 +1,406 @@
+"""The package browser: what repo.tunaos.org is actually serving.
+
+docs/factory-status.json answers "how much of the plan is built". It cannot
+answer "what is in the repository", and that is the question someone has when
+they are deciding whether to point a machine at repo.tunaos.org -- previously
+answerable only by adding the repo and asking dnf, i.e. by trusting it first
+in order to find out what it holds.
+
+The properties below are the ones that make the browser trustworthy rather
+than merely present:
+
+  * it is READ from the served indexes, never hand-kept, so it cannot list a
+    package the repo does not serve nor omit one it does;
+  * an index that cannot be read is REPORTED, not dropped -- a silently
+    shorter list is exactly what #519 looked like from the outside;
+  * a flat repo two arches point at is read ONCE, not once per arch;
+  * every row is in the HTML, so the filter can only hide, never supply.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+import json
+import pathlib
+import re
+import subprocess
+import sys
+
+import pytest
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SNAPSHOT = ROOT / "scripts" / "snapshot-repo-contents.py"
+
+
+def module(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(
+        name, ROOT / "scripts" / filename)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+snap = module("snapshot_repo_contents", "snapshot-repo-contents.py")
+site = module("render_factory_site", "render-factory-site.py")
+
+NOW = dt.datetime(2026, 8, 26, tzinfo=dt.timezone.utc)
+
+
+def contents(**over) -> dict:
+    """A snapshot in the shape the real script emits."""
+    base = {
+        "generated": "2026-08-26T00:00:00Z",
+        "indexes": [
+            {"target": "el10", "arches": ["x86_64"], "format": "rpm",
+             "url": "https://repo.tunaos.org/repo/10/x86_64/", "error": None,
+             "packages": [
+                 {"name": "gtk4", "arch": "x86_64", "evr": "0:4.21.6-1.el10",
+                  "source": "gtk4", "location": "gtk4-4.21.6-1.el10.x86_64.rpm"},
+                 {"name": "libseat", "arch": "x86_64", "evr": "0:0.9.1-1.el10",
+                  "source": "libseat", "location": None},
+             ]},
+            {"target": "ubuntu", "arches": ["amd64", "arm64"], "format": "deb",
+             "url": "https://repo.tunaos.org/tideforge/ubuntu/", "error": None,
+             "packages": [
+                 {"name": "quickshell", "arch": "amd64", "evr": "0.2.0-1",
+                  "source": "quickshell", "location": "pool/q/quickshell.deb"},
+             ]},
+        ],
+        "totals": {"indexes": 2, "unreachable": 0, "packages": 3, "names": 3},
+    }
+    base.update(over)
+    return base
+
+
+# --- the snapshot ----------------------------------------------------------
+
+
+def test_every_declared_index_is_snapshotted():
+    """Contract-driven, so a target that gains a published_index appears here
+    without anyone remembering to add it."""
+    contract = yaml.safe_load(
+        (ROOT / "manifests" / "package-factory.yaml").read_text("utf-8"))
+    rows = snap.indexes(contract, None)
+    declared = {
+        url
+        for spec in contract["targets"].values()
+        for urls in (spec.get("published_index") or {}).values()
+        for url in ([urls] if isinstance(urls, str) else urls)
+    }
+    assert declared == {row["url"] for row in rows}
+    assert declared, "the contract declares no published index at all"
+
+
+def test_a_flat_repo_two_arches_share_is_read_once():
+    """ubuntu declares ONE URL for amd64 and arm64. Reading it per-arch would
+    download it twice and report its packages twice -- the count on the page
+    would be double what the repo holds."""
+    contract = {"targets": {"ubuntu": {
+        "format": "deb",
+        "published_index": {"amd64": "https://x/ubuntu/",
+                            "arm64": "https://x/ubuntu/"}}}}
+    rows = snap.indexes(contract, None)
+    assert len(rows) == 1
+    assert rows[0]["arches"] == ["amd64", "arm64"]
+
+
+def test_two_indexes_of_one_arch_stay_two():
+    """The other direction: el10 x86_64 has two disjoint prefixes (#467).
+    Collapsing them would hide everything the build-chain publisher writes."""
+    contract = {"targets": {"el10": {
+        "format": "rpm",
+        "published_index": {"x86_64": ["https://x/repo/10/x86_64/",
+                                       "https://x/xfce/10-stream-x86_64/"]}}}}
+    assert len(snap.indexes(contract, None)) == 2
+
+
+def test_a_target_with_no_published_index_contributes_none():
+    """arch and opensuse-tumbleweed have none until they publish. A row with
+    no URL would render as an index that 404s."""
+    contract = {"targets": {"arch": {"format": "pkg.tar.zst",
+                                     "published_index": None}}}
+    assert snap.indexes(contract, None) == []
+
+
+def test_an_unreachable_index_is_recorded_not_dropped(monkeypatch, tmp_path):
+    """The single most important thing this file can report. A snapshot that
+    omitted it in the name of a clean run would hide the one failure it
+    exists to catch -- packages silently absent is what #519 looked like."""
+    def boom(*a, **k):
+        raise OSError("HTTP 502")
+    monkeypatch.setattr(site, "_unused", None, raising=False)
+    monkeypatch.setattr(snap.repo_index, "iter_rows", boom)
+    row = snap.read({"target": "el10", "arches": ["x86_64"], "format": "rpm",
+                     "url": "https://x/"}, tmp_path)
+    assert row["error"] and "502" in row["error"]
+    assert row["packages"] == []
+
+
+def test_an_unreachable_index_does_not_fail_the_run(monkeypatch, tmp_path,
+                                                    capsys):
+    """One dead prefix must not take the whole site down: the page reports it
+    instead."""
+    monkeypatch.setattr(snap.repo_index, "iter_rows",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("dead")))
+    out = tmp_path / "c.json"
+    rc = snap.main(["--out", str(out), "--target", "el10",
+                    "--cache", str(tmp_path / "cache")])
+    assert rc == 0
+    data = json.loads(out.read_text("utf-8"))
+    assert data["totals"]["unreachable"] == len(data["indexes"]) > 0
+    assert "::warning::" in capsys.readouterr().err
+
+
+def test_source_packages_are_left_out(monkeypatch, tmp_path):
+    """src rpms are build inputs; publish-rpm-wave.sh excludes them from the
+    served tree, so listing them would advertise something not there."""
+    monkeypatch.setattr(snap.repo_index, "iter_rows", lambda *a, **k: [
+        {"name": "gtk4", "arch": "src", "evr": "0:1-1", "srpm": None},
+        {"name": "gtk4", "arch": "x86_64", "evr": "0:1-1", "srpm": "gtk4-1-1.src.rpm"},
+    ])
+    row = snap.read({"target": "el10", "arches": ["x86_64"], "format": "rpm",
+                     "url": "https://x/"}, tmp_path)
+    assert [p["arch"] for p in row["packages"]] == ["x86_64"]
+
+
+def test_the_snapshot_records_where_each_file_lives(monkeypatch, tmp_path):
+    """Without a location the page could only GUESS the filename from the
+    NEVRA -- and the publisher renames '+' out of filenames, so the guess is
+    wrong for exactly the packages that already caused an incident."""
+    monkeypatch.setattr(snap.repo_index, "iter_rows", lambda *a, **k: [
+        {"name": "gtk4", "arch": "x86_64", "evr": "0:1-1", "srpm": None,
+         "location": "gtk4-1-1.x86_64.rpm"}])
+    row = snap.read({"target": "el10", "arches": ["x86_64"], "format": "rpm",
+                     "url": "https://x/"}, tmp_path)
+    assert row["packages"][0]["location"] == "gtk4-1-1.x86_64.rpm"
+
+
+def test_the_rpm_reader_actually_captures_a_location():
+    """The snapshot can only record what the reader yields. Pinned against a
+    real primary.xml fragment so a refactor of repo_index cannot quietly drop
+    the field and leave every download link unbuilt."""
+    ri = module("repo_index_mod", "repo_index.py")
+    gap = ri.load("gap", "gap_engine.py")
+    blob = (
+        '<?xml version="1.0"?>'
+        f'<metadata xmlns="{gap.COMMON[1:-1]}" xmlns:rpm="{gap.RPM[1:-1]}">'
+        '<package type="rpm"><name>gtk4</name><arch>x86_64</arch>'
+        '<version epoch="0" ver="4.21.6" rel="1.el10"/>'
+        '<location href="gtk4-4.21.6-1.el10.x86_64.rpm"/>'
+        '<format><rpm:sourcerpm>gtk4-4.21.6-1.el10.src.rpm</rpm:sourcerpm>'
+        "</format></package></metadata>"
+    ).encode()
+    rows = list(ri.iter_rpm_rows(blob))
+    assert rows[0]["location"] == "gtk4-4.21.6-1.el10.x86_64.rpm"
+
+
+def test_the_snapshot_runs_end_to_end_offline(monkeypatch, tmp_path):
+    monkeypatch.setattr(snap.repo_index, "iter_rows", lambda *a, **k: [
+        {"name": "p", "arch": "x86_64", "evr": "0:1-1", "srpm": None,
+         "location": "p.rpm"}])
+    out = tmp_path / "c.json"
+    assert snap.main(["--out", str(out), "--now", "2026-08-26T00:00:00Z"]) == 0
+    data = json.loads(out.read_text("utf-8"))
+    assert data["generated"] == "2026-08-26T00:00:00Z"
+    assert data["totals"]["packages"] == len(data["indexes"])
+
+
+def test_the_snapshot_is_deterministic(monkeypatch, tmp_path):
+    """Two runs over the same repository must produce the same bytes, or the
+    page churns on every deploy for no reason."""
+    monkeypatch.setattr(snap.repo_index, "iter_rows", lambda *a, **k: [
+        {"name": "b", "arch": "x86_64", "evr": "0:1-1", "srpm": None},
+        {"name": "a", "arch": "x86_64", "evr": "0:1-1", "srpm": None}])
+    args = ["--out", "-", "--now", "2026-08-26T00:00:00Z"]
+    first = snap.main(args) or None
+    del first
+    contract = yaml.safe_load(
+        (ROOT / "manifests" / "package-factory.yaml").read_text("utf-8"))
+    a = snap.snapshot(contract, None, tmp_path, "T")
+    b = snap.snapshot(contract, None, tmp_path, "T")
+    assert json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True)
+    names = [p["name"] for p in a["indexes"][0]["packages"]]
+    assert names == sorted(names), "rows must be sorted, not index-ordered"
+
+
+# --- the rendered pages ----------------------------------------------------
+
+
+def overview(**over) -> str:
+    return site.render_repo_overview(contents(**over), NOW)
+
+
+def index_page(which: int = 0, **over) -> str:
+    data = contents(**over)
+    return site.render_repo_index(site.repo_rows(data)[which], data, NOW)
+
+
+def test_every_snapshotted_index_reaches_the_overview():
+    page = overview()
+    for row in contents()["indexes"]:
+        assert row["url"] in page
+
+
+def test_the_package_rows_are_in_the_html_not_generated_by_script():
+    """The filter may only HIDE rows. If the list were built by script, a
+    reader with scripting off would see an empty repository, and nobody could
+    diff two days of the page."""
+    page = index_page()
+    assert "gtk4" in page and "libseat" in page
+    assert "<script" not in page, "the list page body must not carry script"
+
+
+def test_a_filtered_row_is_hidden_never_removed():
+    """Pins the mechanism: rows carry a search key and the script toggles
+    `hidden`. A script that removed rows would make the count on the page
+    disagree with the repository."""
+    assert 'data-k="gtk4 gtk4"' in index_page()
+    assert "hidden" in site.FILTER_SCRIPT
+    assert "remove" not in site.FILTER_SCRIPT
+
+
+def test_the_download_link_is_built_from_the_recorded_location():
+    page = index_page()
+    assert ('href="https://repo.tunaos.org/repo/10/x86_64/'
+            'gtk4-4.21.6-1.el10.x86_64.rpm"') in page
+
+
+def test_a_package_with_no_recorded_location_still_lists():
+    """A missing location costs the link, not the row. Dropping the row would
+    make the page disagree with the repo about what is served."""
+    assert "libseat" in index_page()
+
+
+def test_an_unreachable_index_is_named_on_the_page_with_its_reason():
+    data = contents(indexes=[{
+        "target": "el10", "arches": ["aarch64"], "format": "rpm",
+        "url": "https://repo.tunaos.org/rpm/el10/aarch64/",
+        "error": "HTTPError: 502", "packages": []}])
+    page = site.render_repo_overview(data, NOW)
+    assert "unreachable" in page
+    assert "502" in page
+    assert "rpm/el10/aarch64" in page
+
+
+def test_an_unreachable_index_gets_no_browse_page(tmp_path):
+    """There is no list to show, and a link to an empty page would read as
+    'this index is empty' rather than 'this index could not be read'."""
+    data = contents(indexes=[{
+        "target": "el10", "arches": ["x86_64"], "format": "rpm",
+        "url": "https://x/dead/", "error": "boom", "packages": []}])
+    site.write_browser(data, tmp_path, NOW)
+    assert list((tmp_path / "repo").glob("*.html")) == []
+
+
+def test_a_stale_snapshot_raises_a_visible_alarm():
+    old = NOW - dt.timedelta(days=site.STALE_AFTER_DAYS + 3)
+    page = overview(generated=old.strftime("%Y-%m-%dT%H:%M:%SZ"))
+    assert "stale" in page
+    assert "alarm" in page
+
+
+def test_a_fresh_snapshot_raises_no_alarm():
+    assert "stale" not in overview()
+
+
+def test_the_page_says_how_to_add_the_repo():
+    """A browser that shows what is served but not how to consume it stops one
+    step short of the question people arrive with."""
+    assert "dnf config-manager" in index_page(0)
+    deb = [i for i, r in enumerate(site.repo_rows(contents()))
+           if r["format"] == "deb"][0]
+    assert "sources.list" in index_page(deb)
+
+
+def test_each_format_the_contract_declares_has_an_add_repo_recipe():
+    """Adding a format without one would render a browse page that tells a
+    reader nothing about using it."""
+    contract = yaml.safe_load(
+        (ROOT / "manifests" / "package-factory.yaml").read_text("utf-8"))
+    for spec in contract["targets"].values():
+        assert spec.get("format", "rpm") in site.ADD_REPO
+
+
+def test_two_indexes_of_one_target_get_distinct_pages(tmp_path):
+    """el10 x86_64 has two. Naming pages by target would overwrite one with
+    the other and silently halve what the browser shows."""
+    data = contents(indexes=[
+        {"target": "el10", "arches": ["x86_64"], "format": "rpm",
+         "url": "https://repo.tunaos.org/repo/10/x86_64/", "error": None,
+         "packages": [{"name": "a", "arch": "x86_64", "evr": "0:1-1",
+                       "source": "a", "location": None}]},
+        {"target": "el10", "arches": ["x86_64"], "format": "rpm",
+         "url": "https://repo.tunaos.org/xfce/10-stream-x86_64/",
+         "error": None,
+         "packages": [{"name": "b", "arch": "x86_64", "evr": "0:1-1",
+                       "source": "b", "location": None}]},
+    ])
+    site.write_browser(data, tmp_path, NOW)
+    assert len(list((tmp_path / "repo").glob("*.html"))) == 2
+
+
+def test_the_browser_pages_are_self_contained(tmp_path):
+    site.write_browser(contents(), tmp_path, NOW)
+    for page in [tmp_path / "packages.html", *(tmp_path / "repo").glob("*")]:
+        text = page.read_text("utf-8")
+        assert "<script src" not in text.lower(), page
+        assert "<link" not in text.lower(), page
+        for url in re.findall(r'(?:src|href)="(https?://[^"]+)"', text):
+            assert url.startswith(("https://repo.", "https://github.com")), url
+
+
+def test_the_status_page_links_to_the_browser_only_when_it_exists():
+    """A link to a page that was not rendered is worse than no link."""
+    status = json.loads(
+        (ROOT / "docs" / "factory-status.json").read_text("utf-8"))
+    contract = yaml.safe_load(
+        (ROOT / "manifests" / "package-factory.yaml").read_text("utf-8"))
+    cells = yaml.safe_load(
+        (ROOT / "manifests" / "package-builds.yaml").read_text("utf-8"))
+    with_browser = site.render(status, contract, cells, NOW, contents())
+    without = site.render(status, contract, cells, NOW, None)
+    assert 'href="packages.html"' in with_browser
+    assert "packages.html" not in without
+
+
+def test_rendering_the_browser_is_deterministic():
+    assert overview() == overview()
+    assert index_page() == index_page()
+
+
+# --- the workflow that refreshes it ----------------------------------------
+
+
+WORKFLOW = ROOT / ".github" / "workflows" / "pages.yml"
+
+
+def flow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def test_the_deploy_takes_a_fresh_snapshot():
+    """The browser's source is the live repository, not a file in git, so it
+    must be read at deploy time or the page ships yesterday's repo."""
+    steps = flow()["jobs"]["build"]["steps"]
+    assert any("snapshot-repo-contents.py" in str(s.get("run", ""))
+               for s in steps)
+
+
+def test_the_snapshot_runs_before_the_render():
+    steps = flow()["jobs"]["build"]["steps"]
+    order = [i for i, s in enumerate(steps)
+             if "snapshot-repo-contents.py" in str(s.get("run", ""))
+             or "render-factory-site.py" in str(s.get("run", ""))]
+    assert len(order) == 2 and order[0] < order[1]
+
+
+def test_it_also_republishes_on_a_timer():
+    """Unlike the status data -- which lands through a PR merge, so the push
+    paths catch it -- the repository changes when a PUBLISH workflow runs, and
+    no commit records that. A timer is the only signal there is."""
+    triggers = flow()[True]
+    assert "schedule" in triggers, (
+        "without a schedule the browser only refreshes when unrelated files "
+        "change on main")


### PR DESCRIPTION
Two pages, both published to GitHub Pages by `.github/workflows/pages.yml`, both views of measurements the factory already makes.

## 1. The status page — "how much of the plan is built"

`docs/FACTORY-STATUS.md` answers that for someone already reading the repository with a checkout in hand. `scripts/render-factory-site.py` renders the same measurements to a URL, so the answer is reachable without one — and by people who are not going to read YAML.

The renderer reads `docs/factory-status.json`, `manifests/package-factory.yaml` and `manifests/package-builds.yaml` and nothing else. It has no measurement logic of its own, so the site cannot *disagree* with the measurement — it can only be **stale**, and it says so about itself, using the same threshold `factory-status.py` warns at (pinned by a test so the two cannot drift apart).

It also cannot hide bad news. Tests assert that a declared-but-unmeasurable target appears anyway *with its reason*, that every contract target reaches the page, that a `REGRESSED` state reaches the page, and that a stalled target's stall age is shown.

## 2. The package browser — "what is actually IN the repository"

A different question, and the one someone has when deciding whether to point a machine at `repo.tunaos.org`. Until now it was answerable only by adding the repo and asking dnf — you had to trust it first in order to find out what it held.

`scripts/snapshot-repo-contents.py` reads every `published_index` the contract declares, through the same format-neutral index layer (`scripts/repo_index.py`) the hygiene checks use, at the same URLs a package manager would use. Today that is **9,966 packages / 8,215 distinct names across 8 served indexes**. The renderer produces an overview of every index plus one page per index: package, version, arch, source package, a direct download link, and the command to add the repo on that format.

Properties, each pinned by a test:

- **Read, never hand-kept** — it cannot list a package the repo does not serve, nor omit one it does.
- **An unreachable index is named with its reason, not dropped.** A silently shorter list is exactly what #519 looked like from outside. One dead prefix does not fail the deploy; the page reports it.
- **A flat deb repo two arches point at is read once.** Reading it per-arch would report its 16 packages as 32. The arches that name it are recorded on the row instead — also the truthful shape, since the index is not per-arch, the pointer to it is.
- **Two indexes of one arch stay two.** el10 x86_64 has two disjoint prefixes (#467) and they get distinct pages, so nothing the build-chain publisher writes hides behind the tideforge one.
- **Every row is in the HTML.** The filter box only *hides* rows, so with scripting off the page is the full list and a reader is never looking at a subset the page has not told them about.

The download links were verified live: `colord-gtk4-0.3.1-1.el10.x86_64.rpm` and a `tideforge/ubuntu` pool file both return 200. They are built from the recorded `<location>` / `Filename` rather than guessed from the NEVRA — the publisher renames `+` out of filenames, so a guess is wrong for exactly the packages that already caused an incident. Capturing that field is the only change to the shared index readers.

## When each republishes

Deliberately different, for opposite reasons:

- **Status**: on push, keyed to the files it renders *from*. The daily refresh lands through a bot PR at an hour no cron can predict, so a schedule would either race the merge or sit hours behind it.
- **Browser**: on a daily cron *as well*. Its source is not a file in git — the repository changes when a publish workflow runs, and no commit records that, so a timer is the only signal there is.

The snapshot is taken at deploy time and gitignored: megabytes that change daily and are never read back from git.

## Safety

- A pull request **renders but never deploys** — the deploy job is gated on `github.event_name != 'pull_request'`. The render still runs, so a change that breaks the renderer fails the PR rather than the deploy.
- Top-level `permissions: contents: read`; only the deploy job holds `pages: write` / `id-token: write`.
- `cancel-in-progress: false` — a half-published site is worse than a republish landing a minute late.
- `configure-pages@v5` with `enablement: true`, so the first deploy turns Pages on itself rather than failing with a message that reads like a bug but is really a missing settings toggle.

## Accessibility

No external assets of any kind (pinned by test) — the pages open from a `file://` URL. State is carried by icon **and** label, never colour alone; proportion bars have text equivalents and `aria-label`s; a table view of the same numbers sits alongside them; dark mode is a selected palette against a dark surface, not an automatic inversion.

## Testing

`pytest tests/` — **1413 passed, 1 skipped**. The status tests render from the *real* repository data, so a schema change the renderer cannot read fails here rather than on the live site; the browser tests drive the snapshot offline against synthetic indexes so they pin behaviour without depending on the network. The filter and the download links were additionally exercised in a real browser.