### PR TITLE
fix(publish): one failed package must not hold the built wave hostage

### DIFF
--- a/.github/workflows/publish-build-chain-rpms.yml
+++ b/.github/workflows/publish-build-chain-rpms.yml
@@ -207,11 +207,20 @@ jobs:
           CHAIN_BUDGET_SECONDS: ${{ inputs.runner != 'runs-on' && 16200 || 34200 }}
         if: steps.verdict.outputs.hit != 'true'
         run: bash scripts/run-package-factory-cell.sh
+      # always(): the wave is every RPM the chain banked, and a chain that
+      # failed ONE package out of 674 still banked the rest. Without it this
+      # upload skips on any build failure, the publish job starves, and the
+      # same 85 packages are rebuilt every leg while the served index never
+      # moves -- legs 32914264044, 32991216265 and 33022688689 all ended
+      # exactly that way. warn not error: a cell torn down before its first
+      # RPM has nothing to upload, and that must not mask the build step's
+      # own failure as an upload failure.
       - uses: actions/upload-artifact@v7
+        if: always()
         with:
           name: publish-rpm-${{ matrix.id }}
           path: .factory/${{ matrix.id }}/artifacts/*.rpm
-          if-no-files-found: error
+          if-no-files-found: warn
 
       # Bank the partial, so hours spent here are not thrown away.
       #
@@ -254,6 +263,11 @@ jobs:
 
   publish:
     needs: [plan, build]
+    # Publish whatever the build banked, even when the build job itself is
+    # red: one failed package must not hold the other built packages hostage,
+    # or the chain can never accumulate across legs (#544). cancelled() still
+    # aborts -- a torn-down run must not race a fresh one for the bucket.
+    if: ${{ !cancelled() && needs.plan.result == 'success' }}
     runs-on: ubuntu-latest
     strategy:
       # Serial: every cell talks to the same bucket and rclone config.

--- a/mock/hummingbird-ci-aarch64.cfg
+++ b/mock/hummingbird-ci-aarch64.cfg
@@ -122,7 +122,7 @@ priority=11
 # publish-rpm-wave.sh:101 renames across the WHOLE synced-down repo, not
 # just the staged wave, so the first publish that completes fixes all 79 and
 # this exclude can go.
-exclude=*+* libcdio-paranoia* jsoncpp* mingw* ucrt64-* wayland-protocols* python3-docutils*
+exclude=*+* libcdio-paranoia* jsoncpp* mingw* ucrt64-* wayland-protocols* python3-docutils* accounts-qml-module* aribb24* libmpcdec* libultrahdr* musepack-tools* poly2tri* quickshell* rapidjson* signon* stb* transfig* usbmuxd* vpnc*
 # jsoncpp*: see [hummingbird] -- with the base's excluded, OUR jsoncpp
 # (also .so.27, priority 11) would mask Rawhide's .so.26 provider and
 # reinstate the very block being dodged. Only our own jsoncpp-devel
@@ -152,6 +152,16 @@ exclude=*+* libcdio-paranoia* jsoncpp* mingw* ucrt64-* wayland-protocols* python
 # xdg-desktop-portal) is blocked by our own stale copy. Excluding it lets
 # F44's in-range 0.22.4 serve the buildroot. Not in any build order; remove
 # when the served copy is current or pruned.
+#
+# accounts-qml-module* .. vpnc*: TEMPORARY, the '^' twin of the '*+*' glob
+# above. 50 served RPMs carry '^' in their VERSION (libultrahdr, signon,
+# stb, quickshell ...), librepo percent-encodes it (%5E), the R2 worker
+# looks up raw paths, 404. Being version-side, a name glob cannot catch
+# them, so the 14 affected NAME families are listed -- exactly how
+# libcdio-paranoia* is handled above. Leg 33022688689 failed dejavu-fonts
+# on precisely libultrahdr-1.4.0^...rpm. publish-rpm-wave.sh renames '^'
+# like '+' (#555), so the first completed publish repairs all 50 and this
+# list can go.
 
 [fedora-44-python]
 name=Fedora 44 - Python 3.14 build inputs only

--- a/mock/hummingbird-ci.cfg
+++ b/mock/hummingbird-ci.cfg
@@ -269,7 +269,7 @@ priority=11
 # publish-rpm-wave.sh:101 renames across the WHOLE synced-down repo, not
 # just the staged wave, so the first publish that completes fixes all 79 and
 # this exclude can go.
-exclude=*+* libcdio-paranoia* jsoncpp* mingw* ucrt64-* wayland-protocols* python3-docutils*
+exclude=*+* libcdio-paranoia* jsoncpp* mingw* ucrt64-* wayland-protocols* python3-docutils* accounts-qml-module* aribb24* libmpcdec* libultrahdr* musepack-tools* poly2tri* quickshell* rapidjson* signon* stb* transfig* usbmuxd* vpnc*
 # jsoncpp*: see [hummingbird] -- with the base's excluded, OUR jsoncpp
 # (also .so.27, priority 11) would mask Rawhide's .so.26 provider and
 # reinstate the very block being dodged. Only our own jsoncpp-devel
@@ -299,6 +299,16 @@ exclude=*+* libcdio-paranoia* jsoncpp* mingw* ucrt64-* wayland-protocols* python
 # xdg-desktop-portal) is blocked by our own stale copy. Excluding it lets
 # F44's in-range 0.22.4 serve the buildroot. Not in any build order; remove
 # when the served copy is current or pruned.
+#
+# accounts-qml-module* .. vpnc*: TEMPORARY, the '^' twin of the '*+*' glob
+# above. 50 served RPMs carry '^' in their VERSION (libultrahdr, signon,
+# stb, quickshell ...), librepo percent-encodes it (%5E), the R2 worker
+# looks up raw paths, 404. Being version-side, a name glob cannot catch
+# them, so the 14 affected NAME families are listed -- exactly how
+# libcdio-paranoia* is handled above. Leg 33022688689 failed dejavu-fonts
+# on precisely libultrahdr-1.4.0^...rpm. publish-rpm-wave.sh renames '^'
+# like '+' (#555), so the first completed publish repairs all 50 and this
+# list can go.
 
 [fedora-44-python]
 name=Fedora 44 - Python 3.14 build inputs only

--- a/tests/test_buildroot_dodges_base_jsoncpp_skew.py
+++ b/tests/test_buildroot_dodges_base_jsoncpp_skew.py
@@ -123,3 +123,28 @@ def test_new_excludes_do_not_overreach(config, name):
     patterns = section_field(config, "tunaos-hummingbird", "exclude")
     assert not any(fnmatch.fnmatch(name, p) for p in patterns), (
         f"{config}: exclude glob overreaches onto {name!r}")
+
+
+@pytest.mark.parametrize("config", CONFIGS)
+@pytest.mark.parametrize("name", [
+    "libultrahdr", "libultrahdr-devel", "signon", "signon-qt6-devel",
+    "stb_image-devel", "quickshell", "rapidjson-devel", "transfig",
+    "usbmuxd", "vpnc", "aribb24", "libmpcdec", "musepack-tools",
+    "poly2tri", "accounts-qml-module-qt6",
+])
+def test_the_caret_version_families_are_excluded(config, name):
+    """50 served RPMs carry '^' in their VERSION; librepo requests %5E, the
+    R2 worker looks up the raw path, 404. The '*+*' name glob cannot catch a
+    version-side character, so the 14 affected name families are listed --
+    leg 33022688689 failed dejavu-fonts on exactly libultrahdr-1.4.0^....rpm."""
+    patterns = section_field(config, "tunaos-hummingbird", "exclude")
+    assert any(fnmatch.fnmatch(name, p) for p in patterns), (
+        f"{config}: {name!r} still advertised but unfetchable (%5E lookup)")
+
+
+@pytest.mark.parametrize("config", CONFIGS)
+@pytest.mark.parametrize("name", ["rapidcheck", "usbutils", "librsvg2"])
+def test_caret_family_globs_do_not_overreach(config, name):
+    patterns = section_field(config, "tunaos-hummingbird", "exclude")
+    assert not any(fnmatch.fnmatch(name, p) for p in patterns), (
+        f"{config}: caret-family glob overreaches onto {name!r}")

--- a/tests/test_one_failure_does_not_hold_the_wave_hostage.py
+++ b/tests/test_one_failure_does_not_hold_the_wave_hostage.py
@@ -1,0 +1,97 @@
+"""A failed package must not stop the built ones from publishing.
+
+Legs 32914264044, 32991216265 and 33022688689 each built 81-85 packages,
+failed 1-3, and published NOTHING: the wave upload carried no `if:`, so the
+build step's failure skipped it, the publish job (default success gating)
+skipped in turn, and the next leg rebuilt the same packages against an
+unchanged served index. Accumulation (#544) is impossible under that wiring
+regardless of how well the chain itself banks partials.
+
+Asserted here:
+
+  * the wave upload runs `always()` — a chain that failed one package out of
+    674 still banked the rest, and those bytes are the whole point;
+  * it warns rather than errors on an empty wave — a cell torn down before
+    its first RPM must surface the BUILD failure, not an upload failure;
+  * the publish job runs unless the run was cancelled — `!cancelled()`
+    because a torn-down run must not race a fresh dispatch for the bucket,
+    `plan.result == 'success'` because without the planner there is no
+    matrix to publish;
+  * the partial-banking upload keeps its own conditions — publishing the
+    wave and banking the resume state are different guarantees and one must
+    not absorb the other.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = ROOT / ".github" / "workflows" / "publish-build-chain-rpms.yml"
+
+
+@pytest.fixture(scope="module")
+def workflow():
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def build_job(workflow):
+    return workflow["jobs"]["build"]
+
+
+@pytest.fixture(scope="module")
+def wave_upload(build_job):
+    steps = [
+        s for s in build_job["steps"]
+        if "upload-artifact" in str(s.get("uses", ""))
+        and "publish-rpm-" in str(s.get("with", {}).get("name", ""))
+    ]
+    assert len(steps) == 1, "exactly one wave upload expected"
+    return steps[0]
+
+
+def test_the_wave_uploads_even_when_a_package_failed(wave_upload):
+    assert "always()" in str(wave_upload.get("if", "")), (
+        "no always(): one failed package skips the upload, starves publish, "
+        "and the same packages rebuild every leg against a frozen index"
+    )
+
+
+def test_an_empty_wave_warns_instead_of_masking_the_build_failure(wave_upload):
+    assert wave_upload["with"]["if-no-files-found"] == "warn"
+
+
+def test_publish_runs_on_a_red_build(workflow):
+    cond = str(workflow["jobs"]["publish"].get("if", ""))
+    assert "!cancelled()" in cond, (
+        "publish must run when build is red (the wave holds what DID build) "
+        "but never on a cancelled run racing a fresh dispatch for the bucket"
+    )
+    assert "needs.plan.result == 'success'" in cond
+
+
+def test_publish_does_not_run_unconditionally(workflow):
+    cond = str(workflow["jobs"]["publish"].get("if", ""))
+    assert "always()" not in cond, (
+        "always() would publish even from a cancelled run — the exact "
+        "two-publishers-one-bucket shape of #124"
+    )
+
+
+def test_partial_banking_keeps_its_own_conditions(build_job):
+    partials = [
+        s for s in build_job["steps"]
+        if "-partial" in str(s.get("with", {}).get("name", ""))
+    ]
+    assert len(partials) == 1
+    cond = str(partials[0].get("if", ""))
+    assert "always()" in cond
+    assert "steps.build.outcome" in cond, (
+        "the partial's allowlist must survive: it exists so a cache hit does "
+        "not upload a redundant copy, and that logic is separate from the wave"
+    )


### PR DESCRIPTION
Leg [33022688689](https://github.com/tuna-os/tunaos-packages/actions/runs/33022688689) completed 04:05Z, verbatim:

```
==> Packages built:  85
ERROR: Failed packages (1):
ERROR:   - src/hummingbird/dejavu-fonts
==> Deferred (deadline): 588
```

That makes three legs in a row (32914264044: 85 built / 588 deferred; 32991216265: 81/592; this one: 85/588) that built dozens of packages, failed one to three, and **published nothing**. The frozen built/deferred numbers are the tell: with no publish the served index never moves, so every leg rebuilds the same first tier-span from scratch. Accumulation (#544) is impossible under this wiring no matter how well the chain banks partials. Two defects compose:

## 1. The wave upload skipped on any build failure

The `publish-rpm-*` artifact upload carried no `if:` — the build step's failure skipped it (while the `-partial` banking upload with its `always()` correctly ran). The publish job's default success-gating then skipped too, stranding the 85 built RPMs in a partial nothing publishes.

Now: the wave uploads `always()` (with `if-no-files-found: warn`, so a cell torn down before its first RPM surfaces the *build* failure, not an upload failure), and publish runs under `!cancelled() && needs.plan.result == 'success'`. A cancelled run still never touches the bucket — the two-publishers-one-bucket shape of #124 stays impossible, and a new guard test pins that `always()` never appears on the publish job.

## 2. The one failure was the '^' twin of the '+' incident — called in advance

dejavu-fonts died on `Librepo error: Cannot download libultrahdr-1.4.0%5e20251202git8cbc983-1.fc43.x86_64.rpm`. The simulator's fetch-check flagged exactly this class: 50 served RPMs with '^' in their **version**, which librepo percent-encodes (%5E) and the R2 worker looks up raw (#458). #551's `*+*` name glob can't catch a version-side character, so the 14 affected name families are excluded by name — the same way `libcdio-paranoia*` is handled there. #555's rename repairs all 50 on the first completed publish, and the list can then go.

## Measured

- Simulator against current indexes with the new excludes: **630/673 OK, unchanged** — the excluded families' Rawhide twins take over cleanly (overreach guards prove `rapidcheck`, `usbutils`, `librsvg2` stay untouched).
- 524 workflow/publish/chain/buildroot tests pass, including the new suite `test_one_failure_does_not_hold_the_wave_hostage.py`.
- Neither file is an action-key input; running partials resume.

With this merged, the next leg publishes its ~85-plus packages even if a straggler fails, the leg after that skips them, and the deferral ceiling finally starts closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sZp9iEZAJS44joA2Z8mCK

---
_Generated by [Claude Code](https://claude.ai/code/session_015sZp9iEZAJS44joA2Z8mCK)_