### PR TITLE
The chain cannot accumulate: the publisher's key disagrees with the nightly's, and it never banks a partial

### DIFF
--- a/.github/workflows/publish-build-chain-rpms.yml
+++ b/.github/workflows/publish-build-chain-rpms.yml
@@ -101,7 +101,29 @@ jobs:
           # %at, not %ct -- author date survives rebases; the nightly's key
           # uses it and this key must MATCH the nightly's or the bridge is a
           # mirage (package-factory-cell.yml carries the full incident).
-          epoch=$(git log -1 --format=%at -- '${{ matrix.manifest }}' "${source_paths[@]}")
+          #
+          # The manifest is NOT in this list, and that is the whole point.
+          # #529 dropped it from package-factory-cell.yml so a manifest edit
+          # stops re-keying every cell -- and left this copy alone, so the two
+          # halves of the bridge computed different keys from that moment on.
+          # Measured on 2026-08-26: manifests/package-factory.yaml last moved
+          # at 1787654862 and the hummingbird sources at 1787527705, so the
+          # nightly and the publisher disagreed by 127157 seconds -- 35 hours.
+          # The epoch is an action-key input, so the publisher could neither
+          # cache-hit the nightly's completed chain nor accept its partial:
+          # restore-partial-chain-output.py rejects a partial whose key
+          # differs, and the chain restarts at bootstrap-00.
+          #
+          # This is #529's own lesson one file over -- a fix that closed one
+          # of two paths and was named for both.
+          if [ "${#source_paths[@]}" -eq 0 ]; then
+            echo "::error::cell '${{ matrix.id }}' declares no source_paths, so" \
+                 "SOURCE_DATE_EPOCH cannot be derived from them; refusing rather" \
+                 "than falling back to the repository's last commit, which would" \
+                 "re-key this cell on EVERY commit"
+            exit 1
+          fi
+          epoch=$(git log -1 --format=%at -- "${source_paths[@]}")
           args=()
           for path in "${source_paths[@]}"; do args+=(--input "$path"); done
           payload=$(python3 scripts/tideforge-action-cache.py native-key             --identity '${{ matrix.id }}' --manifest '${{ matrix.manifest }}'             "${args[@]}" --target '${{ matrix.target }}'             --arch '${{ matrix.architecture }}' --image "$image"             --dependency-tree '${{ matrix.dependency_tree }}'             --target-queue '${{ matrix.target_queue }}'             --track '${{ matrix.track }}' --series '${{ matrix.series }}'             --source-date-epoch "$epoch")

--- a/.github/workflows/publish-build-chain-rpms.yml
+++ b/.github/workflows/publish-build-chain-rpms.yml
@@ -158,6 +158,7 @@ jobs:
         run: |
           python3 scripts/restore-partial-chain-output.py             --cell-id '${{ matrix.id }}'             --action-key '${{ steps.identity.outputs.key }}'             --out-dir '.factory/${{ matrix.id }}'
       - name: Build the cell
+        id: build
         env:
           CELL_ID: ${{ matrix.id }}
           ENGINE: build-chain
