### PR TITLE
fix(hummingbird): pin the python-3.15-stranded build tools to their F44 builds

### DIFF
--- a/mock/hummingbird-ci-aarch64.cfg
+++ b/mock/hummingbird-ci-aarch64.cfg
@@ -169,7 +169,7 @@ metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-44&arch=$basearc
 gpgcheck=0
 enabled=1
 priority=50
-includepkgs=python3-*,flit,pyproject-rpm-macros,pyproject-srpm-macros,python-rpm-macros,python-srpm-macros,tomcli
+includepkgs=python3-*,flit,pyproject-rpm-macros,pyproject-srpm-macros,python-rpm-macros,python-srpm-macros,tomcli,asciidoc,go-vendor-tools,xwayland-run,blueprint-compiler,marshalparser,xcb-proto,lirc*,glad2,python3-glad2
 
 [fedora-44-python-updates]
 name=Fedora 44 updates - Python 3.14 build inputs only
@@ -177,7 +177,7 @@ metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f44&ar
 gpgcheck=0
 enabled=1
 priority=50
-includepkgs=python3-*,flit,pyproject-rpm-macros,pyproject-srpm-macros,python-rpm-macros,python-srpm-macros,tomcli
+includepkgs=python3-*,flit,pyproject-rpm-macros,pyproject-srpm-macros,python-rpm-macros,python-srpm-macros,tomcli,asciidoc,go-vendor-tools,xwayland-run,blueprint-compiler,marshalparser,xcb-proto,lirc*,glad2,python3-glad2
 
 [fedora-44-perl]
 name=Fedora 44 - perl 5.42 build inputs only

--- a/mock/hummingbird-ci.cfg
+++ b/mock/hummingbird-ci.cfg
@@ -316,7 +316,7 @@ metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-44&arch=$basearc
 gpgcheck=0
 enabled=1
 priority=50
-includepkgs=python3-*,flit,pyproject-rpm-macros,pyproject-srpm-macros,python-rpm-macros,python-srpm-macros,tomcli
+includepkgs=python3-*,flit,pyproject-rpm-macros,pyproject-srpm-macros,python-rpm-macros,python-srpm-macros,tomcli,asciidoc,go-vendor-tools,xwayland-run,blueprint-compiler,marshalparser,xcb-proto,lirc*,glad2,python3-glad2
 
 [fedora-44-python-updates]
 name=Fedora 44 updates - Python 3.14 build inputs only
@@ -324,7 +324,7 @@ metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f44&ar
 gpgcheck=0
 enabled=1
 priority=50
-includepkgs=python3-*,flit,pyproject-rpm-macros,pyproject-srpm-macros,python-rpm-macros,python-srpm-macros,tomcli
+includepkgs=python3-*,flit,pyproject-rpm-macros,pyproject-srpm-macros,python-rpm-macros,python-srpm-macros,tomcli,asciidoc,go-vendor-tools,xwayland-run,blueprint-compiler,marshalparser,xcb-proto,lirc*,glad2,python3-glad2
 
 [fedora-44-perl]
 name=Fedora 44 - perl 5.42 build inputs only

--- a/tests/test_buildroot_dodges_base_jsoncpp_skew.py
+++ b/tests/test_buildroot_dodges_base_jsoncpp_skew.py
@@ -41,7 +41,8 @@ def section_field(config: str, section: str, *keys: str) -> list[str]:
     for key in keys:
         line = re.search(rf"^{key}=(.+)$", match.group(1), re.M)
         if line:
-            patterns.extend(line.group(1).split())
+            # exclude= is whitespace-separated; includepkgs= is comma-separated
+            patterns.extend(line.group(1).replace(",", " ").split())
     return patterns
 
 
@@ -148,3 +149,34 @@ def test_caret_family_globs_do_not_overreach(config, name):
     patterns = section_field(config, "tunaos-hummingbird", "exclude")
     assert not any(fnmatch.fnmatch(name, p) for p in patterns), (
         f"{config}: caret-family glob overreaches onto {name!r}")
