### PR TITLE
fix(publish): let rootless podman clone on the RunsOn Ubuntu 24.04 AMIs

### DIFF
--- a/.github/workflows/publish-build-chain-rpms.yml
+++ b/.github/workflows/publish-build-chain-rpms.yml
@@ -104,6 +104,14 @@ jobs:
         run: |
           sudo apt-get update -q
           sudo apt-get install -y -q createrepo-c podman rpm
+          # Ubuntu 24.04 ships kernel.apparmor_restrict_unprivileged_userns=1;
+          # GitHub's hosted images turn it off, the RunsOn AMIs keep the OS
+          # default -- and rootless podman then dies at its first clone():
+          # "cannot clone: Permission denied / cannot re-exec process", which
+          # is how run 33040673914 failed every package in under 2 minutes.
+          # -e: absent on kernels without AppArmor userns confinement, and
+          # that absence is fine, not an error.
+          sudo sysctl -e -w kernel.apparmor_restrict_unprivileged_userns=0
       # --- Bridge to the nightly's banked work -------------------------------
       # This job used to rebuild every cell from ZERO on every dispatch: no
       # action-cache restore, no partial resume. That made nightly


### PR DESCRIPTION
Bringup leg [33040673914](https://github.com/tuna-os/tunaos-packages/actions/runs/33040673914) proved the pool wiring end to end — both build jobs were picked up by `runs-on--i-*` instances under the `chain-amd64`/`chain-arm64` labels within 30 seconds — and then failed every package in under two minutes with:

```
cannot clone: Permission denied
Error: cannot re-exec process
```

Ubuntu 24.04 ships `kernel.apparmor_restrict_unprivileged_userns=1`. The GitHub-hosted runner images disable it; the RunsOn AMIs keep the OS default, so rootless podman cannot create its first user namespace and every `spectool`/mock invocation dies at `clone()`. One sysctl in the native-tools step clears it; `-e` keeps it a no-op on kernels without the knob (today's hosted path — where the value is already 0 anyway).

The leg was not wasted: it was also the first live pass of #563's publish-on-partial wiring, which behaved exactly as designed on this failure shape — the wave uploaded despite the red build and the publish jobs proceeded with the resumed partial rather than starving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sZp9iEZAJS44joA2Z8mCK

---
_Generated by [Claude Code](https://claude.ai/code/session_015sZp9iEZAJS44joA2Z8mCK)_