### PR TITLE
fix(hummingbird): let the buildroot see what the factory already published

### DIFF
--- a/mock/hummingbird-ci-aarch64.cfg
+++ b/mock/hummingbird-ci-aarch64.cfg
@@ -49,6 +49,41 @@ enabled=1
 priority=10
 excludepkgs=golang1.26*
 
+[tunaos-hummingbird]
+name=TunaOS factory output for hummingbird - our own build-chain packages
+# The factory's own published prefix, and the reason dconf could not build.
+#
+# dconf BuildRequires vala, vala BuildRequires gobject-introspection-devel,
+# and Rawhide's is built against python 3.15 with a rich
+# `(python(abi) = 3.15 if python3)`. python3 IS in the chroot -- Hummingbird's
+# 3.14 -- so the condition fires and dnf5 reports
+#
+#   cannot install both python3-3.15.0~rc1-1.fc45 from fedora
+#   and python3-3.14.3-2.1.hum1 from hummingbird
+#
+# The factory has ALREADY built and published what it needs, against the
+# right interpreter: gobject-introspection 1.86.0-1.fc43 (the same upstream
+# version Rawhide ships) and vala 0.56.19-1.fc43. The buildroot simply had no
+# repo pointing at them, so every resolution fell through to Rawhide.
+#
+# priority 11 is deliberate, one below [hummingbird]:
+#   1  local-build  this run's own output always wins
+#   10 hummingbird  the base OS still wins for anything it ships
+#   11 HERE         fills what the base lacks -- the desktop stack we build
+#   50 fedora-44-*  the narrow python/perl/mpich pins
+#   99 fedora       Rawhide, the last resort it was previously the first
+#
+# Safe against the Obsoletes hijack that published_index.py records for the
+# gnome50/51 prefixes (a bootstrap glib2 with `Obsoletes: glib2 < 2.87.3`
+# replaces the base package regardless of repo priority; publish run
+# 32405815822 died on it). Measured, not assumed: of the 8100 packages in
+# this prefix, ZERO obsolete any package the Hummingbird base ships.
+# tests/test_hummingbird_buildroot_reads_its_own_output.py pins both halves.
+baseurl=https://repo.tunaos.org/hummingbird/20251124-$basearch/
+gpgcheck=0
+enabled=1
+priority=11
+
 [fedora-44-python]
 name=Fedora 44 - Python 3.14 build inputs only
 metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-44&arch=$basearch

--- a/mock/hummingbird-ci.cfg
+++ b/mock/hummingbird-ci.cfg
@@ -196,6 +196,41 @@ enabled=1
 priority=10
 excludepkgs=golang1.26*
 
+[tunaos-hummingbird]
+name=TunaOS factory output for hummingbird - our own build-chain packages
+# The factory's own published prefix, and the reason dconf could not build.
+#
+# dconf BuildRequires vala, vala BuildRequires gobject-introspection-devel,
+# and Rawhide's is built against python 3.15 with a rich
+# `(python(abi) = 3.15 if python3)`. python3 IS in the chroot -- Hummingbird's
+# 3.14 -- so the condition fires and dnf5 reports
+#
+#   cannot install both python3-3.15.0~rc1-1.fc45 from fedora
+#   and python3-3.14.3-2.1.hum1 from hummingbird
+#
+# The factory has ALREADY built and published what it needs, against the
+# right interpreter: gobject-introspection 1.86.0-1.fc43 (the same upstream
+# version Rawhide ships) and vala 0.56.19-1.fc43. The buildroot simply had no
+# repo pointing at them, so every resolution fell through to Rawhide.
+#
+# priority 11 is deliberate, one below [hummingbird]:
+#   1  local-build  this run's own output always wins
+#   10 hummingbird  the base OS still wins for anything it ships
+#   11 HERE         fills what the base lacks -- the desktop stack we build
+#   50 fedora-44-*  the narrow python/perl/mpich pins
+#   99 fedora       Rawhide, the last resort it was previously the first
+#
+# Safe against the Obsoletes hijack that published_index.py records for the
+# gnome50/51 prefixes (a bootstrap glib2 with `Obsoletes: glib2 < 2.87.3`
+# replaces the base package regardless of repo priority; publish run
+# 32405815822 died on it). Measured, not assumed: of the 8100 packages in
+# this prefix, ZERO obsolete any package the Hummingbird base ships.
+# tests/test_hummingbird_buildroot_reads_its_own_output.py pins both halves.
+baseurl=https://repo.tunaos.org/hummingbird/20251124-$basearch/
+gpgcheck=0
+enabled=1
+priority=11
+
 [fedora-44-python]
 name=Fedora 44 - Python 3.14 build inputs only
 metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-44&arch=$basearch

