### PR TITLE
fix(publish): rename '^' filenames like '+' — same worker, same 404

### DIFF
--- a/scripts/publish-rpm-wave.sh
+++ b/scripts/publish-rpm-wave.sh
@@ -98,8 +98,16 @@ find "$STAGED" -name '*.rpm' ! -name '*.src.rpm' -exec rpmsign --addsign {} \;
 mkdir -p "${REPO}/${SUBDIR}"
 find "$STAGED" -name '*.rpm' ! -name '*.src.rpm' -exec cp -t "${REPO}/${SUBDIR}" {} +
 
-find "$REPO" -name '*+*.rpm' -print0 | while IFS= read -r -d '' f; do
-	mv "$f" "$(dirname "$f")/$(basename "$f" | tr '+' '.')"
+# '^' joins '+': same worker, same failure. Fedora's snapshot-version
+# convention puts '^' in filenames (quickshell-0.2.1^git…, signon-8.60^…);
+# librepo and dnf percent-encode it to %5E, the worker looks up raw R2
+# keys, and the file 404s. Found by simulate-buildroot-resolution.py's
+# fetchability pass (~30 served files, every one HEAD-verified 404 at the
+# encoded URL) -- and unlike '+', these are runtime packages the desktop
+# lanes install with --skip-unavailable, so the failure is a silently
+# thinner image rather than a red build.
+find "$REPO" \( -name '*+*.rpm' -o -name '*^*.rpm' \) -print0 | while IFS= read -r -d '' f; do
+	mv "$f" "$(dirname "$f")/$(basename "$f" | tr '+^' '..')"
 done
 
 # Runs AFTER the rename so a legacy 'foo+1.rpm' and a staged 'foo+1.rpm'

--- a/tests/test_publish_rpm_wave.py
+++ b/tests/test_publish_rpm_wave.py
@@ -173,6 +173,24 @@ def test_plus_is_renamed_in_files_synced_down_too(tmp_path, stubbed) -> None:
     assert not any("+" in n for n in rpms(tmp_path / "repo"))
 
 
+def test_caret_is_renamed_like_plus(tmp_path, stubbed) -> None:
+    """'^' is Fedora's snapshot-version convention (quickshell-0.2.1^git…)
+    and fails through the worker exactly as '+' does: librepo and dnf
+    percent-encode it to %5E, the worker looks up raw R2 keys, 404. Found by
+    the resolution simulator's fetchability pass: ~30 served files, each
+    HEAD-verified 404 at the encoded URL. Worse than '+' operationally --
+    these are runtime packages the desktop lanes install with
+    --skip-unavailable, so the symptom is a silently thinner image."""
+    make(tmp_path / "staged", "quickshell-0.2.1^git20260209.dacfa9d.fc43.x86_64.rpm")
+    make(tmp_path / "repo" / "tideforge", "signon-8.60^20240205.c8ad982.fc43.x86_64.rpm")
+    r = run(tmp_path, stubbed)
+    assert r.returncode == 0, r.stderr
+    served = rpms(tmp_path / "repo")
+    assert "quickshell-0.2.1.git20260209.dacfa9d.fc43.x86_64.rpm" in served
+    assert "signon-8.60.20240205.c8ad982.fc43.x86_64.rpm" in served
+    assert not any("^" in n or "+" in n for n in served)
+
+
 # --- never shrink -----------------------------------------------------------
 
 


### PR DESCRIPTION
The resolution simulator's fetchability pass ([#553](https://github.com/tuna-os/tunaos-packages/pull/553)) HEAD-checked every served file whose href percent-encodes differently from its raw form — and found **~30 more unfetchable files** beyond the 79 `+`-named ones [#551](https://github.com/tuna-os/tunaos-packages/pull/551) dodged: files with `^` in the **version**, Fedora's snapshot convention.

```
quickshell-0.2.1^git20260209.dacfa9d-4.1.fc43.x86_64.rpm
signon-8.60^20240205.c8ad982-6.1.fc43.x86_64.rpm
rapidjson-devel-1.1.0^20241222git24b5e7a-1.fc43.x86_64.rpm
libultrahdr, aribb24, poly2tri, libmpcdec, accounts-qml-module, …
```

Same mechanism `publish-rpm-wave.sh:27` already records for `+`: librepo and dnf percent-encode (`^` → `%5E`), the repo.tunaos.org worker looks up raw R2 keys, 404. Each file verified 404 at the encoded URL against the live prefix.

**Operationally worse than the `+` class**: those were buildroot-only, but `quickshell` is a runtime package the niri desktop lane installs with `--skip-unavailable` — so the failure mode is an image silently missing its compositor, not a red build.

The rename runs across the whole synced-down tree (`:101`), so the next completed publish repairs every existing `^` object in the bucket, exactly as the `+` rename does. `publish-rpm-wave.sh` is not an action-key input; nothing re-keys.

Mutation-verified: reverting the rename to `+`-only fails the new test. Full suite: **1558 passed, 1 skipped**.

---
_Generated by [Claude Code](https://claude.ai/code/session_015sZp9iEZAJS44joA2Z8mCK)_