### PR TITLE
fix(hummingbird): stop the next re-measure from downgrading GNOME 51 to 50

### DIFF
--- a/manifests/hummingbird-desktops.yaml
+++ b/manifests/hummingbird-desktops.yaml
@@ -20,8 +20,18 @@ schema: 1
 # where dist-git imports land for packages that have none. Declared here —
 # a property of the target's source tree — so the gap engine stays free of
 # any one family's layout (it used to hard-code exactly these four).
-source_paths: [src/gnome-50, src/deps, src/hummingbird, src/xfce-wayland]
+source_paths: [src/gnome-51, src/deps, src/hummingbird, src/xfce-wayland]
 distgit_prefix: src/hummingbird
+# Names that must come from Fedora Rawhide dist-git even though a directory
+# of that name exists under `source_paths:` -- the directory belongs to
+# another target.  src/deps/libnotify was added 2026-08-23 (#490) for EL10,
+# five days after this build order was last measured, and pins 0.8.7 with
+# the comment "0.8.7 rather than the newer 0.8.8 deliberately: it is the
+# minimum that satisfies the requirement and it matches the version already
+# published".  That is right for EL10 and wrong for a Rawhide rebuild, which
+# gets 0.8.8.  Without this line the next scheduled re-measure would have
+# quietly moved libnotify onto the EL10 pin.
+prefer_distgit: [libnotify]
 # What the generated build order contains.  `runtime` builds only what images
 # ship; BuildRequires-only tools (bison, transfig, gtk-doc, the Java stack the
 # documentation toolchains drag in) come from the buildroot's inherited
@@ -54,8 +64,8 @@ target:
 
 desktops:
   gnome:
-    release: "50"
-    sources: [{local: src/gnome-50}, {local: src/deps}]
+    release: "51"
+    sources: [{local: src/gnome-51}, {local: src/deps}]
     required_packages: [gdm, gjs, gnome-control-center, gnome-initial-setup, gnome-session, gnome-settings-daemon, gnome-shell, mutter, nautilus, xdg-desktop-portal-gnome]
     # Contract surface tunaOS's desktop gate checks by command/path/unit, which
     # the required_packages list above does not name: gnome-keyring-daemon,

