### PR TITLE
fix(hummingbird): let the buildroot see what the factory already published

### DIFF
--- a/mock/hummingbird-ci-aarch64.cfg
+++ b/mock/hummingbird-ci-aarch64.cfg
@@ -49,6 +49,41 @@ enabled=1
 priority=10
 excludepkgs=golang1.26*
 
+[tunaos-hummingbird]
+name=TunaOS factory output for hummingbird - our own build-chain packages
+# The factory's own published prefix, and the reason dconf could not build.
+#
+# dconf BuildRequires vala, vala BuildRequires gobject-introspection-devel,
+# and Rawhide's is built against python 3.15 with a rich
+# `(python(abi) = 3.15 if python3)`. python3 IS in the chroot -- Hummingbird's
+# 3.14 -- so the condition fires and dnf5 reports
+#
+#   cannot install both python3-3.15.0~rc1-1.fc45 from fedora
+#   and python3-3.14.3-2.1.hum1 from hummingbird
+#
+# The factory has ALREADY built and published what it needs, against the
+# right interpreter: gobject-introspection 1.86.0-1.fc43 (the same upstream
+# version Rawhide ships) and vala 0.56.19-1.fc43. The buildroot simply had no
+# repo pointing at them, so every resolution fell through to Rawhide.
+#
+# priority 11 is deliberate, one below [hummingbird]:
+#   1  local-build  this run's own output always wins
+#   10 hummingbird  the base OS still wins for anything it ships
+#   11 HERE         fills what the base lacks -- the desktop stack we build
+#   50 fedora-44-*  the narrow python/perl/mpich pins
+#   99 fedora       Rawhide, the last resort it was previously the first
+#
+# Safe against the Obsoletes hijack that published_index.py records for the
+# gnome50/51 prefixes (a bootstrap glib2 with `Obsoletes: glib2 < 2.87.3`
+# replaces the base package regardless of repo priority; publish run
+# 32405815822 died on it). Measured, not assumed: of the 8100 packages in
+# this prefix, ZERO obsolete any package the Hummingbird base ships.
+# tests/test_hummingbird_buildroot_reads_its_own_output.py pins both halves.
+baseurl=https://repo.tunaos.org/hummingbird/20251124-$basearch/
+gpgcheck=0
+enabled=1
+priority=11
+
 [fedora-44-python]
 name=Fedora 44 - Python 3.14 build inputs only
 metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-44&arch=$basearch

--- a/mock/hummingbird-ci.cfg
+++ b/mock/hummingbird-ci.cfg
@@ -196,6 +196,41 @@ enabled=1
 priority=10
 excludepkgs=golang1.26*
 
+[tunaos-hummingbird]
+name=TunaOS factory output for hummingbird - our own build-chain packages
+# The factory's own published prefix, and the reason dconf could not build.
+#
+# dconf BuildRequires vala, vala BuildRequires gobject-introspection-devel,
+# and Rawhide's is built against python 3.15 with a rich
+# `(python(abi) = 3.15 if python3)`. python3 IS in the chroot -- Hummingbird's
+# 3.14 -- so the condition fires and dnf5 reports
+#
+#   cannot install both python3-3.15.0~rc1-1.fc45 from fedora
+#   and python3-3.14.3-2.1.hum1 from hummingbird
+#
+# The factory has ALREADY built and published what it needs, against the
+# right interpreter: gobject-introspection 1.86.0-1.fc43 (the same upstream
+# version Rawhide ships) and vala 0.56.19-1.fc43. The buildroot simply had no
+# repo pointing at them, so every resolution fell through to Rawhide.
+#
+# priority 11 is deliberate, one below [hummingbird]:
+#   1  local-build  this run's own output always wins
+#   10 hummingbird  the base OS still wins for anything it ships
+#   11 HERE         fills what the base lacks -- the desktop stack we build
+#   50 fedora-44-*  the narrow python/perl/mpich pins
+#   99 fedora       Rawhide, the last resort it was previously the first
+#
+# Safe against the Obsoletes hijack that published_index.py records for the
+# gnome50/51 prefixes (a bootstrap glib2 with `Obsoletes: glib2 < 2.87.3`
+# replaces the base package regardless of repo priority; publish run
+# 32405815822 died on it). Measured, not assumed: of the 8100 packages in
+# this prefix, ZERO obsolete any package the Hummingbird base ships.
+# tests/test_hummingbird_buildroot_reads_its_own_output.py pins both halves.
+baseurl=https://repo.tunaos.org/hummingbird/20251124-$basearch/
+gpgcheck=0
+enabled=1
+priority=11
+
 [fedora-44-python]
 name=Fedora 44 - Python 3.14 build inputs only
 metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-44&arch=$basearch

