### PR TITLE
fix(drift): report a moved package as a move, not as upstream churn

### DIFF
--- a/.github/workflows/gap-drift.yml
+++ b/.github/workflows/gap-drift.yml
@@ -185,31 +185,16 @@ jobs:
           TARGET: ${{ matrix.target }}
         run: |
           set -euo pipefail
-          {
-            echo "Automated re-measurement: ${TARGET}'s live target index"
-            echo "published a new revision, so the build order was regenerated"
-            echo "against it."
-            echo
-            dropped="$(git diff -U0 "$BUILD_ORDER" | grep '^-' | grep -o 'path: src/.*' | sed 's|path: ||' | sort -u || true)"
-            added="$(git diff -U0 "$BUILD_ORDER" | grep '^+' | grep -o 'path: src/.*' | sed 's|path: ||' | sort -u || true)"
-            really_dropped="$(comm -23 <(echo "$dropped") <(echo "$added") | sed '/^$/d' || true)"
-            really_added="$(comm -13 <(echo "$dropped") <(echo "$added") | sed '/^$/d' || true)"
-            if [ -n "$really_dropped" ]; then
-              echo "Dropped from the build set (the target now ships these):"
-              echo '```'
-              echo "$really_dropped"
-              echo '```'
-            fi
-            if [ -n "$really_added" ]; then
-              echo "Added to the build set (the target stopped shipping, or new closure members):"
-              echo '```'
-              echo "$really_added"
-              echo '```'
-            fi
-            if [ -z "$really_dropped" ] && [ -z "$really_added" ]; then
-              echo "No package set changes — only measurement provenance moved."
-            fi
-          } > /tmp/pr-body.md
+          # The comparison used to be over FULL PATHS, so a package that
+          # merely moved spec directories could never cancel: it appeared as
+          # a drop AND an add, under headings claiming the target had adopted
+          # it and stopped shipping it. #542 moved all 19 GNOME packages from
+          # src/gnome-51 to src/gnome-50 -- a desktop-wide downgrade -- and
+          # read as routine upstream churn. Moves are now their own category,
+          # reported first.
+          git diff -U0 "$BUILD_ORDER" \
+            | python3 scripts/summarize-gap-drift.py --target "$TARGET" \
+            > /tmp/pr-body.md
           cat /tmp/pr-body.md
 
       - uses: peter-evans/create-pull-request@v8