--- a/scripts/gap_engine.py
+++ b/scripts/gap_engine.py
@@ -784,10 +784,12 @@ def emit_build_order(path, catalog, global_tiers, global_cycles, report, root,
     """Write a build-chain.sh manifest whose tiers came out of the measurement.
 
     A package that already has a reviewed spec directory in this repository
-    keeps it — src/gnome-50/gtk4 is a project-maintained Rawhide import with
+    keeps it — src/gnome-51/gtk4 is a project-maintained Rawhide import with
     local fixes and must not be silently replaced by a fresh dist-git pull.
     Everything else is marked `distgit:`, which the build workflow imports with
-    scripts/import-fedora-distgit.py before the tier runs.
+    scripts/import-fedora-distgit.py before the tier runs.  A name listed in
+    the roots manifest's `prefer_distgit:` is imported even if such a
+    directory exists: it belongs to another target.
     """
     target = catalog["target"]
     # Where reviewed spec directories live and where dist-git imports land
@@ -800,12 +802,20 @@ def emit_build_order(path, catalog, global_tiers, global_cycles, report, root,
         raise SystemExit(
             f"{target['id']}: --build-order needs `source_paths:` and "
             "`distgit_prefix:` declared in the roots manifest")
+    # A spec directory under a shared prefix may exist for a DIFFERENT
+    # target and carry a pin this one must not inherit.  src/deps/libnotify
+    # is pinned to 0.8.7 for EL10 -- its own comment says "0.8.7 rather than
+    # the newer 0.8.8 deliberately" -- while a Rawhide rebuild wants 0.8.8.
+    # `prefer_distgit:` is how a roots manifest says "always import this one",
+    # so the shared directory cannot silently downgrade it.
+    always_distgit = set(catalog.get("prefer_distgit") or [])
     cycles = {name for cycle in global_cycles for name in cycle}
 
     def locate(name):
-        for prefix in search:
-            if (root / prefix / name).is_dir():
-                return f"{prefix}/{name}", False
+        if name not in always_distgit:
+            for prefix in search:
+                if (root / prefix / name).is_dir():
+                    return f"{prefix}/{name}", False
         return f"{fallback}/{name}", True
 
     target_id = target_name or target["id"].split("-")[0]

--- a/tests/test_regenerating_a_build_order_is_a_fixpoint.py
+++ b/tests/test_regenerating_a_build_order_is_a_fixpoint.py
@@ -1,0 +1,210 @@
+"""Regenerating a build order must not move a package to a different spec dir.
+
+The gap engine picks each package's spec directory by walking the roots
+manifest's `source_paths:` in order and taking the first prefix that has a
+directory of that name (scripts/gap_engine.py, `locate`). So `source_paths`
+is the only thing deciding which GNOME track hummingbird builds -- and it is
+NOT the file anyone edits when they repoint a track.
+
+Measured on 2026-08-26, before this test existed:
+
+    build-order-hummingbird-desktops.yml   19 packages from src/gnome-51/
+    manifests/hummingbird-desktops.yaml    source_paths: [src/gnome-50, ...]
+
+#521 repointed the build order to src/gnome-51 and updated the CELL's
+source_paths in manifests/package-builds.yaml, which is what keys the cache.
+It did not update the roots manifest, which is what regenerates the order.
+Both files are named `source_paths` and they are different keys.
+
+The consequence is not a red build. hummingbird's drift mode is `propose`
+(manifests/package-factory.yaml): a scheduled job regenerates the order when
+the live target index moves and opens a PR. That PR would have carried
+gdm, gnome-shell, mutter, gtk4, libadwaita and 14 more from src/gnome-51
+back to src/gnome-50 -- a silent downgrade of the whole desktop, arriving
+under a title about re-measuring the gap.
+
+The property is a fixpoint: for every `path:` the checked-in order already
+names, resolving that name through the roots manifest must return that same
+path. Anything else means a regeneration would rewrite the file.
+"""
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+FACTORY = yaml.safe_load(
+    (ROOT / "manifests" / "package-factory.yaml").read_text(encoding="utf-8"))
+
+
+def _cases():
+    for name, target in sorted(FACTORY["targets"].items()):
+        gap = target.get("gap_measurement") or {}
+        roots = gap.get("roots_manifest")
+        order = (gap.get("drift") or {}).get("build_order")
+        if roots and order and (ROOT / roots).is_file() \
+                and (ROOT / order).is_file():
+            yield name, roots, order
+
+
+CASES = list(_cases())
+
+
+def referenced_paths(order: str) -> set[str]:
+    """Every `path:` under src/ the build order names."""
+    spec = yaml.safe_load((ROOT / order).read_text(encoding="utf-8"))
+    found: set[str] = set()
+
+    def walk(node):
+        if isinstance(node, dict):
+            path = node.get("path")
+            if isinstance(path, str) and path.startswith("src/"):
+                found.add(path.rstrip("/"))
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for value in node:
+                walk(value)
+
+    walk(spec)
+    return found
+
+
+def resolver(roots: str):
+    """gap_engine.emit_build_order's `locate`, reproduced from the manifest."""
+    catalog = yaml.safe_load((ROOT / roots).read_text(encoding="utf-8"))
+    search = catalog["source_paths"]
+    fallback = catalog["distgit_prefix"]
+    always_distgit = set(catalog.get("prefer_distgit") or [])
+
+    def locate(name: str) -> str:
+        if name not in always_distgit:
+            for prefix in search:
+                if (ROOT / prefix / name).is_dir():
+                    return f"{prefix}/{name}"
+        return f"{fallback}/{name}"
+
+    return locate
+
+
+def test_there_are_targets_to_check():
+    """A rename of gap_measurement would make every case below vacuous."""
+    assert CASES, "no target declares both a roots_manifest and a build_order"
+
+
+@pytest.mark.parametrize("target,roots,order", CASES,
+                         ids=[c[0] for c in CASES])
+def test_regeneration_would_not_move_any_package(target, roots, order):
+    locate = resolver(roots)
+    moved = sorted(
+        (path, locate(path.rsplit("/", 1)[1]))
+        for path in referenced_paths(order)
+        if locate(path.rsplit("/", 1)[1]) != path
+    )
+    assert not moved, (
+        f"{target}: regenerating {order} from {roots} would move these "
+        f"packages to a different spec directory, so a scheduled re-measure "
+        f"silently rewrites what gets built. Fix `source_paths:` in {roots} "
+        f"(it is a different key from the cell's source_paths in "
+        f"manifests/package-builds.yaml): {moved}")
+
+
+@pytest.mark.parametrize("target,roots,order", CASES,
+                         ids=[c[0] for c in CASES])
+def test_a_declared_desktop_source_is_a_prefix_the_resolver_searches(
+        target, roots, order):
+    """`desktops.<d>.sources` naming a local dir outside `source_paths` is a
+    track the manifest claims to build and the resolver can never reach."""
+    catalog = yaml.safe_load((ROOT / roots).read_text(encoding="utf-8"))
+    search = [p.rstrip("/") for p in catalog["source_paths"]]
+    unreachable = sorted(
+        (desktop, source["local"].rstrip("/"))
+        for desktop, spec in (catalog.get("desktops") or {}).items()
+        for source in spec.get("sources", [])
+        if "local" in source and source["local"].rstrip("/") not in search
+    )
+    assert not unreachable, (
+        f"{target}: these desktops declare a local source directory that "
+        f"`source_paths: {search}` never searches, so nothing is built from "
+        f"it: {unreachable}")
+
+
+def test_the_fixpoint_check_can_actually_fail():
+    """Against a resolver that always agrees, the test above passes for the
+    wrong reason. Point hummingbird's search at the track it was on before
+    this commit and the 19 GNOME packages must be reported as moving."""
+    order = "build-order-hummingbird-desktops.yml"
+    paths = referenced_paths(order)
+    assert paths, "the walker found no paths at all"
+
+    search = ["src/gnome-50", "src/deps", "src/hummingbird", "src/xfce-wayland"]
+
+    def stale(name):
+        for prefix in search:
+            if (ROOT / prefix / name).is_dir():
+                return f"{prefix}/{name}"
+        return f"src/hummingbird/{name}"
+
+    moved = [p for p in paths if stale(p.rsplit("/", 1)[1]) != p]
+    assert len(moved) >= 15, (
+        "searching src/gnome-50 first moved fewer packages than the 19 "
+        f"measured, so this check is not exercising the real hazard: {moved}")
+    assert any(p.endswith("/gnome-shell") for p in moved), moved
+    assert any(p.endswith("/gdm") for p in moved), moved
+
+
+def test_prefer_distgit_names_a_real_collision():
+    """A `prefer_distgit:` entry with no directory shadowing it is dead
+    config -- and the day someone adds that directory, it looks intentional
+    while doing nothing."""
+    for target, roots, _order in CASES:
+        catalog = yaml.safe_load((ROOT / roots).read_text(encoding="utf-8"))
+        for name in catalog.get("prefer_distgit") or []:
+            shadowing = [p for p in catalog["source_paths"]
+                         if (ROOT / p / name).is_dir()]
+            assert shadowing, (
+                f"{target}: prefer_distgit lists {name!r}, but no directory "
+                f"under source_paths {catalog['source_paths']} shadows it, "
+                f"so the entry changes nothing")
+
+
+def test_the_engine_itself_honours_prefer_distgit():
+    """The resolver above is a reproduction of gap_engine.locate. If only the
+    reproduction learned `prefer_distgit`, every check in this file passes
+    while the real regeneration still downgrades. Drive the real emitter."""
+    import importlib.util
+    import tempfile
+
+    spec = importlib.util.spec_from_file_location(
+        "gap_engine", ROOT / "scripts" / "gap_engine.py")
+    gap_engine = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(gap_engine)
+
+    catalog = {
+        "target": {"id": "t-1", "r2_path": "t/1"},
+        "source_paths": ["src/deps"],
+        "distgit_prefix": "src/hummingbird",
+    }
+    report = {
+        "measured_at": "2026-01-01T00:00:00+00:00",
+        "target_index": {"primary_sha256": "0" * 8},
+        "reference_index": {"primary_sha256": "0" * 8},
+    }
+    tiers = [["libnotify"]]  # global_tiers is a list of name lists
+
+    def emit(cat):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = pathlib.Path(tmp) / "order.yml"
+            gap_engine.emit_build_order(out, cat, tiers, [], report, ROOT)
+            return out.read_text(encoding="utf-8")
+
+    without = emit(catalog)
+    assert "src/deps/libnotify" in without, (
+        "src/deps/libnotify no longer shadows the import, so this test is "
+        f"not exercising the hazard:\n{without}")
+
+    with_pin = emit({**catalog, "prefer_distgit": ["libnotify"]})
+    assert "src/hummingbird/libnotify" in with_pin, with_pin
+    assert "src/deps/libnotify" not in with_pin, with_pin


### PR DESCRIPTION
Two files are named `source_paths` and they are different keys:

| file | what it does |
|---|---|
| `manifests/package-builds.yaml` | the **cell's** — what keys the cache |
| `manifests/hummingbird-desktops.yaml` | the **roots manifest's** — what the gap engine walks to pick each spec directory |

[#521](https://github.com/tuna-os/tunaos-packages/pull/521) moved hummingbird onto GNOME 51: it updated the first and hand-repointed the generated build order. It did not update the second. So `build-order-hummingbird-desktops.yml` and the manifest that regenerates it have disagreed for five days.

## What a regeneration would have done

Replaying `scripts/gap_engine.py`'s `locate` against the manifest as it stood, every one of these moves:

```
gdm  gnome-shell  mutter  gtk4  libadwaita  gjs  nautilus  vte291  ptyxis
gnome-session  gnome-control-center  gnome-initial-setup
gnome-settings-daemon  gnome-desktop3  gnome-online-accounts
gobject-introspection  gsettings-desktop-schemas
xdg-desktop-portal  xdg-desktop-portal-gnome

    src/gnome-51/<pkg>  ->  src/gnome-50/<pkg>          19 packages
```

This is not a red build. hummingbird's drift mode is `propose` (`manifests/package-factory.yaml`): a scheduled job regenerates the order when the live target index moves and opens a review PR. That PR would have carried the entire desktop back to GNOME 50, under a title about re-measuring the gap.

## The second collision the fixpoint check found

`libnotify` moved too, the other way:

```
build order    src/hummingbird/libnotify   distgit -> Rawhide 0.8.8
regeneration   src/deps/libnotify          EL10,   pinned 0.8.7
```

`src/deps/libnotify` landed **2026-08-23** ([#490](https://github.com/tuna-os/tunaos-packages/pull/490)) — five days *after* this order was last measured (2026-08-18), so nothing has re-resolved since it appeared. Its own comment explains the pin:

> `# 0.8.7 rather than the newer 0.8.8 deliberately: it is the minimum that satisfies the requirement and it matches the version already published, so nothing installed churns.`

Right for EL10, wrong for a Rawhide rebuild. Verified against upstream rather than assumed: `download.gnome.org`'s `cache.json` lists **0.8.8** as the newest libnotify, and the tarball URL the spec builds resolves `200`. So the checked-in build order is correct today and the regeneration was the thing about to downgrade it.

`prefer_distgit:` is the new way for a roots manifest to say *this shared spec directory belongs to another target*. One line of engine, one line of manifest — rather than dropping `src/deps` from the search path, which 28 other hummingbird packages legitimately build from.

## Tests

A **fixpoint** property, generic over every target that declares both a `roots_manifest` and a `drift.build_order`: resolving each path the checked-in order names must return that same path, or a regeneration rewrites the file.

Four mutations, each caught by a different assertion:

| mutation | caught by |
|---|---|
| `source_paths` back to `src/gnome-50` | fixpoint **and** reachability (2 failures) |
| `prefer_distgit` emptied | fixpoint |
| engine ignores `prefer_distgit` | the engine-level test |
| `desktops.gnome.sources` back to 50 | reachability |

The engine-level test drives the real `emit_build_order` rather than the reproduction, because a reproduction that alone learns the new key passes every other check in this file while the real regeneration still downgrades.

Full suite: **1485 passed, 1 skipped**.

## Context

This is on the path to `hummingbird:gnome` reaching gdm. The other pieces: [#545](https://github.com/tuna-os/tunaos-packages/pull/545) unblocks the publish that has been stuck since 2026-08-21, and [tuna-os/tunaOS#2095](https://github.com/tuna-os/tunaOS/pull/2095) makes the desktop repo resolve on aarch64. This one makes sure the track stays at 51 once it gets there.

---
_Generated by [Claude Code](https://claude.ai/code/session_015sZp9iEZAJS44joA2Z8mCK)_