### PR TITLE
feat(publish): route build-chain legs to 16-vCPU RunsOn AWS runners

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,0 +1,29 @@
+# RunsOn (AWS) runner pool for the package factory's long build-chain legs.
+# Same shape as tunaOS's .github/runs-on.yml (build-amd64/build-arm64 there),
+# sized for this repo's bottleneck: mock builds inside podman, dispatched
+# JOBS = nproc/2 wide by scripts/build-chain.sh. 16 vCPU -> 8 parallel mock
+# roots; 64GB-class memory families so eight concurrent chroots + podman
+# never OOM; a big gp3 volume because --uniqueext gives every package its
+# own mock root and the local-repo grows all leg.
+#
+# Measured on GitHub-hosted 4-vCPU runners (JOBS=2): ~17 packages/hour,
+# 81-85 per 4.5h budget, ~590 deferred every leg. At JOBS=8 the same budget
+# quadruples, and self-hosted jobs may exceed the hosted 6h ceiling, so the
+# publisher's runs-on path pairs these with a longer timeout and
+# CHAIN_BUDGET_SECONDS -- one leg can cover the whole current backlog.
+runners:
+  chain-amd64:
+    family: ["m6a", "m7a", "m6i"]
+    cpu: [16]
+    image: ubuntu24-full-x64
+    volume: 200gb:gp3
+    spot: capacity-optimized
+  chain-arm64:
+    family: ["m7g", "m6g"]
+    cpu: [16]
+    image: ubuntu24-full-arm64
+    volume: 200gb:gp3
+    spot: capacity-optimized
+
+tags:
+  team: tunaos

--- a/.github/workflows/publish-build-chain-rpms.yml
+++ b/.github/workflows/publish-build-chain-rpms.yml
@@ -31,6 +31,27 @@ on:
         required: false
         default: false
         type: boolean
+      runner:
+        # `hosted` is the default so an input-less dispatch (and every
+        # existing caller) behaves exactly as before. `runs-on` routes the
+        # build job to the AWS pool in .github/runs-on.yml: 16 vCPU, so
+        # build-chain.sh's JOBS = nproc/2 becomes 8 parallel mocks instead
+        # of 2, and self-hosted jobs may exceed the hosted 6h ceiling, so
+        # the timeout and CHAIN_BUDGET_SECONDS stretch with it -- one leg
+        # can cover what took four.
+        #
+        # If the RunsOn app turns out not to serve this repo, the run sits
+        # `queued` with zero jobs. The recovery is to dispatch again with
+        # `hosted`: this workflow's shared concurrency group keeps at most
+        # one PENDING run, so the newer dispatch cancels the stuck one,
+        # while cancel-in-progress: false still protects a RUNNING leg.
+        description: "Runner pool: hosted (GitHub) or runs-on (AWS, 16 vCPU)"
+        required: false
+        default: hosted
+        type: choice
+        options:
+          - hosted
+          - runs-on
 
 permissions:
   contents: read
@@ -62,10 +83,18 @@ jobs:
 
   build:
     needs: plan
-    runs-on: ${{ matrix.runner }}
+    # The planner's matrix.runner is a GitHub-hosted label; on the runs-on
+    # path it is translated to the equivalent AWS pool entry rather than
+    # threaded through the planner (the planner's output is arch selection,
+    # not a capacity decision).
+    runs-on: ${{ inputs.runner != 'runs-on' && matrix.runner
+      || format('runs-on={0}/runner={1}', github.run_id,
+                matrix.runner == 'ubuntu-24.04-arm' && 'chain-arm64' || 'chain-amd64') }}
     # Build-chain cells are tiered source builds: gnome50 is 19 tiers and
