### PR TITLE
fix(factory): key a continuation shard by its base, so a chain can accumulate across legs

### DIFF
--- a/.github/workflows/package-factory-cell.yml
+++ b/.github/workflows/package-factory-cell.yml
@@ -101,8 +101,16 @@ jobs:
             epoch=$(git log -1 --format=%at -- "${source_paths[@]}")
             args=()
             for path in "${source_paths[@]}"; do args+=(--input "$path"); done
+            # base_id, NOT id. A continuation shard is the SAME work as the
+            # leg it resumes -- same manifest, same inputs, same image -- so it
+            # must compute the same action key. Passing `matrix.id` hashed the
+            # `-c1` suffix into the key, so leg 2 asked for a key no partial
+            # could ever carry and `restore-partial-chain-output.py` rejected
+            # all five candidates as "action key differs", every time. The
+            # partial is already NAMED by base_id (line ~423) and looked up by
+            # base_id (line ~206); this was the one place still using id.
             payload=$(python3 scripts/tideforge-action-cache.py native-key \
-              --identity '${{ matrix.id }}' --manifest '${{ matrix.manifest }}' \
+              --identity '${{ matrix.base_id || matrix.id }}' --manifest '${{ matrix.manifest }}' \
               "${args[@]}" --target '${{ matrix.target }}' \
               --arch '${{ matrix.architecture }}' --image "$image" \
               --dependency-tree '${{ matrix.dependency_tree }}' \

--- a/tests/test_a_continuation_shares_its_bases_action_key.py
+++ b/tests/test_a_continuation_shares_its_bases_action_key.py
@@ -1,0 +1,92 @@
+"""A continuation shard must compute the SAME action key as the leg it resumes.
+
+The chain could not accumulate, and this is why. A cell that runs out of
+clock banks `<base_id>-partial`; the next leg restores it and continues.
+Restore only accepts a partial whose recorded action key matches the key the
+resuming cell computes -- correctly, since a partial built from different
+inputs is not resumable.
+
+But `identity` is one of the hashed key inputs, and the cell workflow passed
+`matrix.id`, which for a continuation carries a `-c1` suffix. So leg 2 asked
+for a key that leg 1's partial could not possibly carry. Observed on
+gnome51-el10-aarch64: all five candidates rejected as "action key differs",
+including a 378 MB partial banked by the SAME RUN's leg 0 nineteen minutes
+earlier, off the same commit. Then "building from scratch", at bootstrap-00.
+
+Every other place already used base_id -- the partial is named by it and
+looked up by it. Only the key computation was left on `matrix.id`.
+
+These tests read BOTH files that call `native-key`, because fixing one and
+leaving the other is the exact shape of the #529 epoch bug.
+"""
+from pathlib import Path
+import re
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CELL = ROOT / ".github/workflows/package-factory-cell.yml"
+PUBLISHER = ROOT / ".github/workflows/publish-build-chain-rpms.yml"
+PLANNER = ROOT / "scripts/plan-build-chain-publish.py"
+
+IDENTITY = re.compile(r"--identity\s+'([^']+)'")
+
+
+def identity_arguments(path: Path) -> list[str]:
+    return IDENTITY.findall(path.read_text(encoding="utf-8"))
+
+
+def test_every_native_key_call_site_was_examined():
+    """Guard against a check that is named for two files and reads one."""
+    assert identity_arguments(CELL), f"no --identity found in {CELL.name}"
+    assert identity_arguments(PUBLISHER), f"no --identity found in {PUBLISHER.name}"
+
+
+def test_the_cell_workflow_keys_a_continuation_by_its_base():
+    for argument in identity_arguments(CELL):
+        assert "base_id" in argument, (
+            f"package-factory-cell.yml computes its action key from {argument!r}. "
+            "A continuation shard's id carries a -cN suffix, so it would hash to "
+            "a key no banked partial can carry and every resume restarts the "
+            "chain at bootstrap-00. Use matrix.base_id || matrix.id."
+        )
+
+
+def test_the_publisher_may_use_id_only_because_it_has_no_continuations():
+    """`matrix.id` is correct there ONLY while the planner emits no base_id.
+
+    The publisher resumes the nightly's partial, so its identity has to equal
+    the nightly's BASE identity. That holds because its cell id IS the base.
+    If the planner ever starts emitting base_id, this file needs the same
+    treatment as the cell workflow, and this test is what will say so.
+    """
+    assert "base_id" not in PLANNER.read_text(encoding="utf-8"), (
+        "the publish planner now emits base_id, so publish-build-chain-rpms.yml "
+        "must key by base_id || id like package-factory-cell.yml does"
+    )
+
+
+@pytest.mark.parametrize("identity, expected", [
+    ("gnome51-el10-aarch64", "gnome51-el10-aarch64"),
+    ("gnome51-el10-aarch64-c1", "gnome51-el10-aarch64-c1"),
+])
+def test_identity_actually_changes_the_action_key(identity, expected, tmp_path):
+    """The premise: identity is hashed, so a -c1 suffix moves the key.
+
+    If this ever stops holding the fix above is pointless, and a test that
+    cannot fail would be hiding that.
+    """
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "tideforge_action_cache", ROOT / "scripts/tideforge-action-cache.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    base = {"schema": 1, "identity": "gnome51-el10-aarch64"}
+    other = {"schema": 1, "identity": identity}
+    assert other["identity"] == expected
+    same = module.action_key(base) == module.action_key(other)
+    assert same == (identity == "gnome51-el10-aarch64"), (
+        "identity must be part of the hashed key for the -cN suffix to have "
+        "been the bug; if it is not, re-diagnose before trusting the fix"
+    )

--- a/tests/test_a_continuation_shares_its_bases_action_key.py
+++ b/tests/test_a_continuation_shares_its_bases_action_key.py
@@ -90,3 +90,28 @@ def test_identity_actually_changes_the_action_key(identity, expected, tmp_path):
         "identity must be part of the hashed key for the -cN suffix to have "
         "been the bug; if it is not, re-diagnose before trusting the fix"
     )