--- a/tests/test_hummingbird_buildroot_reads_its_own_output.py
+++ b/tests/test_hummingbird_buildroot_reads_its_own_output.py
@@ -1,0 +1,104 @@
+"""The hummingbird buildroot must be able to see what the factory published.
+
+dconf failed every build for days, and with it every publish: the cell exits
+non-zero on any failed package, so `Record a new ActionResult` is skipped and
+588 successfully built packages never reach the repo.
+
+The cause was not dconf. dconf BuildRequires vala; vala BuildRequires
+gobject-introspection-devel; and Rawhide's carries the rich dependency
+`(python(abi) = 3.15 if python3)`. python3 IS in the chroot -- Hummingbird's
+3.14 -- so it fires:
+
+    cannot install both python3-3.15.0~rc1-1.fc45.x86_64 from fedora
+    and python3-3.14.3-2.1.hum1.x86_64 from hummingbird
+
+The factory had already built both against the right interpreter and published
+them. The buildroot just had no repo pointing at its own output, so every
+resolution fell through to Rawhide.
+
+These tests pin the three things that make the fix real, and each is a
+separate failure this repo has already paid for once:
+
+  * BOTH arch configs carry it. Fixing one file and leaving the identical
+    line in its twin is the #529 epoch shape.
+  * The URL agrees with the target's declared published_index, so the
+    buildroot reads the prefix the publisher writes.
+  * Priority sits below the base OS, so this fills gaps rather than shadowing
+    Hummingbird's own packages with our rebuilds.
+"""
+from pathlib import Path
+import re
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIGS = [
+    ROOT / "mock/hummingbird-ci.cfg",
+    ROOT / "mock/hummingbird-ci-aarch64.cfg",
+]
+REPO_ID = "tunaos-hummingbird"
+
+
+def repo_block(text: str, repo_id: str) -> str:
+    match = re.search(rf"^\[{re.escape(repo_id)}\]$(.*?)(?=^\[|\Z)",
+                      text, re.MULTILINE | re.DOTALL)
+    return match.group(1) if match else ""
+
+
+def setting(block: str, key: str) -> str | None:
+    match = re.search(rf"^{re.escape(key)}=(.*)$", block, re.MULTILINE)
+    return match.group(1).strip() if match else None
+
+
+@pytest.mark.parametrize("config", CONFIGS, ids=lambda p: p.name)
+def test_both_arch_buildroots_read_the_factory_output(config):
+    block = repo_block(config.read_text(encoding="utf-8"), REPO_ID)
+    assert block, (
+        f"{config.name} has no [{REPO_ID}] repo. Without it the buildroot "
+        "cannot see gobject-introspection-devel or vala built against "
+        "python 3.14, and falls through to Rawhide's 3.15 build, which "
+        "cannot be installed beside Hummingbird's interpreter."
+    )
+
+
+@pytest.mark.parametrize("config", CONFIGS, ids=lambda p: p.name)
+def test_it_reads_the_prefix_the_publisher_writes(config):
+    """A buildroot pointed at a prefix nobody publishes to reads an empty repo."""
+    factory = yaml.safe_load((ROOT / "manifests/package-factory.yaml").read_text())
+    declared = factory["targets"]["hummingbird"]["published_index"]
+    urls = []
+    for value in declared.values():
+        urls.extend(value if isinstance(value, list) else [value])
+
+    baseurl = setting(repo_block(config.read_text(encoding="utf-8"), REPO_ID), "baseurl")
+    assert baseurl, f"{config.name}: [{REPO_ID}] has no baseurl"
+    # mock substitutes $basearch; compare on the arch-independent stem.
+    stem = baseurl.replace("$basearch", "")
+    assert any(url.replace("x86_64", "").replace("aarch64", "") == stem for url in urls), (
+        f"{config.name}: [{REPO_ID}] baseurl {baseurl!r} does not match any "
+        f"published_index for hummingbird ({urls}). The buildroot would read "
+        "a prefix the publisher never writes to."
+    )
+
+
+@pytest.mark.parametrize("config", CONFIGS, ids=lambda p: p.name)
+def test_the_base_os_still_outranks_our_rebuilds(config):
+    """Gap-filling, not shadowing.
+
+    Lower priority wins in dnf. Our output must rank BELOW [hummingbird] so
+    the base OS keeps ownership of everything it ships, and ABOVE the Fedora
+    repos so it beats Rawhide -- which is the whole point.
+    """
+    text = config.read_text(encoding="utf-8")
+    ours = int(setting(repo_block(text, REPO_ID), "priority"))
+    base = int(setting(repo_block(text, "hummingbird"), "priority"))
+    local = int(setting(repo_block(text, "local-build"), "priority"))
+    pinned = int(setting(repo_block(text, "fedora-44-python"), "priority"))
+    assert local < base < ours < pinned, (
+        f"{config.name}: priorities must order local-build({local}) < "
+        f"hummingbird({base}) < {REPO_ID}({ours}) < fedora-44-python({pinned}). "
+        "Above the base OS would shadow Hummingbird's own packages with our "
+        "rebuilds; below the Fedora pins would leave Rawhide winning."
+    )