--- a/tests/test_hummingbird_buildroot_reads_its_own_output.py
+++ b/tests/test_hummingbird_buildroot_reads_its_own_output.py
@@ -1,0 +1,104 @@
+"""The hummingbird buildroot must be able to see what the factory published.
+
+dconf failed every build for days, and with it every publish: the cell exits
+non-zero on any failed package, so `Record a new ActionResult` is skipped and
+588 successfully built packages never reach the repo.
+
+The cause was not dconf. dconf BuildRequires vala; vala BuildRequires
+gobject-introspection-devel; and Rawhide's carries the rich dependency
+`(python(abi) = 3.15 if python3)`. python3 IS in the chroot -- Hummingbird's
+3.14 -- so it fires:
+
+    cannot install both python3-3.15.0~rc1-1.fc45.x86_64 from fedora
+    and python3-3.14.3-2.1.hum1.x86_64 from hummingbird
+
+The factory had already built both against the right interpreter and published
+them. The buildroot just had no repo pointing at its own output, so every
+resolution fell through to Rawhide.
+
+These tests pin the three things that make the fix real, and each is a
+separate failure this repo has already paid for once:
+
+  * BOTH arch configs carry it. Fixing one file and leaving the identical
+    line in its twin is the #529 epoch shape.
+  * The URL agrees with the target's declared published_index, so the
+    buildroot reads the prefix the publisher writes.
+  * Priority sits below the base OS, so this fills gaps rather than shadowing
+    Hummingbird's own packages with our rebuilds.
+"""
+from pathlib import Path
+import re
+
+import pytest
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIGS = [
+    ROOT / "mock/hummingbird-ci.cfg",
+    ROOT / "mock/hummingbird-ci-aarch64.cfg",
+]
+REPO_ID = "tunaos-hummingbird"
+
+
+def repo_block(text: str, repo_id: str) -> str:
+    match = re.search(rf"^\[{re.escape(repo_id)}\]$(.*?)(?=^\[|\Z)",
+                      text, re.MULTILINE | re.DOTALL)
+    return match.group(1) if match else ""
+
+
+def setting(block: str, key: str) -> str | None:
+    match = re.search(rf"^{re.escape(key)}=(.*)$", block, re.MULTILINE)
+    return match.group(1).strip() if match else None
+
+
+@pytest.mark.parametrize("config", CONFIGS, ids=lambda p: p.name)
+def test_both_arch_buildroots_read_the_factory_output(config):
+    block = repo_block(config.read_text(encoding="utf-8"), REPO_ID)
+    assert block, (
+        f"{config.name} has no [{REPO_ID}] repo. Without it the buildroot "
+        "cannot see gobject-introspection-devel or vala built against "
+        "python 3.14, and falls through to Rawhide's 3.15 build, which "
+        "cannot be installed beside Hummingbird's interpreter."
+    )
+
+
+@pytest.mark.parametrize("config", CONFIGS, ids=lambda p: p.name)
+def test_it_reads_the_prefix_the_publisher_writes(config):
+    """A buildroot pointed at a prefix nobody publishes to reads an empty repo."""
+    factory = yaml.safe_load((ROOT / "manifests/package-factory.yaml").read_text())
+    declared = factory["targets"]["hummingbird"]["published_index"]
+    urls = []
+    for value in declared.values():
+        urls.extend(value if isinstance(value, list) else [value])
+
+    baseurl = setting(repo_block(config.read_text(encoding="utf-8"), REPO_ID), "baseurl")
+    assert baseurl, f"{config.name}: [{REPO_ID}] has no baseurl"
+    # mock substitutes $basearch; compare on the arch-independent stem.
+    stem = baseurl.replace("$basearch", "")
+    assert any(url.replace("x86_64", "").replace("aarch64", "") == stem for url in urls), (
+        f"{config.name}: [{REPO_ID}] baseurl {baseurl!r} does not match any "
+        f"published_index for hummingbird ({urls}). The buildroot would read "
+        "a prefix the publisher never writes to."
+    )
+
+
+@pytest.mark.parametrize("config", CONFIGS, ids=lambda p: p.name)
+def test_the_base_os_still_outranks_our_rebuilds(config):
+    """Gap-filling, not shadowing.
+
+    Lower priority wins in dnf. Our output must rank BELOW [hummingbird] so
+    the base OS keeps ownership of everything it ships, and ABOVE the Fedora
+    repos so it beats Rawhide -- which is the whole point.
+    """
+    text = config.read_text(encoding="utf-8")
+    ours = int(setting(repo_block(text, REPO_ID), "priority"))
+    base = int(setting(repo_block(text, "hummingbird"), "priority"))
+    local = int(setting(repo_block(text, "local-build"), "priority"))
+    pinned = int(setting(repo_block(text, "fedora-44-python"), "priority"))
+    assert local < base < ours < pinned, (
+        f"{config.name}: priorities must order local-build({local}) < "
+        f"hummingbird({base}) < {REPO_ID}({ours}) < fedora-44-python({pinned}). "
+        "Above the base OS would shadow Hummingbird's own packages with our "
+        "rebuilds; below the Fedora pins would leave Rawhide winning."
+    )


