### PR TITLE
feat(chain): fan the build order out across free hosted runners

### DIFF
--- a/.github/scripts/fanout-publish-one.sh
+++ b/.github/scripts/fanout-publish-one.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Publish one fanout cell's wave: sync-down, sign+index, sync-up.
+# Copied from publish-build-chain-rpms.yml's publish job so the fanout
+# publisher carries the SAME #519 protections -- most importantly, a failed
+# sync-down must stop everything BEFORE the destructive sync-up.
+#
+# env: R2_BUCKET, R2_PATH, STAGED (dir holding this cell's wave), and
+# DRY_RUN=true to skip the sync-up.
+set -euo pipefail
+
+: "${R2_BUCKET:?}" "${R2_PATH:?}" "${STAGED:?}"
+
+repo="repo-${R2_PATH//\//-}"
+mkdir -p "$repo"
+
+# NOT `|| true`. The sync-up later makes the bucket MATCH the local tree, so
+# any object that failed to come down here would be DELETED there. That is
+# how repo/10/x86_64 lost ~160 served package names (#519), and the same
+# shape as #124 / INCIDENT-repo-wipe-gnome. rclone exit 3 is "directory not
+# found" -- the legitimate first-publish case; everything else stops us.
+set +e
+rclone sync "r2:${R2_BUCKET}/${R2_PATH}/" "$repo/" --exclude "repodata/**"
+_rc=$?
+set -e
+if (( _rc == 3 )); then
+    echo "::notice::no existing objects at ${R2_PATH} -- treating as first publish"
+elif (( _rc != 0 )); then
+    echo "::error::sync-down of ${R2_PATH} failed (rclone rc=${_rc}); refusing to continue -- the sync-up would DELETE every object that failed to come down"
+    exit 1
+fi
+echo "synced down $(find "$repo" -name '*.rpm' | wc -l) RPM(s) from ${R2_PATH}"
+
+bash scripts/publish-rpm-wave.sh --staged "$STAGED" --repo "$repo" --subdir build-chain
+
+if [[ "${DRY_RUN:-false}" == "true" ]]; then
+    echo "::notice::dry run -- signed and indexed ${R2_PATH} but synced nothing"
+    exit 0
+fi
+rclone sync "$repo/" "r2:${R2_BUCKET}/${R2_PATH}/"

--- a/.github/workflows/build-chain-fanout.yml
+++ b/.github/workflows/build-chain-fanout.yml
@@ -246,8 +246,8 @@ jobs:
   # shared concurrency group serialises this against every other publisher.
   # !cancelled(): red shards must not strand the built wave (#563).
   publish:
-    needs: [band4-x86, band4-arm]
-    if: ${{ !cancelled() && needs.plan.result != 'failure' }}
+    needs: [plan, band4-x86, band4-arm]
+    if: ${{ !cancelled() && needs.plan.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
     concurrency:

--- a/.github/workflows/build-chain-fanout.yml
+++ b/.github/workflows/build-chain-fanout.yml
@@ -1,0 +1,331 @@
+name: Build-chain fan-out
+
+# The single-runner chain builds ~19 packages/hour on a hosted runner and
+# ~65 on a 16-vCPU AWS box. This workflow gets the same order built on FREE
+# hosted runners by fanning each tier-band out across disjoint package
+# shards (packages within a tier are dependency-independent), collecting
+# each band through exactly one writer, and handing the final wave to the
+# same serial publish/verify dance the single-runner publisher uses --
+# including its shared concurrency group, so two publishers still cannot
+# touch the bucket at once (#124).
+#
+# Incrementality comes from the served index, not from action-key partials:
+# every shard skips any package whose NVR the published index already
+# serves (build-chain --served-nvrs), so a fanout run only spends runners
+# on the gap. Mock-config edits, image rebuilds and key moves no longer
+# reset the chain to tier 0 (#544's deeper half).
+#
+# A shard needing a same-band package owned by ANOTHER shard resolves it
+# from the served index when an earlier leg published it, and fails fast
+# when nothing serves it yet; that package heals on the next run, after the
+# collector merged its dependency. Fan-out is a gap-closer riding a
+# mostly-served index -- the first full bootstrap of a target belongs to
+# the single-runner chain.
+#
+# Scope: the hummingbird cells. Generalising means parameterising the cell
+# blocks below; chain-band.yml underneath is already family-agnostic.
+# GitHub Actions YAML has no anchors, hence the expanded per-band blocks.
+
+on:
+  workflow_dispatch:
+    inputs:
+      shards:
+        description: "Shards per band per arch (8 peaks at 16 concurrent jobs on a 60-job account)"
+        required: false
+        default: "8"
+      dry_run:
+        description: "Build and index but do not sync to R2"
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      bands: ${{ steps.bands.outputs.bands }}
+      epoch: ${{ steps.epoch.outputs.epoch }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Plan bands and shards
+        id: bands
+        env:
+          SHARDS: ${{ inputs.shards }}
+        run: |
+          set -euo pipefail
+          plan=$(python3 scripts/plan-chain-shards.py \
+            --order build-order-hummingbird-desktops.yml \
+            --bands 5 --shards "${SHARDS:-8}")
+          echo "bands=$plan" >> "$GITHUB_OUTPUT"
+      - name: Derive SOURCE_DATE_EPOCH
+        id: epoch
+        run: |
+          set -euo pipefail
+          # Same derivation as the single-runner publisher: the newest
+          # commit touching the cell's source paths. Both hummingbird cells
+          # declare the same paths, so one epoch serves both.
+          epoch=$(git log -1 --format=%at -- src/hummingbird/ src/xfce-wayland/ src/gnome-51/ src/deps/)
+          [ -n "$epoch" ] || { echo "::error::no epoch derivable"; exit 1; }
+          echo "epoch=$epoch" >> "$GITHUB_OUTPUT"
+
+  band0-x86:
+    needs: plan
+    uses: ./.github/workflows/chain-band.yml
+    with:
+      cell_id: hummingbird-x86_64
+      target: hummingbird
+      architecture: x86_64
+      runner: ubuntu-24.04
+      image: ghcr.io/tuna-os/mock-runner:centos-stream-10
+      manifest: build-order-hummingbird-desktops.yml
+      mock_config: hummingbird-ci
+      epoch: ${{ needs.plan.outputs.epoch }}
+      served_index_url: https://repo.tunaos.org/hummingbird/20251124-x86_64/
+      band_index: 0
+      band_tiers: ${{ fromJSON(needs.plan.outputs.bands).bands[0].tiers }}
+      shards_json: ${{ toJSON(fromJSON(needs.plan.outputs.bands).bands[0].shards) }}
+
+  band1-x86:
+    needs: [plan, band0-x86]
+    uses: ./.github/workflows/chain-band.yml
+    with:
+      cell_id: hummingbird-x86_64
+      target: hummingbird
+      architecture: x86_64
+      runner: ubuntu-24.04
+      image: ghcr.io/tuna-os/mock-runner:centos-stream-10
+      manifest: build-order-hummingbird-desktops.yml
+      mock_config: hummingbird-ci
+      epoch: ${{ needs.plan.outputs.epoch }}
+      served_index_url: https://repo.tunaos.org/hummingbird/20251124-x86_64/
+      band_index: 1
+      band_tiers: ${{ fromJSON(needs.plan.outputs.bands).bands[1].tiers }}
+      shards_json: ${{ toJSON(fromJSON(needs.plan.outputs.bands).bands[1].shards) }}
+
+  band2-x86:
+    needs: [plan, band1-x86]
+    uses: ./.github/workflows/chain-band.yml
+    with:
+      cell_id: hummingbird-x86_64
+      target: hummingbird
+      architecture: x86_64
+      runner: ubuntu-24.04
+      image: ghcr.io/tuna-os/mock-runner:centos-stream-10
+      manifest: build-order-hummingbird-desktops.yml
+      mock_config: hummingbird-ci
+      epoch: ${{ needs.plan.outputs.epoch }}
+      served_index_url: https://repo.tunaos.org/hummingbird/20251124-x86_64/
+      band_index: 2
+      band_tiers: ${{ fromJSON(needs.plan.outputs.bands).bands[2].tiers }}
+      shards_json: ${{ toJSON(fromJSON(needs.plan.outputs.bands).bands[2].shards) }}
+
+  band3-x86:
+    needs: [plan, band2-x86]
+    uses: ./.github/workflows/chain-band.yml
+    with:
+      cell_id: hummingbird-x86_64
+      target: hummingbird
+      architecture: x86_64
+      runner: ubuntu-24.04
+      image: ghcr.io/tuna-os/mock-runner:centos-stream-10
+      manifest: build-order-hummingbird-desktops.yml
+      mock_config: hummingbird-ci
+      epoch: ${{ needs.plan.outputs.epoch }}
+      served_index_url: https://repo.tunaos.org/hummingbird/20251124-x86_64/
+      band_index: 3
+      band_tiers: ${{ fromJSON(needs.plan.outputs.bands).bands[3].tiers }}
+      shards_json: ${{ toJSON(fromJSON(needs.plan.outputs.bands).bands[3].shards) }}
+
+  band4-x86:
+    needs: [plan, band3-x86]
+    uses: ./.github/workflows/chain-band.yml
+    with:
+      cell_id: hummingbird-x86_64
+      target: hummingbird
+      architecture: x86_64
+      runner: ubuntu-24.04
+      image: ghcr.io/tuna-os/mock-runner:centos-stream-10
+      manifest: build-order-hummingbird-desktops.yml
+      mock_config: hummingbird-ci
+      epoch: ${{ needs.plan.outputs.epoch }}
+      served_index_url: https://repo.tunaos.org/hummingbird/20251124-x86_64/
+      band_index: 4
+      band_tiers: ${{ fromJSON(needs.plan.outputs.bands).bands[4].tiers }}
+      shards_json: ${{ toJSON(fromJSON(needs.plan.outputs.bands).bands[4].shards) }}
+
+  band0-arm:
+    needs: plan
+    uses: ./.github/workflows/chain-band.yml
+    with:
+      cell_id: hummingbird-aarch64
+      target: hummingbird
+      architecture: aarch64
+      runner: ubuntu-24.04-arm
+      image: ghcr.io/tuna-os/mock-runner:centos-stream-10
+      manifest: build-order-hummingbird-desktops.yml
+      mock_config: hummingbird-ci-aarch64
+      epoch: ${{ needs.plan.outputs.epoch }}
+      served_index_url: https://repo.tunaos.org/hummingbird/20251124-aarch64/
+      band_index: 0
+      band_tiers: ${{ fromJSON(needs.plan.outputs.bands).bands[0].tiers }}
+      shards_json: ${{ toJSON(fromJSON(needs.plan.outputs.bands).bands[0].shards) }}
+
+  band1-arm:
+    needs: [plan, band0-arm]
+    uses: ./.github/workflows/chain-band.yml
+    with:
+      cell_id: hummingbird-aarch64
+      target: hummingbird
+      architecture: aarch64
+      runner: ubuntu-24.04-arm
+      image: ghcr.io/tuna-os/mock-runner:centos-stream-10
+      manifest: build-order-hummingbird-desktops.yml
+      mock_config: hummingbird-ci-aarch64
+      epoch: ${{ needs.plan.outputs.epoch }}
+      served_index_url: https://repo.tunaos.org/hummingbird/20251124-aarch64/
+      band_index: 1
+      band_tiers: ${{ fromJSON(needs.plan.outputs.bands).bands[1].tiers }}
+      shards_json: ${{ toJSON(fromJSON(needs.plan.outputs.bands).bands[1].shards) }}
+
+  band2-arm:
+    needs: [plan, band1-arm]
+    uses: ./.github/workflows/chain-band.yml
+    with:
+      cell_id: hummingbird-aarch64
+      target: hummingbird
+      architecture: aarch64
+      runner: ubuntu-24.04-arm
+      image: ghcr.io/tuna-os/mock-runner:centos-stream-10
+      manifest: build-order-hummingbird-desktops.yml
+      mock_config: hummingbird-ci-aarch64
+      epoch: ${{ needs.plan.outputs.epoch }}
+      served_index_url: https://repo.tunaos.org/hummingbird/20251124-aarch64/
+      band_index: 2
+      band_tiers: ${{ fromJSON(needs.plan.outputs.bands).bands[2].tiers }}
+      shards_json: ${{ toJSON(fromJSON(needs.plan.outputs.bands).bands[2].shards) }}
+
+  band3-arm:
+    needs: [plan, band2-arm]
+    uses: ./.github/workflows/chain-band.yml
+    with:
+      cell_id: hummingbird-aarch64
+      target: hummingbird
+      architecture: aarch64
+      runner: ubuntu-24.04-arm
+      image: ghcr.io/tuna-os/mock-runner:centos-stream-10
+      manifest: build-order-hummingbird-desktops.yml
+      mock_config: hummingbird-ci-aarch64
+      epoch: ${{ needs.plan.outputs.epoch }}
+      served_index_url: https://repo.tunaos.org/hummingbird/20251124-aarch64/
+      band_index: 3
+      band_tiers: ${{ fromJSON(needs.plan.outputs.bands).bands[3].tiers }}
+      shards_json: ${{ toJSON(fromJSON(needs.plan.outputs.bands).bands[3].shards) }}
+
+  band4-arm:
+    needs: [plan, band3-arm]
+    uses: ./.github/workflows/chain-band.yml
+    with:
+      cell_id: hummingbird-aarch64
+      target: hummingbird
+      architecture: aarch64
+      runner: ubuntu-24.04-arm
+      image: ghcr.io/tuna-os/mock-runner:centos-stream-10
+      manifest: build-order-hummingbird-desktops.yml
+      mock_config: hummingbird-ci-aarch64
+      epoch: ${{ needs.plan.outputs.epoch }}
+      served_index_url: https://repo.tunaos.org/hummingbird/20251124-aarch64/
+      band_index: 4
+      band_tiers: ${{ fromJSON(needs.plan.outputs.bands).bands[4].tiers }}
+      shards_json: ${{ toJSON(fromJSON(needs.plan.outputs.bands).bands[4].shards) }}
+
+  # One job, both cells, strictly sequential steps: the sync-down/sign/
+  # sync-up dance is copied from publish-build-chain-rpms.yml, and the
+  # shared concurrency group serialises this against every other publisher.
+  # !cancelled(): red shards must not strand the built wave (#563).
+  publish:
+    needs: [band4-x86, band4-arm]
+    if: ${{ !cancelled() && needs.plan.result != 'failure' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    concurrency:
+      group: publish-rpms
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install tooling
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q createrepo-c rpm gpg gpgconf
+          curl -fsSL https://rclone.org/install.sh | sudo bash
+      - name: Import GPG key
+        id: import-gpg
+        uses: crazy-max/ghaction-import-gpg@v7
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Configure rpmsign and rclone
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+        run: |
+          set -euo pipefail
+          echo "%_signature gpg" > ~/.rpmmacros
+          echo "%_gpg_name ${{ steps.import-gpg.outputs.keyid }}" >> ~/.rpmmacros
+          echo "%__gpg_sign_cmd %{__gpg} gpg --batch --no-verbose --no-armor --use-agent --no-secmem-warning -u \"%{_gpg_name}\" -sbo %{__signature_filename} %{__plaintext_filename}" >> ~/.rpmmacros
+          mkdir -p ~/.config/rclone
+          umask 077
+          cat > ~/.config/rclone/rclone.conf << EOF
+          [r2]
+          type = s3
+          provider = Cloudflare
+          access_key_id = ${R2_ACCESS_KEY_ID}
+          secret_access_key = ${R2_SECRET_ACCESS_KEY}
+          endpoint = ${R2_ENDPOINT}
+          EOF
+      - name: Fetch the x86_64 wave
+        uses: actions/download-artifact@v8
+        with:
+          name: fanout-repo-hummingbird-x86_64
+          path: staged-x86_64
+      - name: Fetch the aarch64 wave
+        uses: actions/download-artifact@v8
+        with:
+          name: fanout-repo-hummingbird-aarch64
+          path: staged-aarch64
+      - name: Publish hummingbird-x86_64
+        env:
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_PATH: hummingbird/20251124-x86_64
+          STAGED: staged-x86_64
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: bash .github/scripts/fanout-publish-one.sh
+      - name: Publish hummingbird-aarch64
+        env:
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_PATH: hummingbird/20251124-aarch64
+          STAGED: staged-aarch64
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: bash .github/scripts/fanout-publish-one.sh
+      - name: Report a dry run honestly
+        if: ${{ inputs.dry_run }}
+        run: echo "::notice::dry run -- built, signed and indexed both cells but synced nothing"
+
+  verify:
+    needs: publish
+    if: ${{ !cancelled() && needs.publish.result == 'success' && !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - name: The published indexes answer over HTTPS
+        run: |
+          set -euo pipefail
+          for url in \
+            "https://repo.tunaos.org/hummingbird/20251124-x86_64/" \
+            "https://repo.tunaos.org/hummingbird/20251124-aarch64/"; do
+            python3 scripts/verify-published-wave.py "$url"
+          done

--- a/.github/workflows/chain-band.yml
+++ b/.github/workflows/chain-band.yml
@@ -1,0 +1,175 @@
+name: Chain band (reusable)
+
+# One BAND of build-chain-fanout.yml: a contiguous run of build-order tiers,
+# split into disjoint package shards that build concurrently on free hosted
+# runners, then collected by exactly ONE writer into the cumulative band
+# repo. Packages within a tier are dependency-independent by construction,
+# which is what makes the shard split legal; dependencies on EARLIER bands
+# come from the cumulative artifact, and dependencies already published come
+# from the served index (both via the local-repo / priority mechanism the
+# single-runner chain already uses).
+#
+# A shard that needs a same-band package owned by another shard resolves it
+# from the SERVED index when an earlier leg published it, and fails fast when
+# nothing serves it yet -- that package heals on the next fanout run, after
+# the collector has merged its dependency. Fan-out is a gap-closer riding a
+# mostly-served index, not a from-scratch bootstrapper; the first full
+# bootstrap of a target belongs to the single-runner chain.
+
+on:
+  workflow_call:
+    inputs:
+      cell_id: {type: string, required: true}
+      target: {type: string, required: true}
+      architecture: {type: string, required: true}
+      runner: {type: string, required: true}
+      image: {type: string, required: true}
+      manifest: {type: string, required: true}
+      mock_config: {type: string, required: true}
+      epoch: {type: string, required: true}
+      band_index: {type: number, required: true}
+      band_tiers: {type: string, required: true}
+      # JSON array of arrays: shards_json[i] lists shard i's src/ paths.
+      shards_json: {type: string, required: true}
+      served_index_url: {type: string, required: true}
+
+permissions:
+  contents: read
+
+jobs:
+  shard:
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 350
+    strategy:
+      # One red shard must not cancel its siblings: every finished package
+      # still reaches the collector, and the next run heals the failure.
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(inputs.shards_json) }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install native build tools
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q createrepo-c podman rpm
+          # Same knob #564 documented: Ubuntu 24.04's default AppArmor
+          # confinement kills rootless podman's first clone(); hosted images
+          # ship it off, but a no-op re-set is cheaper than assuming.
+          sudo sysctl -e -w kernel.apparmor_restrict_unprivileged_userns=0
+      - name: Pull the declared build image
+        run: docker pull -q '${{ inputs.image }}'
+      - name: Restore the cumulative band repo
+        if: ${{ inputs.band_index != 0 }}
+        uses: actions/download-artifact@v8
+        with:
+          name: fanout-repo-${{ inputs.cell_id }}
+          path: .factory/${{ inputs.cell_id }}/artifacts
+      - name: Index what was restored
+        run: |
+          set -euo pipefail
+          mkdir -p '.factory/${{ inputs.cell_id }}/artifacts'
+          find '.factory/${{ inputs.cell_id }}/artifacts' -maxdepth 1 -name '*.rpm' \
+            -printf '%f\n' | sort > /tmp/rpms-before.txt
+          wc -l < /tmp/rpms-before.txt
+      - name: List what the published index already serves
+        run: |
+          set -euo pipefail
+          python3 scripts/list-served-nvrs.py '${{ inputs.served_index_url }}' \
+            > /tmp/served-nvrs.txt
+          echo "served NVRs: $(wc -l < /tmp/served-nvrs.txt)"
+      - name: Write this shard's package list
+        env:
+          SHARD_JSON: ${{ toJSON(matrix.shard) }}
+        run: |
+          set -euo pipefail
+          python3 -c 'import json,os; print("\n".join(json.loads(os.environ["SHARD_JSON"])))' \
+            > /tmp/shard-packages.txt
+          cat /tmp/shard-packages.txt
+      - name: Build the shard
+        env:
+          CELL_ID: ${{ inputs.cell_id }}
+          ENGINE: build-chain
+          TARGET: ${{ inputs.target }}
+          ARCHITECTURE: ${{ inputs.architecture }}
+          IMAGE: ${{ inputs.image }}
+          MANIFEST: ${{ inputs.manifest }}
+          MOCK_CONFIG: ${{ inputs.mock_config }}
+          SOURCE_DATE_EPOCH: ${{ inputs.epoch }}
+          TIERS: ${{ inputs.band_tiers }}
+          CHAIN_PACKAGES_FILE: /tmp/shard-packages.txt
+          CHAIN_SERVED_NVRS: /tmp/served-nvrs.txt
+          # A shard holds a fraction of a band; 4.5h of budget inside the
+          # 350-minute ceiling is generous, and the drain semantics match
+          # the single-runner chain.
+          CHAIN_BUDGET_SECONDS: 16200
+        run: bash scripts/run-package-factory-cell.sh
+      - name: Stage only what this shard built
+        if: always()
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/shard-new
+          find '.factory/${{ inputs.cell_id }}/artifacts' -maxdepth 1 -name '*.rpm' \
+            -printf '%f\n' | sort > /tmp/rpms-after.txt
+          comm -13 /tmp/rpms-before.txt /tmp/rpms-after.txt | while IFS= read -r f; do
+            cp ".factory/${{ inputs.cell_id }}/artifacts/$f" /tmp/shard-new/
+          done
+          # Failure logs and buildroot manifests ride along for diagnosis.
+          for extra in failure-logs buildroots; do
+            if [ -d ".factory/${{ inputs.cell_id }}/artifacts/$extra" ]; then
+              cp -r ".factory/${{ inputs.cell_id }}/artifacts/$extra" /tmp/shard-new/
+            fi
+          done
+          echo "new RPMs: $(find /tmp/shard-new -maxdepth 1 -name '*.rpm' | wc -l)"
+      # always(): a shard that failed one package still built others, and
+      # publishing the built ones is the whole point (#563's lesson, applied
+      # at shard granularity). warn: a shard whose every package was already
+      # served has nothing new, and that is success, not error.
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: fanout-new-${{ inputs.cell_id }}-b${{ inputs.band_index }}-s${{ strategy.job-index }}
+          path: /tmp/shard-new/
+          if-no-files-found: warn
+
+  collect:
+    needs: shard
+    # !cancelled(): red shards still produced artifacts worth merging; a
+    # cancelled run must not write the cumulative artifact at all.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Restore the cumulative band repo
+        if: ${{ inputs.band_index != 0 }}
+        uses: actions/download-artifact@v8
+        with:
+          name: fanout-repo-${{ inputs.cell_id }}
+          path: repo
+      - name: Merge every shard's new packages
+        uses: actions/download-artifact@v8
+        with:
+          pattern: fanout-new-${{ inputs.cell_id }}-b${{ inputs.band_index }}-s*
+          path: shards
+          merge-multiple: true
+      - name: Index the merged repo
+        run: |
+          set -euo pipefail
+          sudo apt-get update -q && sudo apt-get install -y -q createrepo-c
+          mkdir -p repo
+          # Shards are disjoint by construction, so -n never actually
+          # collides; it is a guard, not a policy.
+          find shards -maxdepth 1 -name '*.rpm' -exec cp -n {} repo/ \; 2>/dev/null || true
+          for extra in failure-logs buildroots; do
+            if [ -d "shards/$extra" ]; then
+              mkdir -p "repo/$extra"
+              cp -rn "shards/$extra/." "repo/$extra/" || true
+            fi
+          done
+          createrepo_c repo/
+          echo "cumulative RPMs after band ${{ inputs.band_index }}: $(find repo -maxdepth 1 -name '*.rpm' | wc -l)"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: fanout-repo-${{ inputs.cell_id }}
+          path: repo/
+          overwrite: true
+          if-no-files-found: warn

--- a/scripts/build-chain.sh
+++ b/scripts/build-chain.sh
@@ -154,6 +154,24 @@ JOBS=$(( $(nproc) / 2 ))
 FILTER_TIER=""
 FILTER_PACKAGE=""
 FILTER_TIERS=""
+# --packages-file: build ONLY the paths listed (one src/... path per line,
+# blank lines and #-comments ignored). The shard runner in
+# build-chain-fanout.yml is the intended caller: packages within a tier are
+# dependency-independent, so disjoint shards of one tier can build on
+# separate runners against the same inputs. Unset = no behavior change.
+FILTER_PACKAGES_FILE=""
+declare -A FILTER_PACKAGES_SET=()
+# --served-nvrs: NVRs the published index already serves (one per line).
+# check_package_exists skips a package whose computed NVR is listed, exactly
+# as it skips one whose RPM sits in the local repo. Without this, "already
+# built" was ONLY the local repo -- seeded from action-key-matched partials
+# -- so any key move (a mock cfg edit rebuilds the image, the image digest
+# is a key input) sent the next leg back to tier 0 to rebuild packages the
+# repo has SERVED for days. Legs 32914264044/32991216265/33022688689 each
+# rebuilt the same ~85 packages for exactly this reason (#544). The served
+# index is the durable record of what exists; keys only guard partials.
+SERVED_NVRS_FILE=""
+declare -A SERVED_NVRS_SET=()
 DRY_RUN=false
 FORCE=false
 WITH_CHECKS=false
@@ -223,6 +241,8 @@ while [[ $# -gt 0 ]]; do
         --tier)        FILTER_TIER="$2"; shift 2 ;;
         --tiers)       FILTER_TIERS="$2"; shift 2 ;;
         --package)     FILTER_PACKAGE="$2"; shift 2 ;;
+        --packages-file) FILTER_PACKAGES_FILE="$2"; shift 2 ;;
+        --served-nvrs)   SERVED_NVRS_FILE="$2"; shift 2 ;;
         --with-checks)  WITH_CHECKS=true; shift ;;
         --dry-run)     DRY_RUN=true;     shift ;;
         --force)       FORCE=true;       shift ;;