--- a/scripts/summarize-gap-drift.py
+++ b/scripts/summarize-gap-drift.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Describe what a regenerated build order changed, without lying about it.
+
+The drift job opens a PR whose body is the only thing most readers will judge
+it by, so the body has to distinguish the three things that can happen to a
+package:
+
+  dropped  the target now ships it, so we stop building it
+  added    the target stopped shipping it, or the closure grew
+  MOVED    same package, different spec directory -- a version-track change
+
+The old summary compared FULL PATHS, so a move could never cancel: `gdm`
+appeared as a drop of `src/gnome-51/gdm` and an add of `src/gnome-50/gdm`,
+under the headings "the target now ships these" and "the target stopped
+shipping". Both false, and the pair reads as routine upstream churn.
+
+Measured on tuna-os/tunaos-packages#542 (2026-08-26): that PR moved all 19
+GNOME packages from src/gnome-51 to src/gnome-50 -- a desktop-wide downgrade
+of gdm, gnome-shell, mutter, gtk4 and the rest -- and described it as the
+target having adopted them. The target ships none of them; that is the whole
+premise of the gap measurement.
+
+A move is the one category worth reading closely, so it is reported first and
+shows both paths.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+
+PATH = re.compile(r"^([-+])\s*-?\s*path:\s*(src/\S+)")
+
+
+def parse(diff: str) -> tuple[set[str], set[str]]:
+    """The src/ paths a unified diff removes and adds."""
+    removed: set[str] = set()
+    added: set[str] = set()
+    for line in diff.splitlines():
+        match = PATH.match(line)
+        if not match:
+            continue
+        (removed if match.group(1) == "-" else added).add(match.group(2))
+    return removed, added
+
+
+def classify(removed: set[str], added: set[str]):
+    """Split into moves (same basename, different directory), drops and adds."""
+    def by_name(paths):
+        out: dict[str, set[str]] = {}
+        for path in paths:
+            out.setdefault(path.rsplit("/", 1)[1], set()).add(path)
+        return out
+
+    gone, came = by_name(removed), by_name(added)
+    # A name on both sides whose paths are IDENTICAL did not move: the line
+    # was rewritten in place (a reordering, or a `bootstrap:` flag changing
+    # next to it), so -U0 shows it as both a removal and an addition.
+    # Reporting that as a move puts `lame: src/hummingbird/lame ->
+    # src/hummingbird/lame` in the list and teaches readers to skim it.
+    moved = sorted(
+        (name, sorted(gone[name] - came[name]), sorted(came[name] - gone[name]))
+        for name in gone.keys() & came.keys()
+        if gone[name] != came[name]
+    )
+    dropped = sorted(p for n in gone.keys() - came.keys() for p in gone[n])
+    plus = sorted(p for n in came.keys() - gone.keys() for p in came[n])
+    return moved, dropped, plus
+
+
+def render(target: str, moved, dropped, added) -> str:
+    out = [
+        f"Automated re-measurement: {target}'s live target index",
+        "published a new revision, so the build order was regenerated",
+        "against it.",
+        "",
+    ]
+    if moved:
+        out += [
+            f"**{len(moved)} package(s) MOVED to a different spec directory.**",
+            "This is not the target adopting or dropping anything — it is a",
+            "change of which tree we build them from, usually a version track.",
+            "Read these before merging:",
+            "",
+            "```",
+        ]
+        out += [f"{name}: {', '.join(old)} -> {', '.join(new)}"
+                for name, old, new in moved]
+        out += ["```", ""]
+    if dropped:
+        out += ["Dropped from the build set (the target now ships these):",
+                "```"] + dropped + ["```", ""]
+    if added:
+        out += ["Added to the build set (the target stopped shipping, "
+                "or new closure members):", "```"] + added + ["```", ""]
+    if not (moved or dropped or added):
+        out.append("No package set changes — only measurement provenance moved.")
+    return "\n".join(out).rstrip() + "\n"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--target", required=True)
+    args = ap.parse_args()
+    removed, added = parse(sys.stdin.read())
+    sys.stdout.write(render(args.target, *classify(removed, added)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gap_drift_reports_a_move_as_a_move.py
+++ b/tests/test_gap_drift_reports_a_move_as_a_move.py
@@ -1,0 +1,114 @@
+"""A regenerated build order must not describe a version downgrade as churn.
+
+The drift job opens a PR whose body is the only thing most reviewers judge it
+by. The old summary compared FULL PATHS, so a package that moved between spec
+directories could never cancel between the drop and add lists -- it appeared
+in both, under headings that were each false for it:
+
+    Dropped from the build set (the target now ships these):
+      src/gnome-51/gdm
+    Added to the build set (the target stopped shipping, ...):
+      src/gnome-50/gdm
+
+tuna-os/tunaos-packages#542 (2026-08-26) is the measured case: all 19 GNOME
+packages moved from src/gnome-51 to src/gnome-50, a desktop-wide downgrade of
+gdm, gnome-shell, mutter and gtk4, presented as the target having adopted
+them. It ships none of them -- that is the premise of the gap measurement.
+
+So a move is its own category, reported first and showing both paths.
+"""
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "summarize-gap-drift.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "gap-drift.yml"
+
+
+def summarize(diff: str, target: str = "hummingbird") -> str:
+    done = subprocess.run(
+        [sys.executable, str(SCRIPT), "--target", target],
+        input=diff, capture_output=True, text=True)
+    assert done.returncode == 0, done.stderr
+    return done.stdout
+
+
+def diff_for(removed, added) -> str:
+    lines = ["--- a/build-order.yml", "+++ b/build-order.yml", "@@ -1 +1 @@"]
+    lines += [f"-      - path: {p}" for p in removed]
+    lines += [f"+      - path: {p}" for p in added]
+    return "\n".join(lines) + "\n"
+
+
+def test_a_version_track_change_is_called_a_move():
+    body = summarize(diff_for(["src/gnome-51/gdm"], ["src/gnome-50/gdm"]))
+    assert "MOVED" in body, body
+    assert "gdm: src/gnome-51/gdm -> src/gnome-50/gdm" in body, body
+    # and NOT under either of the two headings that would be false
+    assert "the target now ships these" not in body, body
+    assert "the target stopped shipping" not in body, body
+
+
+def test_the_whole_gnome_downgrade_is_reported_as_moves():
+    """The #542 shape: 19 packages, one track to another."""
+    names = ["gdm", "gnome-shell", "mutter", "gtk4", "libadwaita", "gjs",
+             "nautilus", "vte291", "ptyxis", "gnome-session"]
+    body = summarize(diff_for([f"src/gnome-51/{n}" for n in names],
+                              [f"src/gnome-50/{n}" for n in names]))
+    assert f"**{len(names)} package(s) MOVED" in body, body
+    for name in names:
+        assert f"{name}: src/gnome-51/{name} -> src/gnome-50/{name}" in body, name
+
+
+def test_a_real_drop_is_still_a_drop():
+    body = summarize(diff_for(["src/hummingbird/jsoncpp"], []))
+    assert "the target now ships these" in body, body
+    assert "src/hummingbird/jsoncpp" in body, body
+    assert "MOVED" not in body, body
+
+
+def test_a_real_add_is_still_an_add():
+    body = summarize(diff_for([], ["src/hummingbird/mako"]))
+    assert "the target stopped shipping" in body, body
+    assert "src/hummingbird/mako" in body, body
+    assert "MOVED" not in body, body
+
+
+def test_a_line_rewritten_in_place_is_not_a_move():
+    """-U0 shows a reordered line as both a removal and an addition. Calling
+    that `lame: src/hummingbird/lame -> src/hummingbird/lame` a move teaches
+    readers to skim the one list that must be read."""
+    body = summarize(diff_for(["src/hummingbird/lame"], ["src/hummingbird/lame"]))
+    assert "MOVED" not in body, body
+    assert "No package set changes" in body, body
+
+
+def test_no_changes_says_so():
+    assert "No package set changes" in summarize(diff_for([], []))
+
+
+def test_moves_drops_and_adds_can_coexist():
+    body = summarize(diff_for(
+        ["src/gnome-51/gdm", "src/hummingbird/jsoncpp"],
+        ["src/gnome-50/gdm", "src/hummingbird/mako"]))
+    assert "MOVED" in body
+    assert "gdm: src/gnome-51/gdm -> src/gnome-50/gdm" in body
+    assert "src/hummingbird/jsoncpp" in body
+    assert "src/hummingbird/mako" in body
+
+
+def test_the_workflow_actually_calls_this_script():
+    """The script can be perfect and unreferenced; the old inline bash would
+    still be what opens the PR."""
+    spec = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    bodies = [s.get("run", "") for job in spec["jobs"].values()
+              for s in job.get("steps", [])]
+    joined = "\n".join(bodies)
+    assert "scripts/summarize-gap-drift.py" in joined, joined[:400]
+    # the inline version's tell-tale, which must be gone
+    assert "really_dropped" not in joined, "the old inline summary is still there"


### PR DESCRIPTION
The drift job opens a PR whose body is the only thing most reviewers judge it by — and that body could not describe the most dangerous change it makes.

`dropped` and `added` were compared as **full paths**, so a package that merely moved between spec directories never cancelled. It appeared in both lists, under headings that were each false for it:

```
Dropped from the build set (the target now ships these):
  src/gnome-51/gdm
Added to the build set (the target stopped shipping, ...):
  src/gnome-50/gdm
```

## The measured case

[#542](https://github.com/tuna-os/tunaos-packages/pull/542) moves **all 19 GNOME packages** from `src/gnome-51` to `src/gnome-50` — `gdm`, `gnome-shell`, `mutter`, `gtk4`, `libadwaita` and the rest, a desktop-wide downgrade — and describes it as the target having adopted them. The target ships none of them; that is the entire premise of the gap measurement. It also moves `libnotify` off a Rawhide distgit import onto `src/deps`' deliberate EL10 `0.8.7` pin, described the same way.

A reader skimming that PR sees routine upstream churn.

## The change

Compare by package **name**, and make a move its own category — reported first, showing both paths:

```
**21 package(s) MOVED to a different spec directory.**
This is not the target adopting or dropping anything — it is a
change of which tree we build them from, usually a version track.
Read these before merging:

gdm: src/gnome-51/gdm -> src/gnome-50/gdm
...
libnotify: src/hummingbird/libnotify -> src/deps/libnotify
```

Run against #542's real diff it reports **20 moves**, leaving three genuine drops and one genuine add correctly labelled.

Moved out of inline bash into `scripts/summarize-gap-drift.py` so it can be tested against real diffs rather than only observed in production.

### A second defect, found by looking at the output

`lame` came out as `src/hummingbird/lame -> src/hummingbird/lame`. `-U0` shows a line rewritten in place as both a removal and an addition. A move list padded with non-moves is a move list nobody reads, so identical paths are now excluded.

## Tests

Eight, over real diff text rather than a paraphrase. Mutation-verified, each caught by a distinct test:

| mutation | caught by |
|---|---|
| compare full paths again (the original bug) | 3 failures |
| drop the identical-path guard | the `lame` test |
| workflow reverts to the inline bash | the wiring test |

**A ninth test was written and then deleted rather than shipped.** It asserted that `---`/`+++` diff headers are not read as paths — and removing the guard it covered did not fail it. The regex already requires `path:`, so headers can never match and the guard was dead code. A check that examines nothing is the failure mode this repo keeps re-learning, so both the guard and the test went.

Full suite: **1487 passed, 1 skipped**.

## Relationship to #546

Two halves of the same problem. [#546](https://github.com/tuna-os/tunaos-packages/pull/546) fixes the *cause* — the roots manifest still pointed at GNOME 50 — and adds a fixpoint test so CI refuses the downgrade. This one fixes the *report*, so that any legitimate future re-measure describes itself honestly instead of hiding a version change inside two reassuring lists.

Neither is redundant: #546 stops this particular downgrade, this stops the next one being unreadable.

---
_Generated by [Claude Code](https://claude.ai/code/session_015sZp9iEZAJS44joA2Z8mCK)_