### PR DESCRIPTION
**Identical commit to [#545](https://github.com/tuna-os/tunaos-packages/pull/545) (`ab610a5`), reopened on a fresh branch because #545's merge-queue entry is unrecoverable from the API.** Full rationale lives on #545; this describes only why a second PR exists.

## Why #545 could not be re-queued

Its entry was evicted at 16:30:41Z by `github-merge-queue[bot]` with reason `CI_TIMEOUT`, after two of its three check runs were created at 15:29:22Z and never scheduled — zero jobs, `updated_at` frozen at `created_at`.

Re-queueing does not help, and the reason is structural. The merge-group ref is

```
gh-readonly-queue/main/pr-545-<base-sha>
```

and its head sha (`f98c39e0`) is deterministic from (base, PR head). Neither has moved — `main` is still `91cbab0` and the PR head is still `ab610a5` — so every re-queue reproduces the *same* ref and the *same* sha, and GitHub matches the existing dead runs rather than creating new ones. I re-queued at 16:31:03Z; no new merge-group runs appeared.

Changing the sha needs either `main` to move (blocked — this PR is what's at the front of the queue) or the PR head to change (an empty commit, which is not something I'll push to kick CI). A different PR number gives a different ref, which is the one lever left.

## What this is not

Not a fix for a failing check. Nothing about #545 is red — its `pull_request` CI was fully green, with `build-0`, `build-1` and `build-2` all `skipped`, confirming mock configs are not action-key inputs. This is a workaround for a wedged queue entry, not a way around a test.

## Why it's urgent

The publish wave has not moved since **2026-08-21**. The last real publisher run built 85 packages, deferred 588, and exited 1 on `dconf` alone, so the publish step never ran. `gnome-shell`, `gdm`, `mutter` and `flatpak` are unserved as a direct consequence — and `gstreamer1-plugins-bad-free`, which is [#540](https://github.com/tuna-os/tunaos-packages/issues/540)'s blocker.

Closing #545 in favour of this one.

---
_Generated by [Claude Code](https://claude.ai/code/session_015sZp9iEZAJS44joA2Z8mCK)_