+
+
+def test_a_canary_never_inherits_the_chains_identity():
+    """The hazard this fix could have introduced, ruled out.
+
+    Keying by `base_id || id` would be dangerous if a canary cell carried
+    base_id: a canary truncated to bootstrap-00 would compute the full
+    chain's action key, and could restore -- or be mistaken for -- the
+    converging chain's partial. It does not. `canary_cells()` only appends
+    `-canary` to the id and swaps in canary_tiers; `base_id` is set in one
+    place, the continuation path, so a canary falls back to its own id and
+    keeps banking to `<id>-canary-partial`.
+    """
+    planner = (ROOT / "scripts/plan-package-factory.py").read_text(encoding="utf-8")
+    start = planner.index("def canary_cells(")
+    end = planner.index("\ndef ", start + 1)
+    assert "base_id" not in planner[start:end], (
+        "canary_cells() now touches base_id; with the workflow keying by "
+        "base_id || id a canary could compute the full chain's action key "
+        "and collide with the converging chain's partial"
+    )
+    assert planner.count('["base_id"] =') == 1, (
+        "base_id is assigned somewhere new; confirm it is still only the "
+        "continuation path before trusting the identity fallback"
+    )


### PR DESCRIPTION
A continuation shard could never resume its own predecessor's partial. One line.

## Measured, not inferred

A cell that runs out of clock banks `<base_id>-partial`; the next leg restores it and continues — but only if the partial's recorded action key matches the key the resuming cell computes. That check is right: a partial built from different inputs is not resumable.

`identity` is one of the hashed key inputs, and this workflow passed `matrix.id`. For a continuation that id carries a `-c1` suffix. So leg 2 asked for a key leg 1's partial could not possibly carry.

`gnome51-el10-aarch64`, run [32947605536](https://github.com/tuna-os/tunaos-packages/actions/runs/32947605536/job/98134608843):

```
[resume] found `gnome51-el10-aarch64-partial` from 2026-08-26T09:33:50Z (378 MB)
[resume]   action key differs (partial sha256:ea3bf524..., this cell sha256:0d2c452c...); trying an older one
[resume] found ... 08:25:00Z (278 MB)   action key differs
[resume] found ... 08:22:54Z (3 MB)     action key differs
[resume] found ... 08:18:08Z (70 MB)    action key differs
[resume] found ... 07:51:30Z (231 MB)   action key differs
[resume] no unexpired partial carries usable packages; building from scratch
```

`MAX_CANDIDATES` is 5, so all five were spent and the leg started over at `bootstrap-00`.

The 378 MB partial it rejected was banked by the **same run's leg 0**, nineteen minutes earlier, off the same commit. Dumping both key-input dicts shows every field identical — `build_image` digest, every `native_inputs` digest, `native_contracts`, `renderer_inputs`, `source_date_epoch`, `release_track`, `target` — and exactly one field different:

```
"identity": "gnome51-el10-aarch64-c1"     (the resuming cell)
"identity": "gnome51-el10-aarch64"        (the partial it wanted)
```

## The fix

`--identity '${{ matrix.base_id || matrix.id }}'`, which is the idiom every *other* site already uses: the partial is **named** by `base_id` (line ~423) and **looked up** by `base_id` (line ~206). Only the key computation was still on `matrix.id`.

## The other call site, checked rather than patched

`publish-build-chain-rpms.yml` also calls `native-key --identity '${{ matrix.id }}'`. It is **correct as-is**: its planner emits no `base_id` and its cell id *is* the base, which is precisely what lets it resume the nightly's partial. Changing it would have been a no-op at best.

Fixing one file and leaving the identical line in the other is exactly how the #529 epoch bug shipped, so `test_the_publisher_may_use_id_only_because_it_has_no_continuations` pins the invariant: if the planner ever starts emitting `base_id`, that test fails and says so.

## Tests

Five, in `tests/test_a_continuation_shares_its_bases_action_key.py`:

- both `native-key` call sites are actually read (guards against a check named for two files that examines one)
- the cell workflow keys by base — **verified to fail** against the unfixed line, not merely to pass against the fixed one
- the publisher's use of `id` is conditional on the planner emitting no `base_id`
- `identity` really is hashed into the key, so the `-cN` suffix really was the cause; if that premise ever stops holding, the fix is pointless and the test says so rather than passing silently

Full suite: **1482 passed, 1 skipped**.

## Scope and safety

Workflow YAML is not an action-key input, so this changes no cell's identity except the continuations it is meant to fix, and cannot re-key a converging chain. It is safe to merge while the hummingbird chain is mid-flight.

It does **not** rescue the currently running hummingbird dispatch: a run resolves its reusable workflow at start (that run pins `package-factory-cell.yml@f61e85f`), so its own leg 2 will still use the old line. This takes effect on the next dispatch.

Worth being precise about what this does and does not repair. Accumulation *across runs* already worked — a fresh dispatch's leg 0 computes the same identity as the previous run's leg 0, which is how the chain reached 570 of 673 sources. What was broken is accumulation *across legs within one run*: every leg after the first threw away up to six hours of work and restarted at `bootstrap-00`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015sZp9iEZAJS44joA2Z8mCK)_