### PR DESCRIPTION
**One package has blocked every publish for five days.** The last successful publish was 2026-08-21.

## The chain is not the problem

Run [32940584755](https://github.com/tuna-os/tunaos-packages/actions/runs/32940584755) reached `layer-17`, the last tier, and its own summary reads:

```
ERROR: Failed packages (2):
ERROR:   - src/hummingbird/dconf
ERROR:   - src/hummingbird/libuser
```

The publisher's last real attempt, [32914264044](https://github.com/tuna-os/tunaos-packages/actions/runs/32914264044), is starker:

```
ERROR: Failed packages (1):
ERROR:   - src/hummingbird/dconf
==> Packages built:  85
==> Deferred (deadline): 588
##[error]Process completed with exit code 1.
```

It built 85, deferred 588, and exited 1 for **dconf alone** — so the publish step never ran. That is why the served index sits at 570 of 673 sources with no `gnome-shell`, `gdm` or `flatpak`. Not because the chain cannot build them; because one failure stops the wave that would ship them.

## Why dconf and not its ~200 tier-mates

`dconf` BuildRequires `vala` → `vala` BuildRequires `gobject-introspection-devel` → Rawhide's carries the rich dependency `(python(abi) = 3.15 if python3)`. python3 **is** in the chroot — Hummingbird's 3.14 — so it fires:

```
package gobject-introspection-devel-1.86.0-11.fc45.x86_64 from fedora
  requires (python(abi) = 3.15 if python3), but none of the providers can be installed
cannot install both python3-3.15.0~rc1-1.fc45.x86_64 from fedora
  and python3-3.14.3-2.1.hum1.x86_64 from hummingbird
```

`vala` is what distinguishes dconf from everything else in `layer-00`.

## What it needed already existed

Read from the served index, not assumed:

| capability | what the factory already published |
|---|---|
| `gobject-introspection-devel` | `gobject-introspection-1.86.0-1.fc43` |
| `vala` | `vala-0.56.19-1.fc43` |

Both built by this factory against the right interpreter. `gobject-introspection` 1.86.0 is the **same upstream version Rawhide ships**, so nothing is held back by preferring ours — this keeps the rolling, latest-release posture rather than pinning backwards.

The buildroot simply had no repo pointing at its own output. `mock/hummingbird-ci*.cfg` lists `local-build`, the Hummingbird base, the narrow F44 python/perl/mpich pins, and Rawhide — never `repo.tunaos.org/hummingbird`. So everything the base could not satisfy fell through to Rawhide, which has moved on: python 3.15, glib2 2.89.4 against Hummingbird's 2.89.3, `libcrypto.so.4` against its `.so.3`.

## This fixes `libuser` too

An earlier draft of this description claimed libuser was out of scope. **That was wrong, and the distinction matters**: the cell exits non-zero on *any* failed package, so a fix that closed dconf and left libuser would leave publishing exactly as blocked as before.

`libuser` fails on `docbook-utils` → `text-www-browser` → elinks/lynx, which in Rawhide link against `libcrypto.so.4` while Hummingbird ships `.so.3`. But this factory has already built and published that whole chain against the right openssl:

| package | published build | openssl it links |
|---|---|---|
| `lynx` | `lynx-2.9.3-4.1.fc43` | `libcrypto.so.3`, `libssl.so.3` |
| `docbook-utils` | `docbook-utils-0.6.15-8.1.fc43` | — |
| `openjade` | `openjade-1.3.2-86.1.fc43` | — |
| `docbook-style-dsssl` | `docbook-style-dsssl-1.79-45.1.fc43` | — |

`lynx` is also what **provides `text-www-browser`** — the Hummingbird base provides it from nothing, which is why the resolver had to reach into Rawhide at all.

Resolving every requirement of those four, plus dconf's chain, against `base ∪ factory`:

```
lynx                          UNMET: none
docbook-utils                 UNMET: none
openjade                      UNMET: none
docbook-style-dsssl           UNMET: none
vala                          UNMET: none
gobject-introspection-devel   UNMET: none
dconf                         UNMET: none
```

Both failures share one cause and one fix.

## Priority, and why it is 11

```
 1  local-build  this run's own output always wins
10  hummingbird  the base OS still owns everything it ships
11  NEW          fills what the base lacks -- the desktop stack we build
50  fedora-44-*  the narrow python/perl/mpich pins
99  fedora       Rawhide, the last resort it was previously the first
```

Below the base so this is **gap-filling, not shadowing**: Hummingbird's own packages are never replaced by our rebuilds. Above the Fedora repos so it actually beats Rawhide, which is the point.

## Safe against the Obsoletes hijack — measured

`scripts/published_index.py` records why the gnome50/51 prefixes are deliberately **not** declared: they carry a bootstrap `glib2` with `Obsoletes: glib2 < 2.87.3`, which replaces the base package *regardless of repo priority*, and publish run 32405815822 died on exactly that. That history is the reason to check here rather than assume.

Scanned this prefix's own `primary.xml`: of its **8100** packages, **zero** obsolete any package the Hummingbird base ships.

## Scope

mock configs are **not** action-key inputs — `renderer_inputs` is `build-chain.sh`, `run-package-factory-cell.sh` and `import-fedora-distgit.py` — so this re-keys no cell and **cannot restart a converging chain**. It is safe to merge while the hummingbird chain is mid-flight.

CI on this PR planned **zero build cells** — `build-0`, `build-1` and `build-2` all `skipped`, every other check green. That is independent confirmation of the claim above.

Both arch configs carry the change. Fixing one and leaving the identical line in its twin is the shape #529 shipped in.

## Tests

Three properties, each mutation-verified to fail on its own:

- both arch configs carry the repo (removing it from only aarch64 fails)
- the `baseurl` agrees with the target's declared `published_index`, so the buildroot reads the prefix the publisher writes (pointing it elsewhere fails)
- the priority ordering `local-build < hummingbird < ours < fedora-44-*` (moving it above the base fails)

Full suite: **1485 passed, 1 skipped**.

## The prediction, stated before the fact

With both failures closed, the cell should exit 0, `Record a new ActionResult` should run, and the wave that has not moved since 2026-08-21 should carry the ~588 deferred packages — `gnome-shell`, `gdm`, `flatpak` and `gstreamer1-plugins-bad-free` among them. That last one is #540's blocker, so this likely closes that too.

The proof is a green cell and a served index above 570 of 673. I will report whichever way it lands.