### PR TITLE
fix(hummingbird): evict two stale fc43 packages that mask the providers GNOME 51 needs

### DIFF
--- a/mock/hummingbird-ci-aarch64.cfg
+++ b/mock/hummingbird-ci-aarch64.cfg
@@ -122,7 +122,7 @@ priority=11
 # publish-rpm-wave.sh:101 renames across the WHOLE synced-down repo, not
 # just the staged wave, so the first publish that completes fixes all 79 and
 # this exclude can go.
-exclude=*+* libcdio-paranoia* jsoncpp* mingw* ucrt64-*
+exclude=*+* libcdio-paranoia* jsoncpp* mingw* ucrt64-* wayland-protocols* python3-docutils*
 # jsoncpp*: see [hummingbird] -- with the base's excluded, OUR jsoncpp
 # (also .so.27, priority 11) would mask Rawhide's .so.26 provider and
 # reinstate the very block being dodged. Only our own jsoncpp-devel
@@ -136,6 +136,22 @@ exclude=*+* libcdio-paranoia* jsoncpp* mingw* ucrt64-*
 # That is the next failure the running leg will hit at abseil-cpp/inih.
 # Excluding the whole family keeps Rawhide's toolchain internally
 # coherent, exactly as it was before #548 added this repo.
+#
+# wayland-protocols*: TEMPORARY. Our served wayland-protocols-devel is
+# 1.47-2.fc43 (stale, not in any build order) and at priority 11 it masks
+# Rawhide's 1.49. gtk4 and mutter BuildRequire
+# pkgconfig(wayland-protocols) >= 1.48, so the stale copy blocks the two
+# packages the GNOME 51 goal hangs on. Nothing rebuilds it in the chain;
+# once a wave publishes a current build (or the stale one is pruned) this
+# exclude can go.
+#
+# python3-docutils*: TEMPORARY. Our served python3-docutils is 0.23-1.fc43;
+# at priority 11 it masks F44's 0.22.4 while python3-sphinx (fc44) requires
+# python3.14dist(docutils) >= 0.20 with < 0.23~~ -- 0.23 fails the upper
+# bound, so every sphinx consumer (~17 sources incl. at-spi2-core and
+# xdg-desktop-portal) is blocked by our own stale copy. Excluding it lets
+# F44's in-range 0.22.4 serve the buildroot. Not in any build order; remove
+# when the served copy is current or pruned.
 
 [fedora-44-python]
 name=Fedora 44 - Python 3.14 build inputs only

--- a/mock/hummingbird-ci.cfg
+++ b/mock/hummingbird-ci.cfg
@@ -269,7 +269,7 @@ priority=11
 # publish-rpm-wave.sh:101 renames across the WHOLE synced-down repo, not
 # just the staged wave, so the first publish that completes fixes all 79 and
 # this exclude can go.
-exclude=*+* libcdio-paranoia* jsoncpp* mingw* ucrt64-*
+exclude=*+* libcdio-paranoia* jsoncpp* mingw* ucrt64-* wayland-protocols* python3-docutils*
 # jsoncpp*: see [hummingbird] -- with the base's excluded, OUR jsoncpp
 # (also .so.27, priority 11) would mask Rawhide's .so.26 provider and
 # reinstate the very block being dodged. Only our own jsoncpp-devel
@@ -283,6 +283,22 @@ exclude=*+* libcdio-paranoia* jsoncpp* mingw* ucrt64-*
 # That is the next failure the running leg will hit at abseil-cpp/inih.
 # Excluding the whole family keeps Rawhide's toolchain internally
 # coherent, exactly as it was before #548 added this repo.
+#
+# wayland-protocols*: TEMPORARY. Our served wayland-protocols-devel is
+# 1.47-2.fc43 (stale, not in any build order) and at priority 11 it masks
+# Rawhide's 1.49. gtk4 and mutter BuildRequire
+# pkgconfig(wayland-protocols) >= 1.48, so the stale copy blocks the two
+# packages the GNOME 51 goal hangs on. Nothing rebuilds it in the chain;
+# once a wave publishes a current build (or the stale one is pruned) this
+# exclude can go.
+#
+# python3-docutils*: TEMPORARY. Our served python3-docutils is 0.23-1.fc43;
+# at priority 11 it masks F44's 0.22.4 while python3-sphinx (fc44) requires
+# python3.14dist(docutils) >= 0.20 with < 0.23~~ -- 0.23 fails the upper
+# bound, so every sphinx consumer (~17 sources incl. at-spi2-core and
+# xdg-desktop-portal) is blocked by our own stale copy. Excluding it lets
+# F44's in-range 0.22.4 serve the buildroot. Not in any build order; remove
+# when the served copy is current or pruned.
 
 [fedora-44-python]
 name=Fedora 44 - Python 3.14 build inputs only

