### PR TITLE
Name the one-time Pages toggle; fix the pacman db name

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -98,14 +98,24 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      # Turn Pages on if it is not already, and point it at Actions rather
-      # than a branch. Without this the FIRST deploy fails with "Pages is not
-      # enabled" and someone has to go click a settings toggle -- which makes
-      # the publish manual, which is the one thing this workflow exists to
-      # avoid. It is idempotent: on every later run it just reads back the
-      # settings that are already correct.
+      # Reads the Pages configuration, and turns Pages on where the token is
+      # allowed to. `enablement: true` is kept because it costs nothing and
+      # self-heals a fork, but do NOT rely on it here: creating a Pages site
+      # needs repository-administration scope, which GITHUB_TOKEN cannot be
+      # granted no matter what `permissions:` says, so on this repository the
+      # first enable is a one-time human action. Run 32926048349 failed
+      # exactly there, with "Create Pages site failed: Resource not accessible
+      # by integration" -- an error that names an integration and reads like a
+      # bug, when the actual fix is one settings toggle. The step below turns
+      # that into instructions.
       - uses: actions/configure-pages@v5
         with:
           enablement: true
+      - name: Explain a Pages site that does not exist yet
+        if: failure()
+        run: |
+          # One line, because ::error:: annotations are line-oriented.
+          echo "::error::GitHub Pages is not enabled for this repository, and the workflow token is not permitted to enable it (creating a Pages site needs repository-administration scope, which GITHUB_TOKEN cannot be granted). A repository admin must do this ONCE: Settings -> Pages -> Build and deployment -> Source: GitHub Actions. Every later run of this workflow then deploys with no manual step."
+          exit 1
       - id: deployment
         uses: actions/deploy-pages@v4

--- a/scripts/snapshot-repo-contents.py
+++ b/scripts/snapshot-repo-contents.py
@@ -94,8 +94,13 @@ def read(row: dict, cache: pathlib.Path) -> dict:
     """One index's packages, or the reason there are none."""
     out = dict(row, packages=[], error=None)
     try:
-        rows = list(repo_index.iter_rows(
-            row["url"], row["format"], cache, repo_name=row["target"]))
+        # NOT repo_name=target. For pkg.tar.zst the db file is named after
+        # the REPOSITORY (scripts/plan-arch-publish.py: REPO_NAME = "tunaos",
+        # published as tunaos.db), not after the factory's target id, so
+        # passing "arch" here would fetch arch.db, 404, and report the index
+        # as unreachable the day it is first declared. Omitting it takes the
+        # same default the hygiene checks take.
+        rows = list(repo_index.iter_rows(row["url"], row["format"], cache))
     except Exception as exc:                    # noqa: BLE001 -- see docstring
         out["error"] = f"{type(exc).__name__}: {exc}"
         return out

--- a/tests/test_repo_browser.py
+++ b/tests/test_repo_browser.py
@@ -404,3 +404,40 @@ def test_it_also_republishes_on_a_timer():
     assert "schedule" in triggers, (
         "without a schedule the browser only refreshes when unrelated files "
         "change on main")
+
+
+def test_the_pacman_db_is_named_after_the_repo_not_the_target():
+    """arch declares no published_index yet, so this is unexercised until the
+    day it does -- which is exactly when a wrong db name would surface, as an
+    index reported unreachable rather than as a bug anyone could see coming.
+
+    repo-add publishes <REPO_NAME>.db (scripts/plan-arch-publish.py, "tunaos"),
+    and the factory's target id is "arch". Passing the target as the db name
+    would fetch arch.db and 404."""
+    body = SNAPSHOT.read_text(encoding="utf-8")
+    assert "repo_name=row" not in body, (
+        "the target id is not the repository name; see plan-arch-publish.py")
+    name = re.search(r'REPO_NAME\s*=\s*"([^"]+)"',
+                     (ROOT / "scripts" / "plan-arch-publish.py")
+                     .read_text(encoding="utf-8")).group(1)
+    ri = module("repo_index_for_db", "repo_index.py")
+    default = re.search(r'db = f"\{repo_name\}\.db" if repo_name else "([^"]+)\.db"',
+                        (ROOT / "scripts" / "repo_index.py")
+                        .read_text(encoding="utf-8")).group(1)
+    assert default == name, (
+        f"repo_index defaults to {default}.db but the publisher writes "
+        f"{name}.db")
+    del ri
+
+
+def test_a_missing_pages_site_is_explained_not_just_failed():
+    """`Create Pages site failed: Resource not accessible by integration` names
+    an integration and reads like a bug. It is a one-time settings toggle that
+    GITHUB_TOKEN cannot perform at any permission level, and the workflow
+    should say so rather than leave the next person reading GitHub's REST
+    docs (run 32926048349)."""
+    steps = flow()["jobs"]["deploy"]["steps"]
+    explain = [s for s in steps if s.get("if") == "failure()"]
+    assert explain, "nothing explains a deploy that failed to configure Pages"
+    body = str(explain[0].get("run", ""))
+    assert "Settings" in body and "Pages" in body and "GitHub Actions" in body


### PR DESCRIPTION
Two fixes found by the first real deploy ([run 32926048349](https://github.com/tuna-os/tunaos-packages/actions/runs/32926048349)).

## Pages self-enablement does not work on this repository

`configure-pages` failed with:

```
Create Pages site failed. Error: Resource not accessible by integration
```

The job's token had `Pages: write`. That is enough to *read* the Pages config and to deploy, but **creating** a Pages site needs repository-administration scope, which `GITHUB_TOKEN` cannot be granted at any `permissions:` level. So the first enable is a one-time human action here regardless of what the workflow asks for — [PR #530](https://github.com/tuna-os/tunaos-packages/pull/530) claimed otherwise and was wrong about it.

**What a repo admin needs to do, once:** Settings → Pages → Build and deployment → Source: **GitHub Actions**. Every later run then deploys with no manual step.

The `configure-pages` step is kept — it costs nothing, self-heals a fork, and succeeds on every run once the site exists. What changes is honesty about it: the comment no longer claims it removes the manual step, and a failure now prints the actual fix rather than an error that names an integration and reads like a bug.

## The pacman db name

The snapshot passed the factory's *target id* as the pacman db name. `repo-add` publishes `<REPO_NAME>.db` — `"tunaos"`, per `scripts/plan-arch-publish.py:37` — not `<target>.db`. So `arch` would have fetched `arch.db`, 404'd, and reported the index as **unreachable** the day arch first declares a `published_index`. Omitting the argument takes the same default the hygiene checks already take.

Unexercised today, since arch declares no index yet — which is precisely why it would have surfaced as a mystery 404 rather than as a bug anyone saw coming. The test reads both names from their own sources rather than restating either, so a rename of one without the other fails here.

## Testing

`pytest tests/` — 1415 passed, 1 skipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_015sZp9iEZAJS44joA2Z8mCK)_