### PR TITLE
fix(hummingbird): dodge the base jsoncpp skew and heal the mingw split-brain

### DIFF
--- a/mock/hummingbird-ci-aarch64.cfg
+++ b/mock/hummingbird-ci-aarch64.cfg
@@ -47,7 +47,18 @@ baseurl=https://packages.redhat.com/api/pulp-content/public-hummingbird/$basearc
 gpgcheck=0
 enabled=1
 priority=10
-excludepkgs=golang1.26*
+excludepkgs=golang1.26* jsoncpp*
+# jsoncpp* TEMPORARY. The base compose bumped jsoncpp to libjsoncpp.so.27
+# while every cmake it ships (all six releases, 4.3.0-2.1.hum1 through
+# -5.1.hum1) still requires libjsoncpp.so.26 -- a rebuild-in-flight skew
+# that appeared between ~17:00Z and ~23:25Z on 2026-08-26 and makes cmake
+# uninstallable, which takes down 211 of the 673 build-order packages
+# (measured by scripts/simulate-buildroot-resolution.py, root-cause
+# aggregation). Rawhide has NOT bumped: its jsoncpp still provides .so.26
+# and its cmake wants .so.26, a coherent pair. Excluding the base's
+# jsoncpp* (and ours, below) lets that pair through. In the base, only
+# jsoncpp-devel requires .so.27 -- excluded alongside its provider.
+# Remove when the base compose ships a cmake linked against .so.27.
 
 [tunaos-hummingbird]
 name=TunaOS factory output for hummingbird - our own build-chain packages
@@ -111,7 +122,20 @@ priority=11
 # publish-rpm-wave.sh:101 renames across the WHOLE synced-down repo, not
 # just the staged wave, so the first publish that completes fixes all 79 and
 # this exclude can go.
-exclude=*+* libcdio-paranoia*
+exclude=*+* libcdio-paranoia* jsoncpp* mingw* ucrt64-*
+# jsoncpp*: see [hummingbird] -- with the base's excluded, OUR jsoncpp
+# (also .so.27, priority 11) would mask Rawhide's .so.26 provider and
+# reinstate the very block being dodged. Only our own jsoncpp-devel
+# requires .so.27 in this repo, and it leaves alongside its provider.
+#
+# mingw* / ucrt64-*: the '+'-glob above excluded mingw{32,64}-gcc-c++ but
+# left the REST of our mingw toolchain visible, and dnf priorities split
+# the toolchain across repos: our mingw32-gcc (11) masks Rawhide's, while
+# Rawhide's mingw32-gcc-c++ -- the only c++ left -- requires
+# mingw32-gcc = 16.1.1-3.fc45 EXACTLY and gets our fc43 build instead.
+# That is the next failure the running leg will hit at abseil-cpp/inih.
+# Excluding the whole family keeps Rawhide's toolchain internally
+# coherent, exactly as it was before #548 added this repo.
 
 [fedora-44-python]
 name=Fedora 44 - Python 3.14 build inputs only

--- a/mock/hummingbird-ci.cfg
+++ b/mock/hummingbird-ci.cfg
@@ -194,7 +194,18 @@ baseurl=https://packages.redhat.com/api/pulp-content/public-hummingbird/$basearc
 gpgcheck=0
 enabled=1
 priority=10
-excludepkgs=golang1.26*
+excludepkgs=golang1.26* jsoncpp*
+# jsoncpp* TEMPORARY. The base compose bumped jsoncpp to libjsoncpp.so.27
+# while every cmake it ships (all six releases, 4.3.0-2.1.hum1 through
+# -5.1.hum1) still requires libjsoncpp.so.26 -- a rebuild-in-flight skew
+# that appeared between ~17:00Z and ~23:25Z on 2026-08-26 and makes cmake
+# uninstallable, which takes down 211 of the 673 build-order packages
+# (measured by scripts/simulate-buildroot-resolution.py, root-cause
+# aggregation). Rawhide has NOT bumped: its jsoncpp still provides .so.26
+# and its cmake wants .so.26, a coherent pair. Excluding the base's
+# jsoncpp* (and ours, below) lets that pair through. In the base, only
+# jsoncpp-devel requires .so.27 -- excluded alongside its provider.
+# Remove when the base compose ships a cmake linked against .so.27.
 
 [tunaos-hummingbird]
 name=TunaOS factory output for hummingbird - our own build-chain packages
@@ -258,7 +269,20 @@ priority=11
 # publish-rpm-wave.sh:101 renames across the WHOLE synced-down repo, not
 # just the staged wave, so the first publish that completes fixes all 79 and
 # this exclude can go.