--- a/tests/test_buildroot_dodges_base_jsoncpp_skew.py
+++ b/tests/test_buildroot_dodges_base_jsoncpp_skew.py
@@ -90,3 +90,36 @@ def test_both_arches_agree():
                           ("tunaos-hummingbird", ("exclude",))):
         assert section_field(CONFIGS[0], section, *keys) == \
             section_field(CONFIGS[1], section, *keys)
+
+
+@pytest.mark.parametrize("config", CONFIGS)
+@pytest.mark.parametrize("name", ["wayland-protocols-devel", "wayland-protocols"])
+def test_stale_wayland_protocols_is_excluded(config, name):
+    """Our served wayland-protocols-devel is 1.47-2.fc43 and at priority 11
+    it masks Rawhide's 1.49; gtk4 and mutter BuildRequire >= 1.48, so the
+    stale copy blocks exactly the two packages GNOME 51 hangs on."""
+    patterns = section_field(config, "tunaos-hummingbird", "exclude")
+    assert any(fnmatch.fnmatch(name, p) for p in patterns), (
+        f"{config}: stale {name!r} survives and starves gtk4/mutter of "
+        f"pkgconfig(wayland-protocols) >= 1.48")
+
+
+@pytest.mark.parametrize("config", CONFIGS)
+def test_stale_docutils_is_excluded(config):
+    """Our served python3-docutils 0.23-1.fc43 masks F44's 0.22.4 while
+    python3-sphinx requires python3.14dist(docutils) < 0.23~~ -- our copy
+    fails the upper bound and every sphinx consumer blocks on it."""
+    patterns = section_field(config, "tunaos-hummingbird", "exclude")
+    assert any(fnmatch.fnmatch("python3-docutils", p) for p in patterns), (
+        f"{config}: stale 'python3-docutils' survives, fails sphinx's "
+        f"docutils < 0.23~~ bound, and blocks ~17 sources")
+
+
+@pytest.mark.parametrize("config", CONFIGS)
+@pytest.mark.parametrize("name", ["python3-sphinx", "python3-gobject", "wayland-devel"])
+def test_new_excludes_do_not_overreach(config, name):
+    """The two new globs must hit only the stale pair -- not sphinx itself,
+    not unrelated wayland-* or python3-* names."""
+    patterns = section_field(config, "tunaos-hummingbird", "exclude")
+    assert not any(fnmatch.fnmatch(name, p) for p in patterns), (
+        f"{config}: exclude glob overreaches onto {name!r}")


### PR DESCRIPTION
> [!NOTE]
> This PR originally carried the gnome51 accountsservice + preflight work. A push to the shared task branch replaced its content with the change below before the queue picked it up; the original accountsservice/preflight work is being reopened unchanged as a separate PR from the preserved head (`3734f4d`). This body now describes what actually merges here.

The post-#554 simulator run (fresh indexes — the base compose moved again) collapsed the board from 260 blocked to 57 and exposed two more self-maskings. Both are stale fc43 leftovers in the served repo that no build order rebuilds:

## wayland-protocols-devel 1.47-2.fc43 → blocks gtk4 and mutter

Our served copy at priority 11 masks Rawhide's 1.49. gtk4 and mutter BuildRequire `pkgconfig(wayland-protocols) >= 1.48` — the stale copy blocks exactly the two packages the GNOME 51 goal hangs on. Versions measured across indexes: Rawhide 1.49-2.fc45, F44-updates 1.49-1.fc44, ours 1.47-2.fc43.

## python3-docutils 0.23-1.fc43 → blocks the whole sphinx cluster (~17 sources)

python3-sphinx (fc44 pin) requires `(python3.14dist(docutils) < 0.23~~ with python3.14dist(docutils) >= 0.20)`. F44's python3-docutils 0.22.4 satisfies that — but our 0.23 masks it and fails the `< 0.23~~` upper bound. Blocked consumers include at-spi2-core and xdg-desktop-portal, both on the GNOME 51 path.

## Measured effect (simulator, current indexes, both changes)

| | OK | blocked |
|---|---|---|
| before | 616 | 57 |
| after | 630 | 43 |

gtk4, mutter, at-spi2-core, xdg-desktop-portal, khal, libnvme, serd, lilv, zix, imath, libfyaml, python-dateutil, vdirsyncer, sratom all leave the blocked list.

Both excludes are TEMPORARY-commented in the cfg like the jsoncpp/mingw pair, with removal conditions stated. Guard tests added (both arches), including overreach checks proving the globs cannot touch `python3-sphinx`, `wayland-devel`, or other neighbors.

Mock cfgs are not action-key inputs — the running chain is unaffected and partials resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sZp9iEZAJS44joA2Z8mCK