@@ -176,6 +177,45 @@ jobs:
           name: publish-rpm-${{ matrix.id }}
           path: .factory/${{ matrix.id }}/artifacts/*.rpm
           if-no-files-found: error
+
+      # Bank the partial, so hours spent here are not thrown away.
+      #
+      # This job resumes the nightly's partial and extends it, and until now it
+      # could only ever READ one. Its sole upload is the success artifact
+      # above, which has no `always()`, so a run torn down at the 360-minute
+      # cap uploaded nothing at all and the next run resumed from a partial as
+      # old as whatever the nightly last banked. Six hours of chain, discarded
+      # silently, on a job whose whole purpose is to accumulate.
+      #
+      # Everything here is copied deliberately from package-factory-cell.yml,
+      # which paid for each rule:
+      #
+      #   always()      a job that exhausts timeout-minutes is torn down, and
+      #                 always() is the only condition GitHub documents as
+      #                 still running steps then. failure()/cancelled() is a
+      #                 guess about which one a timeout satisfies.
+      #   an ALLOWLIST  written as `!= 'success'` it also fires on an exact
+      #                 cache hit, where the build never ran, and uploads a
+      #                 redundant ~500MB copy beside the real artifact.
+      #   chain_deferred  the soft deadline exits 0, so the outcome is
+      #                 `success` — but "ran and did not finish" is exactly
+      #                 its state, and it is the upload the next run resumes.
+      #
+      # The name is `${{ matrix.id }}-partial` and that is not arbitrary:
+      # restore-partial-chain-output.py queries `f"{cell_id}-partial"` and this
+      # job passes `--cell-id '${{ matrix.id }}'`, while the nightly writes
+      # `${{ matrix.base_id || matrix.id }}-partial` and reads the same. The
+      # publish planner emits no base_id and its cell id IS the base, so both
+      # sides land on one shared name per family cell.
+      - uses: actions/upload-artifact@v7
+        if: always() && (steps.build.outcome == 'failure' || steps.build.outcome == 'cancelled' || steps.build.outputs.chain_deferred == 'true')
+        with:
+          name: ${{ matrix.id }}-partial
+          overwrite: true
+          path: |
+            .factory/${{ matrix.id }}/artifacts/
+            .factory/${{ matrix.id }}/action-key.txt
+          if-no-files-found: warn
 
   publish:
     needs: [plan, build]

--- a/tests/test_action_key_epoch_survives_rebase.py
+++ b/tests/test_action_key_epoch_survives_rebase.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 CELL = ROOT / ".github" / "workflows" / "package-factory-cell.yml"
+WORKFLOWS = ROOT / ".github" / "workflows"
 
 
 def workflow() -> str:
@@ -30,6 +31,26 @@ def workflow() -> str:
 
 def epoch_lines() -> list[str]:
     return [ln.strip() for ln in workflow().splitlines() if "epoch=$(git log" in ln]
+
+
+def every_epoch_line() -> dict[str, list[str]]:
+    """Every workflow that derives an epoch, not just the cell runner.
+
+    This file read one file for its whole life, and that is precisely how the
+    bug below survived: #529 removed the manifest from the cell runner's epoch
+    and left the publisher's copy of the same line untouched, because nothing
+    looked at it.
+    """
+    found = {}
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        lines = [
+            ln.strip()
+            for ln in path.read_text(encoding="utf-8").splitlines()
+            if "epoch=$(git log" in ln
+        ]
+        if lines:
+            found[path.name] = lines
+    return found
 
 
 def test_both_engines_derive_an_epoch():
@@ -60,3 +81,74 @@ def test_the_reason_is_recorded_next_to_the_change():
     preamble = text[max(0, anchor - 1200):anchor]
     assert "#477" in preamble
     assert re.search(r"author", preamble, re.I)
+
+
+# ── The two halves of the nightly→publisher bridge must agree ────────────────
+#
+# publish-build-chain-rpms.yml resumes the nightly's banked partial, and its
+# own comment says the key "must MATCH the nightly's or the bridge is a
+# mirage". The epoch is an action-key input, so any difference in how the two
+# derive it breaks that match silently — no error, just a chain that restarts
+# at bootstrap-00 while every step reports success.
+#
+# Measured on 2026-08-26, before the fix: manifests/package-factory.yaml last
+# moved at 1787654862, the hummingbird sources at 1787527705. The publisher
+# included the manifest in its `git log` paths and the nightly (post-#529) did
+# not, so they disagreed by 127157 seconds — 35 hours — and had done since
+# #529 merged.
+
+
+def test_no_workflow_puts_the_manifest_in_the_epoch_paths():
+    """The manifest is the input #529 removed; it must stay out of all of them."""
+    offenders = [
+        f"{name}: {line}"
+        for name, lines in every_epoch_line().items()
+        for line in lines
+        if "matrix.manifest" in line
+    ]
+    assert not offenders, (
+        "an epoch derived from the manifest re-keys every cell on any manifest "
+        "edit, and disagrees with the cell runner's key: " + "; ".join(offenders)
+    )
+
+
+def test_every_workflow_that_derives_an_epoch_uses_the_same_paths():
+    """Guard the guard: equality, not just absence of the manifest.
+
+    Asserting only that the manifest is gone would still pass if one workflow
+    added some other path the other lacked — the same class of silent drift
+    one input over.
+    """
+    def paths(line: str) -> str:
+        return line.split("--", 1)[1].strip() if "--" in line else line
+
+    seen = {
+        name: sorted({paths(line) for line in lines})
+        for name, lines in every_epoch_line().items()
+    }
+    assert seen, "no workflow derives an epoch — this test is measuring nothing"
+    native = {
+        name: [p for p in ps if "source_paths" in p] for name, ps in seen.items()
+    }
+    native = {name: ps for name, ps in native.items() if ps}
+    assert len(native) >= 2, (
+        "expected both the cell runner and the publisher to derive a native "
+        f"epoch; found {sorted(native)}"
+    )
+    distinct = {tuple(ps) for ps in native.values()}
+    assert len(distinct) == 1, (
+        "the nightly and the publisher derive the epoch from different paths, "
+        f"so their action keys cannot match: {native}"
+    )
+
+
+def test_the_publisher_refuses_an_empty_source_path_list():
+    """`git log -1 --format=%at --` with no paths returns the repo's last commit.
+
+    That re-keys every cell on every push — strictly worse than the bug this
+    fixes, and silent, because an epoch is just a number. The cell runner
+    already guards it; the publisher must too.
+    """
+    body = (WORKFLOWS / "publish-build-chain-rpms.yml").read_text(encoding="utf-8")
+    assert "declares no source_paths" in body
+    assert '"${#source_paths[@]}" -eq 0' in body

--- a/tests/test_the_publisher_banks_its_own_partial.py
+++ b/tests/test_the_publisher_banks_its_own_partial.py
@@ -1,0 +1,144 @@
+"""A six-hour publisher run that is torn down must not lose its chain.
+
+`publish-build-chain-rpms.yml` exists to resume the nightly's banked partial
+and extend it. Until now it could only ever READ one. Its single upload is the
+success artifact, which carries no `always()`, so a run that exhausted its
+360-minute `timeout-minutes` uploaded nothing — and the next run resumed from
+whatever the nightly had last banked, as if those six hours had not happened.
+
+That is the other half of why the chain does not accumulate. The first half
+was the epoch: the publisher derived it from paths including the manifest
+while `package-factory-cell.yml` (post-#529) did not, so their action keys
+disagreed by 35 hours of commit time and every partial was rejected as "action
+key differs". Fixing only the key would let the publisher accept a partial it
+still could not produce.
+
+Every rule asserted here was learned in package-factory-cell.yml and is copied
+rather than re-derived:
+
+  * `always()`, because a timeout tears the job down and it is the only
+    condition GitHub documents as still running steps then;
+  * an outcome ALLOWLIST, because `!= 'success'` also fires on an exact cache
+    hit — where the build never ran — and uploads a redundant copy the size of
+    the real artifact;
+  * `chain_deferred`, because the soft deadline exits 0 and would otherwise
+    look like a clean finish.
+
+The `id: build` test is the one that matters most. Without it every condition
+above reads `steps.build.outcome` on a step that has no id, evaluates empty,
+and the upload silently never runs — configured, reviewed, and inert.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[1]
+PUBLISHER = ROOT / ".github" / "workflows" / "publish-build-chain-rpms.yml"
+CELL = ROOT / ".github" / "workflows" / "package-factory-cell.yml"
+RESTORE = ROOT / "scripts" / "restore-partial-chain-output.py"
+
+
+def build_steps() -> list[dict]:
+    return yaml.safe_load(PUBLISHER.read_text(encoding="utf-8"))["jobs"]["build"]["steps"]
+
+
+def partial_upload() -> dict:
+    for step in build_steps():
+        with_ = step.get("with") or {}
+        if "upload-artifact" in str(step.get("uses", "")) and str(
+            with_.get("name", "")
+        ).endswith("-partial"):
+            return step
+    raise AssertionError("the publisher has no partial upload step")
+
+
+def test_the_publisher_uploads_a_partial_at_all():
+    assert partial_upload()
+
+
+def test_the_build_step_has_an_id_or_every_condition_is_inert():
+    """`steps.build.outcome` on a step with no id evaluates to empty."""
+    named = [s for s in build_steps() if s.get("name") == "Build the cell"]
+    assert named, "the build step was renamed; this file no longer measures it"
+    assert named[0].get("id") == "build", (
+        "the partial upload conditions read steps.build.*, which is empty "
+        "unless the step declares `id: build` — the upload would never run"
+    )
+
+
+def test_it_survives_a_timeout_teardown():
+    assert "always()" in partial_upload()["if"], (
+        "a job that exhausts timeout-minutes is torn down; only always() is "
+        "documented as still running steps then"
+    )
+
+
+def test_the_outcome_test_is_an_allowlist_not_a_denylist():
+    """`!= 'success'` also fires on a cache hit, where the build never ran."""
+    condition = partial_upload()["if"]
+    assert "!=" not in condition, (
+        "a denylist admits every future outcome value, which is how `skipped` "
+        "got in and uploaded a redundant copy of every cached cell"
+    )
+    for outcome in ("failure", "cancelled"):
+        assert f"steps.build.outcome == '{outcome}'" in condition
+
+
+def test_a_deferred_chain_also_banks():
+    """The soft deadline exits 0, so the outcome is `success`."""
+    assert "steps.build.outputs.chain_deferred == 'true'" in partial_upload()["if"]
+
+
+def test_the_name_is_what_the_resume_step_queries():
+    """Read and write must agree, or the upload is written where nothing looks.
+
+    restore-partial-chain-output.py builds the artifact name as
+    f"{cell_id}-partial", and this job passes --cell-id matrix.id.
+    """
+    assert '-partial"' in RESTORE.read_text(encoding="utf-8")
+    assert partial_upload()["with"]["name"] == "${{ matrix.id }}-partial"
+    body = PUBLISHER.read_text(encoding="utf-8")
+    assert "--cell-id '${{ matrix.id }}'" in body
+
+
+def test_it_overwrites_rather_than_failing_on_the_shared_name():
+    """One partial per family cell; each run replaces the previous."""
+    assert partial_upload()["with"]["overwrite"] is True
+
+
+def test_it_carries_the_action_key_the_next_resume_checks():
+    """A partial with no recorded key is rejected as unverifiable."""
+    paths = partial_upload()["with"]["path"]
+    assert "action-key.txt" in paths
+    assert "artifacts/" in paths
+
+
+def test_a_missing_directory_warns_rather_than_failing_the_job():
+    """A cell that died before creating it would otherwise replace the real
+    error with an upload error."""
+    assert partial_upload()["with"]["if-no-files-found"] == "warn"
+
+
+def test_the_success_upload_is_left_alone():
+    """Guard the guard: the deliverable must still be uploaded on success."""
+    names = [
+        (s.get("with") or {}).get("name")
+        for s in build_steps()
+        if "upload-artifact" in str(s.get("uses", ""))
+    ]
+    assert "publish-rpm-${{ matrix.id }}" in names
+
+
+def test_the_rules_match_the_workflow_they_were_copied_from():
+    """Drift guard: if the cell runner's allowlist changes, this should too."""
+    cell_body = CELL.read_text(encoding="utf-8")
+    cell_conditions = re.findall(r"steps\.build\.outcome == '(\w+)'", cell_body)
+    assert set(cell_conditions) >= {"failure", "cancelled"}, (
+        "package-factory-cell.yml's allowlist changed shape; re-check this one"
+    )


### PR DESCRIPTION
Two halves of one failure. `publish-build-chain-rpms.yml` exists to resume the nightly's banked chain and extend it — it could do neither.

## 1. The keys disagree, so every partial is rejected

The job's own comment states the requirement it stopped meeting:

> `%at`, not `%ct` — author date survives rebases; **the nightly's key uses it and this key must MATCH the nightly's or the bridge is a mirage**.

#529 removed `matrix.manifest` from `SOURCE_DATE_EPOCH` in `package-factory-cell.yml` so a manifest edit stops re-keying every cell. It left the identical line here untouched. Measured on 2026-08-26 against the live tree:

```
manifests/package-factory.yaml   last commit 1787654862   (2026-08-25 10:47)
hummingbird sources              last commit 1787527705

epoch without the manifest (nightly, post-#529)   1787527705
epoch with the manifest    (publisher)            1787654862
difference                                        127157s = 35 hours
```

The epoch is an action-key input, so the publisher could neither cache-hit a completed chain nor accept a banked partial — `restore-partial-chain-output.py` rejects a partial whose key differs and restarts at `bootstrap-00`. That is #528's signature:

```
[resume] found `hummingbird-x86_64-partial` from 11:26:17Z (429 MB)
[resume] action key differs … the inputs changed, so building from scratch
===== Tier: bootstrap-00 =====
```

still firing after #529 closed the *other* path into the key.

Also adds the empty-`source_paths` guard the cell runner already has: `git log -1 --format=%at --` with no paths returns the repository's last commit, which would re-key every cell on every push — worse than the bug, and silent, because an epoch is only a number.

## 2. It could resume a partial but never produce one

The job's only upload is the success artifact, which carries no `always()`. A run torn down at its 360-minute `timeout-minutes` uploaded **nothing**, and the next run resumed from whatever the nightly last banked — as if those six hours had not happened. Fixing only the key would have let the publisher accept a partial it still could not produce.

Every rule is copied from `package-factory-cell.yml` rather than re-derived, because each was paid for there: `always()` (a timeout teardown runs only `always()` steps), an outcome **allowlist** (`!= 'success'` also fires on an exact cache hit and uploads a redundant ~500MB copy), and `chain_deferred` (the soft deadline exits 0, so the outcome is `success` while "ran and did not finish" is exactly its state).

The artifact name is settled rather than guessed: `restore-partial-chain-output.py` builds it as `f"{cell_id}-partial"` and this job passes `--cell-id matrix.id`; the nightly writes `${{ matrix.base_id || matrix.id }}-partial` and reads the same. The publish planner emits no `base_id` and its cell id **is** the base, so both sides land on one shared name per family cell. Verified against the planner's emitted keys and the restore script's query.

`id: build` had to be added — the step had none, so every condition would have read `steps.build.*` as empty and the upload would have been configured, reviewed, and inert.

## Why this matters beyond this repo

Nothing downstream moves until the chain accumulates. `tuna-os/tunaOS`'s hummingbird gnome image is currently **14 of 52** desktop packages: `flatpak` (layer-07) gates every ISO, `gnome-shell` (layer-09) gates the desktop. Both are in the build order and unbuilt. The chain is **570 of 673 sources served** — it is not far from done; it just keeps starting over. Publish run [32914264044](https://github.com/tuna-os/tunaos-packages/actions/runs/32914264044) has been in `Build the cell` for over four hours and would have banked nothing.

## Tests

The epoch test read **one file** for its whole life, which is exactly how this survived: #529 changed the cell runner and nothing was looking at the publisher. It now walks every workflow that derives an epoch and asserts they **agree** — not merely that the manifest is absent, since equality is what the bridge needs and an extra path in either file is the same drift one input over.

| Mutation | Fails |
| :--- | :--- |
| restore `matrix.manifest` in the publisher's epoch | `test_no_workflow_puts_the_manifest_in_the_epoch_paths`, `test_every_workflow_that_derives_an_epoch_uses_the_same_paths` |
| drop the empty-`source_paths` guard | `test_the_publisher_refuses_an_empty_source_path_list` |
| remove `id: build` | `test_the_build_step_has_an_id_or_every_condition_is_inert` |
| denylist instead of allowlist | `test_the_outcome_test_is_an_allowlist_not_a_denylist`, `test_a_deferred_chain_also_banks` |
| rename the partial artifact | `test_the_name_is_what_the_resume_step_queries` |

Full suite: **1429 passed, 1 skipped**.

Neither change touches an action-key input (`renderer_inputs` covers `scripts/build-chain.sh` and `scripts/run-package-factory-cell.sh`, not workflow YAML), so nothing here re-keys a cell or disturbs the in-flight run.