-exclude=*+* libcdio-paranoia*
+exclude=*+* libcdio-paranoia* jsoncpp* mingw* ucrt64-*
+# jsoncpp*: see [hummingbird] -- with the base's excluded, OUR jsoncpp
+# (also .so.27, priority 11) would mask Rawhide's .so.26 provider and
+# reinstate the very block being dodged. Only our own jsoncpp-devel
+# requires .so.27 in this repo, and it leaves alongside its provider.
+#
+# mingw* / ucrt64-*: the '+'-glob above excluded mingw{32,64}-gcc-c++ but
+# left the REST of our mingw toolchain visible, and dnf priorities split
+# the toolchain across repos: our mingw32-gcc (11) masks Rawhide's, while
+# Rawhide's mingw32-gcc-c++ -- the only c++ left -- requires
+# mingw32-gcc = 16.1.1-3.fc45 EXACTLY and gets our fc43 build instead.
+# That is the next failure the running leg will hit at abseil-cpp/inih.
+# Excluding the whole family keeps Rawhide's toolchain internally
+# coherent, exactly as it was before #548 added this repo.
 
 [fedora-44-python]
 name=Fedora 44 - Python 3.14 build inputs only

--- a/tests/test_buildroot_dodges_base_jsoncpp_skew.py
+++ b/tests/test_buildroot_dodges_base_jsoncpp_skew.py
@@ -1,0 +1,92 @@
+"""Two buildroot repo-set fixes, both found by the resolution simulator in
+one pass, hours before a build would have found the first of them.
+
+JSONCPP SKEW. The base compose bumped jsoncpp to libjsoncpp.so.27 while
+every cmake it ships still requires libjsoncpp.so.26 -- rebuild-in-flight
+skew, appearing between ~17:00Z and ~23:25Z on 2026-08-26. cmake thereby
+became uninstallable, taking 211 of 673 build-order packages with it.
+Rawhide has NOT bumped: its jsoncpp/.so.26 + cmake pair is coherent. The
+dodge is to exclude jsoncpp* from BOTH the base (so Rawhide's provider
+survives name-masking) and our own repo (whose jsoncpp is also .so.27 at
+priority 11 and would otherwise reinstate the block). Only jsoncpp-devel
+requires .so.27 in either repo, and it leaves with its provider.
+
+MINGW SPLIT-BRAIN. #551's '+'-glob excluded mingw{32,64}-gcc-c++ from our
+repo but left the rest of our mingw toolchain visible. dnf priorities then
+split the toolchain: our mingw32-gcc (priority 11) masks Rawhide's, while
+Rawhide's mingw32-gcc-c++ -- the only c++ compiler left -- requires
+mingw32-gcc = 16.1.1-3.fc45 EXACTLY and resolves our fc43 build instead.
+abseil-cpp and inih fail again, one leg after #551 fixed their previous
+failure. Excluding the whole family (mingw*, ucrt64-*) keeps Rawhide's
+toolchain internally coherent, exactly as before #548 added this repo.
+"""
+from __future__ import annotations
+
+import fnmatch
+import pathlib
+import re
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+CONFIGS = ["mock/hummingbird-ci.cfg", "mock/hummingbird-ci-aarch64.cfg"]
+
+
+def section_field(config: str, section: str, *keys: str) -> list[str]:
+    text = (ROOT / config).read_text(encoding="utf-8")
+    match = re.search(rf"^\[{re.escape(section)}\]$(.*?)(?=^\[|\Z)",
+                      text, re.M | re.S)
+    assert match, f"{config}: no [{section}]"
+    patterns = []
+    for key in keys:
+        line = re.search(rf"^{key}=(.+)$", match.group(1), re.M)
+        if line:
+            patterns.extend(line.group(1).split())
+    return patterns
+
+
+@pytest.mark.parametrize("config", CONFIGS)
+def test_base_jsoncpp_is_excluded_so_rawhides_survives(config):
+    patterns = section_field(config, "hummingbird", "excludepkgs")
+    for name in ("jsoncpp", "jsoncpp-devel"):
+        assert any(fnmatch.fnmatch(name, p) for p in patterns), (
+            f"{config}: base {name!r} not excluded -- its .so.27 masks "
+            f"Rawhide's .so.26 provider and cmake cannot install")
+
+
+@pytest.mark.parametrize("config", CONFIGS)
+def test_our_jsoncpp_is_excluded_too(config):
+    """With only the base's excluded, OUR jsoncpp (priority 11, also .so.27)
+    wins the name against Rawhide (99) and reinstates the very block."""
+    patterns = section_field(config, "tunaos-hummingbird", "exclude")
+    assert any(fnmatch.fnmatch("jsoncpp", p) for p in patterns), config
+
+
+@pytest.mark.parametrize("config", CONFIGS)
+@pytest.mark.parametrize("name", [
+    "mingw32-gcc", "mingw64-gcc", "mingw32-filesystem", "mingw64-filesystem",
+    "mingw32-libstdc++", "ucrt64-gcc-c++",
+])
+def test_the_whole_mingw_family_leaves_together(config, name):
+    """Half a toolchain is worse than none: any surviving member masks its
+    Rawhide twin and breaks Rawhide's exact-version internal requires."""
+    patterns = section_field(config, "tunaos-hummingbird", "exclude")
+    assert any(fnmatch.fnmatch(name, p) for p in patterns), (
+        f"{config}: {name!r} survives and splits the toolchain across repos")
+
+
+@pytest.mark.parametrize("config", CONFIGS)
+def test_the_base_exclude_stays_narrow(config):
+    """excludepkgs=* on the BASE would hand the whole OS to Rawhide."""
+    patterns = section_field(config, "hummingbird", "excludepkgs")
+    assert "*" not in patterns
+    for keep in ("python3", "glib2", "openssl-libs", "cmake"):
+        assert not any(fnmatch.fnmatch(keep, p) for p in patterns), (
+            f"{config}: {keep!r} must keep coming from the base")
+
+
+def test_both_arches_agree():
+    for section, keys in (("hummingbird", ("excludepkgs",)),
+                          ("tunaos-hummingbird", ("exclude",))):
+        assert section_field(CONFIGS[0], section, *keys) == \
+            section_field(CONFIGS[1], section, *keys)