-    # hours, not the minutes a tideforge cell takes.
-    timeout-minutes: 360
+    # hours, not the minutes a tideforge cell takes. Hosted runners cap a
+    # job at 6h; the AWS pool does not, so the ceiling stretches and
+    # CHAIN_BUDGET_SECONDS (in the build step) stretches inside it.
+    timeout-minutes: ${{ inputs.runner != 'runs-on' && 360 || 660 }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
@@ -170,6 +199,12 @@ jobs:
           MANIFEST: ${{ matrix.manifest }}
           MOCK_CONFIG: ${{ matrix.mock_config }}
           SOURCE_DATE_EPOCH: ${{ steps.identity.outputs.epoch }}
+          # run-package-factory-cell.sh defaults this to 16200 (4.5h of
+          # building inside the hosted 6h ceiling). The AWS pool has no 6h
+          # ceiling and timeout-minutes is 660 there, so give the chain
+          # 9.5h of building and the same ~1.5h to drain the longest
+          # in-flight package and run validate/checksum/SBOM/upload.
+          CHAIN_BUDGET_SECONDS: ${{ inputs.runner != 'runs-on' && 16200 || 34200 }}
         if: steps.verdict.outputs.hit != 'true'
         run: bash scripts/run-package-factory-cell.sh
       - uses: actions/upload-artifact@v7

--- a/tests/test_publisher_can_use_runs_on_pool.py
+++ b/tests/test_publisher_can_use_runs_on_pool.py
@@ -1,0 +1,79 @@
+"""The publisher's runs-on path: bigger AWS runners, longer budget, and a
+default that changes nothing for existing callers.
+
+Throughput on GitHub-hosted runners is the chain's wall: 4 vCPU means
+build-chain.sh's JOBS = nproc/2 = 2 parallel mocks, ~17 packages/hour,
+81-85 per leg against ~590 deferred. The AWS pool's 16 vCPU makes that 8
+parallel mocks, and self-hosted jobs are not bound by the hosted 6h
+ceiling, so one leg can cover what took four.
+
+Everything here is workflow YAML and a RunsOn config -- neither is an
+action-key input, so the change re-keys nothing and partials resume.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "publish-build-chain-rpms.yml"
+SPEC = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+POOL = yaml.safe_load((ROOT / ".github" / "runs-on.yml").read_text(encoding="utf-8"))
+BUILD = SPEC["jobs"]["build"]
+
+
+def test_the_default_is_hosted_so_existing_dispatches_are_unchanged():
+    runner = SPEC[True]["workflow_dispatch"]["inputs"]["runner"]
+    assert runner["default"] == "hosted"
+    assert runner["required"] is False
+    assert set(runner["options"]) == {"hosted", "runs-on"}
+
+
+def test_the_hosted_branch_still_uses_the_planner_runner():
+    assert "matrix.runner" in BUILD["runs-on"]
+    assert "inputs.runner != 'runs-on'" in BUILD["runs-on"]
+
+
+def test_the_runs_on_branch_references_pool_runners_that_exist():
+    """A label naming a runner absent from .github/runs-on.yml queues
+    forever, and there is no cancel tool in this environment."""
+    referenced = set(re.findall(r"'(chain-[a-z0-9]+)'", BUILD["runs-on"]))
+    assert referenced == {"chain-amd64", "chain-arm64"}
+    assert referenced <= set(POOL["runners"]), (
+        f"workflow references {referenced - set(POOL['runners'])} "
+        "which .github/runs-on.yml does not define")
+
+
+def test_the_arm_matrix_runner_maps_to_the_arm_pool():
+    assert "matrix.runner == 'ubuntu-24.04-arm' && 'chain-arm64'" in BUILD["runs-on"]
+
+
+@pytest.mark.parametrize("name", ["chain-amd64", "chain-arm64"])
+def test_pool_runners_are_sized_for_eight_parallel_mocks(name):
+    runner = POOL["runners"][name]
+    assert runner["cpu"] == [16], "JOBS = nproc/2 -> 8 needs 16 vCPU"
+    # m-family = 4GB/vCPU: eight parallel mock chroots plus podman need the
+    # memory headroom; c-family's 2GB/vCPU is what the hosted runners have
+    # and mock builds already brush against it at JOBS=2.
+    assert all(f.startswith("m") for f in runner["family"]), runner["family"]
+
+
+def test_the_budget_stretches_only_on_the_runs_on_branch():
+    step = next(s for s in BUILD["steps"] if s.get("name") == "Build the cell")
+    budget = str(step["env"]["CHAIN_BUDGET_SECONDS"])
+    assert "16200" in budget and "34200" in budget
+    assert "inputs.runner != 'runs-on'" in budget
+
+
+def test_budget_fits_inside_the_timeout_with_drain_headroom():
+    """The whole point of the soft deadline (#480) is finishing the leg's
+    in-flight packages and post-processing BEFORE timeout-minutes tears the
+    job down. Both branches must keep >= 60 minutes of headroom."""
+    timeout = str(BUILD["timeout-minutes"])
+    pairs = {360: 16200, 660: 34200}
+    for minutes, budget in pairs.items():
+        assert str(minutes) in timeout
+        assert minutes * 60 - budget >= 3600, (minutes, budget)


### PR DESCRIPTION
Per James's direction: use the beefier AWS runners to speed the chain up.

## The math

`build-chain.sh` dispatches `JOBS = nproc/2` parallel mocks. GitHub-hosted 4 vCPU → 2 jobs → measured **~17 packages/hour, 81–85 per 4.5h budget, ~590 deferred every leg**.

The org already runs RunsOn (tunaOS's `.github/runs-on.yml`, same label syntax). This repo gets its own pool sized for the chain's bottleneck:

| | hosted today | `runs-on` path |
|---|---|---|
| vCPU / parallel mocks | 4 / 2 | **16 / 8** |
| memory per mock | ~2GB/vCPU (c-class) | **4GB/vCPU (m-family)** |
| disk | ~14GB free | **200GB gp3** (`--uniqueext` = one mock root per package) |
| `timeout-minutes` | 360 (hosted hard cap) | **660** |
| `CHAIN_BUDGET_SECONDS` | 16200 (4.5h build) | **34200** (9.5h build, same ~1.5h drain headroom the soft deadline exists for, #480) |

At 4× parallelism × 2× budget, **one leg covers roughly the entire current backlog** — versus four legs and counting.

## Safety properties

- `runner` is a dispatch input **defaulting to `hosted`** — input-less dispatches and every existing caller behave exactly as before.
- If the RunsOn app doesn't serve this repo, the run sits queued with zero jobs. Documented recovery: dispatch again with `hosted` — the shared concurrency group keeps at most one *pending* run, so the newer dispatch cancels the stuck one while `cancel-in-progress: false` still protects a running leg. That escape hatch is what makes this safely triable in an environment with no cancel tool.
- Workflow YAML and the RunsOn config are **not action-key inputs**: nothing re-keys, partials resume.
- `CHAIN_BUDGET_SECONDS` was already an env override (`run-package-factory-cell.sh:53`); no script changes.

## Tests

8, mutation-verified — each caught distinctly:

| mutation | caught |
|---|---|
| workflow references a runner the pool doesn't define (the queue-forever hazard) | ✔ 2 failures |
| default flips to `runs-on` | ✔ |
| budget outgrows its timeout (drain headroom gone) | ✔ |

Full suite: **1565 passed, 1 skipped**.

First real use: the next auto-chained leg dispatches with `runner: runs-on` once this merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_015sZp9iEZAJS44joA2Z8mCK)_