+
+
+@pytest.mark.parametrize("config", CONFIGS)
+@pytest.mark.parametrize("name", [
+    "asciidoc", "go-vendor-tools", "xwayland-run", "blueprint-compiler",
+    "marshalparser", "xcb-proto", "lirc-devel", "glad2", "python3-glad2",
+])
+def test_python315_buildtools_are_pinned_to_f44(config, name):
+    """Rawhide is mid python-3.15 transition: these build tools require
+    python(abi) = 3.15, which no repo in the set provides. Their F44 builds
+    run on python 3.14 (which the base serves), so they are pinned via
+    includepkgs -- the same pattern as the python3-*/perl-*/mpich* pins.
+    Measured with the simulator: 630 -> 642 OK, 12 sources unblocked, no
+    regressions."""
+    patterns = section_field(config, "fedora-44-python", "includepkgs")
+    assert any(fnmatch.fnmatch(name, p) for p in patterns), (
+        f"{config}: {name!r} not pinned -- its Rawhide build needs "
+        f"python(abi) = 3.15 and blocks its consumers")
+
+
+@pytest.mark.parametrize("config", CONFIGS)
+@pytest.mark.parametrize("name", ["opencv-devel", "openexr", "fontforge", "gnuplot"])
+def test_dead_end_f44_pins_stay_out(config, name):
+    """Verified NOT to help before being left out: F44 opencv needs F44's
+    OpenEXR, which the base's newer openexr masks by name; F44 fontforge
+    needs the old libxml2.so.2 the base no longer ships; F44 gnuplot did
+    not unblock leptonica. Pinning them would mask working Rawhide copies
+    for nothing."""
+    patterns = section_field(config, "fedora-44-python", "includepkgs")
+    assert not any(fnmatch.fnmatch(name, p) for p in patterns), (
+        f"{config}: {name!r} pinned despite being a verified dead end")


### PR DESCRIPTION
> [!WARNING]
> **Staged — do not merge while a publisher leg is in flight.** Mock cfgs are baked into the mock-runner image; the image push moves the digest, and the digest is in the action key. Merging this re-keys the chain and orphans its banked partials (measured today: five partials rejected across five image pushes). Merge at the next leg boundary, after a publish lands. Kept as draft to make that hold mechanical.

Rawhide is mid python-3.15 transition: `asciidoc`, `go-vendor-tools`, `xwayland-run`, `blueprint-compiler`, `marshalparser`, `xcb-proto`, `lirc`, and `glad2` all require `python(abi) = 3.15` there, which no repo in the buildroot set provides — the base serves python 3.14. Their F44 builds run on 3.14, so they join the `includepkgs` pins in `[fedora-44-python]`, the same pattern that already carries `python3-*`, `perl-*`, and `mpich*`.

## Measured (simulator, current indexes)

| | OK | blocked |
|---|---|---|
| before | 630 | 43 |
| after | 642 | 31 |

Unblocked: gnome-remote-desktop, localsearch, pulseaudio, tesseract, jpegxl, blueman, libplacebo, xcb-util-errors, DankMaterialShell, cliphist, danksearch, dgop. Zero regressions (blocked-list diff is strictly one-directional).

## Verified dead ends, deliberately not pinned (guarded by test)

- **opencv/openexr**: F44 opencv needs F44's OpenEXR, which the base's newer openexr masks by name — `gstreamer1-plugins-bad-free` needs a spec-side fix (build without the opencv plugin) instead.
- **fontforge**: F44's needs `libxml2.so.2`; the base ships `.so.16`.
- **gnuplot**: measured, did not unblock leptonica.

Also fixes `section_field` in the guard suite to split `includepkgs` on commas — it only ever split on whitespace, so every prior includepkgs assertion matched the single joined string by accident of the pins being one token. 108 tests pass in the two touched suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sZp9iEZAJS44joA2Z8mCK

---
_Generated by [Claude Code](https://claude.ai/code/session_015sZp9iEZAJS44joA2Z8mCK)_