### PR DESCRIPTION
Both found by the resolution simulator ([#553](https://github.com/tuna-os/tunaos-packages/pull/553)) in **one local pass** — the first hours before any build would have hit it, the second before the *currently running* leg re-fails on the exact packages [#551](https://github.com/tuna-os/tunaos-packages/pull/551) just fixed.

## jsoncpp: the base compose is mid-rebuild and cmake is uninstallable

Between ~17:00Z and ~23:25Z on 2026-08-26 the base bumped jsoncpp to `libjsoncpp.so.27` while **every cmake it ships** still requires `.so.26`. Verified against the raw indexes, independent of the simulator:

```
base cmake      ×6   requires libjsoncpp.so.26()(64bit)   (4.3.0-2.1.hum1 … -5.1.hum1)
base cmake-gui  ×6   requires libjsoncpp.so.26()(64bit)
base jsoncpp         provides libjsoncpp.so.27 ONLY
base jsoncpp-devel   requires libjsoncpp.so.27            ← the only .so.27 consumer
```

The 17:00 builddep on the previous leg installed cmake fine, so this skew landed in the base within those six hours. Root-cause aggregation: **211 of 673** build-order packages fall to this one root.

Rawhide has **not** bumped — its `jsoncpp` still provides `.so.26` and its cmake wants `.so.26`, a coherent pair. So: exclude `jsoncpp*` from the base (Rawhide's provider survives name-masking) **and** from our own repo, whose jsoncpp is also `.so.27` at priority 11 and would otherwise mask Rawhide's right back. In each repo only `jsoncpp-devel` consumes `.so.27`, and it leaves with its provider. **Temporary**: remove when the base ships a cmake linked against `.so.27`.

## mingw: #551 excluded half a toolchain, and half is worse than none

The `*+*` glob dropped `mingw{32,64}-gcc-c++` from our repo but left the rest of our mingw set visible. dnf priorities then split the toolchain across repos:

- our `mingw32-gcc` (priority 11) masks Rawhide's;
- Rawhide's `mingw32-gcc-c++` — now the only c++ compiler — requires `mingw32-gcc = 16.1.1-3.fc45` **exactly**, and resolves our fc43 build.

`abseil-cpp` and `inih` fail again, one leg after #551 fixed their previous failure. Excluding the whole family (`mingw*`, `ucrt64-*`) keeps Rawhide's toolchain internally coherent — exactly the pre-#548 state for those names.

## Tests

19 new, both arch configs, mutations each caught distinctly:

| mutation | caught |
|---|---|
| revert the base jsoncpp exclude | ✔ |
| restore the split-brain state (only `-gcc-c++` out) | ✔ (5 failures) |
| `excludepkgs=*` on the base | ✔ — `python3`, `glib2`, `openssl-libs`, `cmake` pinned as must-stay-base |

mock configs are not action-key inputs: this re-keys nothing, and the next leg resumes its partials with the fixed repo set.

Full suite: **1576 passed, 1 skipped**.

## The iteration-speed point

This is the first round-trip of the new workflow: simulator finds → raw-index verification → cfg fix → simulator re-run confirms. Discovery latency for this class was ~6 hours per failure; these two took minutes, and the second was found **before** the run that will hit it has even reached the package.

---
_Generated by [Claude Code](https://claude.ai/code/session_015sZp9iEZAJS44joA2Z8mCK)_