@@ -233,6 +253,44 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+if [[ -n "$FILTER_PACKAGES_FILE" ]]; then
+    if [[ ! -f "$FILTER_PACKAGES_FILE" ]]; then
+        echo "ERROR: --packages-file '$FILTER_PACKAGES_FILE' does not exist" >&2
+        exit 1
+    fi
+    while IFS= read -r _line; do
+        _line="${_line%%#*}"
+        _line="${_line//[$'\t\r ']/}"
+        [[ -n "$_line" ]] && FILTER_PACKAGES_SET["$_line"]=1
+    done < "$FILTER_PACKAGES_FILE"
+    if [[ ${#FILTER_PACKAGES_SET[@]} -eq 0 ]]; then
+        echo "ERROR: --packages-file '$FILTER_PACKAGES_FILE' lists no packages" >&2
+        exit 1
+    fi
+fi
+
+if [[ -n "$SERVED_NVRS_FILE" ]]; then
+    if [[ ! -f "$SERVED_NVRS_FILE" ]]; then
+        echo "ERROR: --served-nvrs '$SERVED_NVRS_FILE' does not exist" >&2
+        exit 1
+    fi
+    while IFS= read -r _line; do
+        _line="${_line%%#*}"
+        _line="${_line//[$'\t\r ']/}"
+        [[ -n "$_line" ]] && SERVED_NVRS_SET["$_line"]=1
+    done < "$SERVED_NVRS_FILE"
+    # An empty list is legal: a first publish has nothing served yet.
+fi
+
+# True when filters say this package is NOT ours to build. Deferral/skip
+# accounting deliberately does not count these: another shard owns them.
+_package_filtered_out() {
+    local pkg_path="$1"
+    [[ -n "$FILTER_PACKAGE" && "$pkg_path" != "$FILTER_PACKAGE" ]] && return 0
+    [[ ${#FILTER_PACKAGES_SET[@]} -gt 0 && -z "${FILTER_PACKAGES_SET[$pkg_path]:-}" ]] && return 0
+    return 1
+}
 
 # Without --with-checks the build already passes --nocheck, so %check never
 # runs -- but its BuildRequires: are still installed, and they are not free.
@@ -687,6 +745,15 @@ check_package_exists() {
     # We check for $nvr.rpm or $nvr.*.rpm
     if ls "${LOCAL_REPO}/${nvr}"*.rpm &>/dev/null; then
         echo "==> [${pkg_name}] Skipping: ${nvr} already exists in local repo"
+        return 0
+    fi
+
+    # The published index is the durable record: a served NVR was built,
+    # signed and synced by an earlier leg, and consumers resolve it from the
+    # repo at priority 11 -- rebuilding it buys nothing. This is what makes
+    # legs incremental ACROSS action-key moves, which partials cannot be.
+    if [[ -n "${SERVED_NVRS_SET[$nvr]:-}" ]]; then
+        echo "==> [${pkg_name}] Skipping: ${nvr} already served by the published index"
         return 0
     fi
 
@@ -1327,7 +1394,7 @@ build_tier() {
     }
 
     while IFS=$'\t' read -r pkg_path spec_override; do
-        if [[ -n "$FILTER_PACKAGE" && "$pkg_path" != "$FILTER_PACKAGE" ]]; then
+        if _package_filtered_out "$pkg_path"; then
             continue
         fi
 
@@ -1473,7 +1540,7 @@ build_stream() {
     }
 
     while IFS=$'\t' read -r pkg_path spec_override; do
-        if [[ -n "$FILTER_PACKAGE" && "$pkg_path" != "$FILTER_PACKAGE" ]]; then
+        if _package_filtered_out "$pkg_path"; then
             continue
         fi
 

--- a/scripts/list-served-nvrs.py
+++ b/scripts/list-served-nvrs.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Print NAME-VERSION-RELEASE for every package a published rpm-md index serves.
+
+    list-served-nvrs.py https://repo.tunaos.org/hummingbird/20251124-x86_64/
+
+Output feeds `build-chain.sh --served-nvrs`: one NVR per line, deduplicated.
+Epoch is deliberately dropped -- the skip compares against `rpmspec
+--queryformat %{NAME}-%{VERSION}-%{RELEASE}`, which has no epoch either.
+
+An unreachable or empty index prints nothing and exits 0: a first publish
+legitimately has nothing served, and the caller must build, not crash.
+"""
+
+from __future__ import annotations
+
+import gzip
+import re
+import subprocess
+import sys
+
+
+def fetch(url: str) -> bytes:
+    # curl, not urllib: the CI egress proxy 403s urllib's requests.
+    run = subprocess.run(["curl", "-sfL", "--max-time", "120", url],
+                         capture_output=True)
+    if run.returncode != 0:
+        return b""
+    return run.stdout
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit(__doc__)
+    base = sys.argv[1].rstrip("/")
+    repomd = fetch(f"{base}/repodata/repomd.xml").decode(errors="replace")
+    m = re.search(r'href="(repodata/[^"]*primary\.xml[^"]*)"', repomd)
+    if not m:
+        return
+    raw = fetch(f"{base}/{m.group(1)}")
+    if not raw:
+        return
+    if m.group(1).endswith(".gz"):
+        raw = gzip.decompress(raw)
+    data = raw.decode(errors="replace")
+    seen = set()
+    for pkg in re.finditer(
+        r'<name>([^<]+)</name>.*?ver="([^"]+)" rel="([^"]+)"', data, re.S
+    ):
+        nvr = f"{pkg.group(1)}-{pkg.group(2)}-{pkg.group(3)}"
+        if nvr not in seen:
+            seen.add(nvr)
+            print(nvr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/plan-chain-shards.py
+++ b/scripts/plan-chain-shards.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Split a build order into tier-bands and per-band shards for fan-out.
+
+The invariant this rides: a build order's tiers are dependency layers, so
+packages WITHIN one tier never depend on each other. Disjoint subsets of a
+band's packages can therefore build on separate runners against the same
+inputs (the served index plus every earlier band's collected output), and a
+single collector merges the results between bands. Nothing here changes what
+gets built -- only where.
+
+Output (JSON on stdout):
+
+    {
+      "bands": [
+        {"index": 0,
+         "tiers": "bootstrap-00,bootstrap-01",
+         "shards": [["src/a", "src/b"], ["src/c"]]},
+        ...
+      ]
+    }
+
+Band boundaries respect tier order: a band is a contiguous run of tiers, cut
+so package counts stay roughly even. Shards are dealt round-robin in tier
+order, which keeps each shard's work spread across the band's tiers rather
+than concentrating one slow tier in one shard.
+
+Shard lists are consumed by `build-chain.sh --packages-file`; the tiers
+string by `--tiers`. Empty shards are dropped so the workflow matrix never
+schedules a runner with nothing to do.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def read_tiers(order: str) -> list[tuple[str, list[str]]]:
+    """[(tier_name, [pkg_path, ...]), ...] in build order."""
+    parse = SCRIPT_DIR / "parse-build-order.py"
+    names = subprocess.run(
+        [sys.executable, str(parse), order, "--tiers"],
+        capture_output=True, text=True, check=True,
+    ).stdout.split()
+    tiers = []
+    for name in names:
+        out = subprocess.run(
+            [sys.executable, str(parse), order, "--tier", name],
+            capture_output=True, text=True, check=True,
+        ).stdout
+        pkgs = [line.split("\t")[0] for line in out.splitlines() if line.strip()]
+        tiers.append((name, pkgs))
+    return tiers
+
+
+def cut_bands(tiers: list[tuple[str, list[str]]], band_count: int) -> list[list[tuple[str, list[str]]]]:
+    """Contiguous tier runs with roughly even package counts.
+
+    Greedy: close the current band once it holds its fair share of the
+    REMAINING packages over the REMAINING bands, but never leave more bands
+    than tiers left to fill them.
+    """
+    total = sum(len(p) for _, p in tiers)
+    bands: list[list[tuple[str, list[str]]]] = []
+    current: list[tuple[str, list[str]]] = []
+    placed = 0
+    current_count = 0
+    for i, (name, pkgs) in enumerate(tiers):
+        current.append((name, pkgs))
+        current_count += len(pkgs)
+        placed += len(pkgs)
+        bands_left = band_count - len(bands)
+        tiers_left = len(tiers) - i - 1
+        fair = (total - placed + current_count) / max(bands_left, 1)
+        if bands_left > 1 and current_count >= fair and tiers_left >= bands_left - 1:
+            bands.append(current)
+            current = []
+            current_count = 0
+    if current:
+        bands.append(current)
+    return bands
+
+
+def deal_shards(pkgs: list[str], shard_count: int) -> list[list[str]]:
+    shards: list[list[str]] = [[] for _ in range(shard_count)]
+    for i, p in enumerate(pkgs):
+        shards[i % shard_count].append(p)
+    return [s for s in shards if s]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--order", required=True)
+    ap.add_argument("--bands", type=int, default=5)
+    ap.add_argument("--shards", type=int, default=8)
+    args = ap.parse_args()
+    if args.bands < 1 or args.shards < 1:
+        raise SystemExit("--bands and --shards must be >= 1")
+
+    tiers = read_tiers(args.order)
+    if not tiers:
+        raise SystemExit(f"{args.order}: no tiers")
+
+    bands = []
+    for idx, band in enumerate(cut_bands(tiers, args.bands)):
+        pkgs = [p for _, tier_pkgs in band for p in tier_pkgs]
+        bands.append({
+            "index": idx,
+            "tiers": ",".join(name for name, _ in band),
+            "shards": deal_shards(pkgs, args.shards),
+        })
+    json.dump({"bands": bands}, sys.stdout)
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run-package-factory-cell.sh
+++ b/scripts/run-package-factory-cell.sh
@@ -44,6 +44,16 @@ if [[ $engine == build-chain ]]; then
     if [[ -n ${TIERS:-} ]]; then
       args+=(--stream --tiers "$TIERS")
     fi
+    # Fan-out shards (build-chain-fanout.yml): each shard builds a disjoint
+    # slice of the band's packages, and the served-NVR list keeps every
+    # runner from rebuilding what an earlier leg already published. Both
+    # unset = the single-runner behavior above, unchanged.
+    if [[ -n ${CHAIN_PACKAGES_FILE:-} ]]; then
+      args+=(--packages-file "$CHAIN_PACKAGES_FILE")
+    fi
+    if [[ -n ${CHAIN_SERVED_NVRS:-} ]]; then
+      args+=(--served-nvrs "$CHAIN_SERVED_NVRS")
+    fi
     # Soft deadline inside the job's hard ceiling (#480, and the 08-19..08-24
     # nightlies dying at 5h59m with everything after the build skipped). The
     # chain finishes its in-flight packages, drains and exits 0, so the

--- a/tests/test_chain_fanout.py
+++ b/tests/test_chain_fanout.py
@@ -1,0 +1,181 @@
+"""The fan-out must build everything exactly once, and publish like one.
+
+Three layers, three failure modes:
+
+  * the PLANNER must cover the whole order with disjoint shards -- a package
+    dealt twice builds twice (wasted runner), a package dealt never silently
+    falls out of the repo;
+  * the CHAIN must treat filters and served-NVRs as opt-in -- the
+    single-runner publisher passes neither and must behave exactly as before;
+  * the WORKFLOWS must keep the one-publisher invariant -- the fanout's
+    publish job rides the same `publish-rpms` concurrency group as every
+    other publisher, and only ONE collector writes each band's cumulative
+    artifact.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parent.parent
+ORDER = ROOT / "build-order-hummingbird-desktops.yml"
+FANOUT = ROOT / ".github" / "workflows" / "build-chain-fanout.yml"
+BAND = ROOT / ".github" / "workflows" / "chain-band.yml"
+CHAIN = ROOT / "scripts" / "build-chain.sh"
+
+
+@pytest.fixture(scope="module")
+def plan():
+    out = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "plan-chain-shards.py"),
+         "--order", str(ORDER), "--bands", "5", "--shards", "8"],
+        capture_output=True, text=True, check=True, cwd=ROOT,
+    ).stdout
+    return json.loads(out)
+
+
+@pytest.fixture(scope="module")
+def order_packages():
+    out = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "parse-build-order.py"),
+         str(ORDER), "--all"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    return [line.split("\t")[0] for line in out.splitlines() if line.strip()]
+
+
+def test_every_package_dealt_exactly_once(plan, order_packages):
+    dealt = [p for b in plan["bands"] for s in b["shards"] for p in s]
+    assert sorted(dealt) == sorted(order_packages), (
+        "a package dealt twice builds twice; one dealt never silently "
+        "falls out of the repo"
+    )
+
+
+def test_bands_are_contiguous_tier_runs(plan):
+    tiers = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "parse-build-order.py"),
+         str(ORDER), "--tiers"],
+        capture_output=True, text=True, check=True,
+    ).stdout.split()
+    flattened = [t for b in plan["bands"] for t in b["tiers"].split(",")]
+    assert flattened == tiers, "band boundaries must respect tier order"
+
+
+def test_shards_are_balanced(plan):
+    for b in plan["bands"]:
+        sizes = [len(s) for s in b["shards"]]
+        assert max(sizes) - min(sizes) <= 1, (
+            f"band {b['index']}: one hot shard sets the band's wall-clock"
+        )
+
+
+def test_no_empty_shards(plan):
+    for b in plan["bands"]:
+        assert all(b["shards"]), "an empty shard schedules a runner for nothing"
+
+
+# --- build-chain flags stay opt-in ------------------------------------------
+
+def test_chain_filters_are_opt_in():
+    text = CHAIN.read_text(encoding="utf-8")
+    assert '--packages-file) FILTER_PACKAGES_FILE="$2"' in text
+    assert '--served-nvrs)   SERVED_NVRS_FILE="$2"' in text
+    assert 'FILTER_PACKAGES_FILE=""' in text and 'SERVED_NVRS_FILE=""' in text, (
+        "unset defaults are the single-runner publisher's unchanged behavior"
+    )
+
+
+def test_chain_uses_the_shared_filter_helper_in_both_loops():
+    text = CHAIN.read_text(encoding="utf-8")
+    assert text.count('if _package_filtered_out "$pkg_path"; then') == 2, (
+        "tier loop and stream loop must apply the same filter"
+    )
+
+
+def test_served_skip_reads_like_the_local_skip():
+    text = CHAIN.read_text(encoding="utf-8")
+    assert "already served by the published index" in text
+
+
+def test_cell_runner_forwards_the_fanout_env():
+    text = (ROOT / "scripts" / "run-package-factory-cell.sh").read_text(encoding="utf-8")
+    assert "CHAIN_PACKAGES_FILE" in text and "CHAIN_SERVED_NVRS" in text
+
+
+# --- workflow shape ----------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def fanout():
+    return yaml.safe_load(FANOUT.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def band():
+    return yaml.safe_load(BAND.read_text(encoding="utf-8"))
+
+
+def test_publish_shares_the_one_publisher_group(fanout):
+    conc = fanout["jobs"]["publish"]["concurrency"]
+    assert conc["group"] == "publish-rpms"
+    assert conc["cancel-in-progress"] is False, (
+        "cancelling a RUNNING publisher mid-sync is how repos get wiped (#124)"
+    )
+
+
+def test_publish_runs_on_red_shards_but_not_cancelled_runs(fanout):
+    cond = str(fanout["jobs"]["publish"].get("if", ""))
+    assert "!cancelled()" in cond and "always()" not in cond
+
+
+def test_bands_chain_in_order(fanout):
+    for arch in ("x86", "arm"):
+        for i in range(1, 5):
+            needs = fanout["jobs"][f"band{i}-{arch}"]["needs"]
+            assert f"band{i - 1}-{arch}" in needs, (
+                "a band consumes its predecessor's collected output"
+            )
+
+
+def test_exactly_one_collector_writes_the_cumulative_artifact(band):
+    writers = [
+        name for name, job in band["jobs"].items()
+        for step in job.get("steps", [])
+        if "upload-artifact" in str(step.get("uses", ""))
+        and "fanout-repo-" in str(step.get("with", {}).get("name", ""))
+    ]
+    assert writers == ["collect"], (
+        f"cumulative artifact writers: {writers} -- two writers is the "
+        "two-publishers-one-bucket shape at band scale"
+    )
+
+
+def test_shards_upload_even_when_red(band):
+    uploads = [
+        step for step in band["jobs"]["shard"]["steps"]
+        if "upload-artifact" in str(step.get("uses", ""))
+    ]
+    assert len(uploads) == 1
+    assert "always()" in str(uploads[0].get("if", "")), "#563 at shard scale"
+    assert uploads[0]["with"]["if-no-files-found"] == "warn", (
+        "an all-served shard has nothing new, and that is success"
+    )
+
+
+def test_shards_do_not_cancel_their_siblings(band):
+    assert band["jobs"]["shard"]["strategy"]["fail-fast"] is False
+
+
+def test_fanout_stays_on_free_hosted_runners(fanout):
+    text = FANOUT.read_text(encoding="utf-8")
+    assert "runs-on=" not in text, (
+        "the fan-out exists to use FREE hosted concurrency; the AWS pool "
+        "is the one-time bringup tool"
+    )


### PR DESCRIPTION
Authorized by James: 60 concurrent hosted jobs are available and free — use them. The single-runner chain measures ~19 pkg/h hosted, ~65 on the one-time 16-vCPU AWS bringup. This gets comparable-or-better throughput on $0.

## Shape

- **`scripts/plan-chain-shards.py`** cuts the build order into 5 contiguous tier-bands of roughly even package count and deals each band round-robin into disjoint shards. Legality comes from the data model: tiers are dependency layers, so packages within a tier never depend on each other. Measured on the real order: bands of 200/125/124/136/88 packages, shards balanced within ±1, all 673 dealt exactly once (tested).
- **`chain-band.yml`** (reusable): shard matrix builds concurrently (`fail-fast: false`, uploads `always()` — #563 at shard scale), then exactly **one collector** merges the band's new RPMs into the cumulative repo the next band consumes (tested: one writer).
- **`build-chain-fanout.yml`**: 5 bands × 2 arches chained via `needs` (peak 16 concurrent jobs), then a single serial publish job under the **same `publish-rpms` concurrency group** with the same #519 sync-down guard (extracted to `.github/scripts/fanout-publish-one.sh`) and the existing verify script.

## The piece that matters beyond fan-out

`build-chain.sh --served-nvrs`: `check_package_exists` now also skips any package whose NVR the **published index** already serves. Until now "already built" meant only the local repo — seeded from action-key-matched partials — so any key move (a mock cfg edit rebuilds the image; the image digest is a key input) sent the next leg back to tier 0. That is the deeper half of #544, and it's why legs kept rebuilding the same ~85 packages. The served index is the durable record; keys only guard partials. **This benefits the single-runner publisher too** the moment its workflow passes a served-NVR list (follow-up).

Cross-shard, same-band dependencies resolve from the served index when published and fail fast when not, healing on the next run — the fan-out is a gap-closer riding a mostly-served index (580/673 today), not a from-scratch bootstrapper.

## Opt-in, byte-identical otherwise

`--packages-file`, `--served-nvrs`, and the two cell-runner envs are strictly opt-in; unset reproduces single-runner behavior exactly. Merging this re-keys cells (build-chain.sh is a key input) — deliberately timed to the same boundary as #567, and with served-NVR skipping the re-key no longer costs a tier-0 restart.

15 new tests in `tests/test_chain_fanout.py`; 399 related tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sZp9iEZAJS44joA2Z8mCK

---
_Generated by [Claude Code](https://claude.ai/code/session_015sZp9iEZAJS44joA2Z8mCK)_