### PR TITLE
fix(fanout): arm shards need the aarch64 image; bands must outlive red shards

### DIFF
--- a/.github/workflows/build-chain-fanout.yml
+++ b/.github/workflows/build-chain-fanout.yml
@@ -90,6 +90,10 @@ jobs:
 
   band1-x86:
     needs: [plan, band0-x86]
+    # A band with a red shard still collected everything its other shards
+    # built; the next band must consume that and keep going. Only a
+    # cancelled run stops the chain.
+    if: ${{ !cancelled() && needs.plan.result == 'success' }}
     uses: ./.github/workflows/chain-band.yml
     with:
       cell_id: hummingbird-x86_64
@@ -107,6 +111,10 @@ jobs:
 
   band2-x86:
     needs: [plan, band1-x86]
+    # A band with a red shard still collected everything its other shards
+    # built; the next band must consume that and keep going. Only a
+    # cancelled run stops the chain.
+    if: ${{ !cancelled() && needs.plan.result == 'success' }}
     uses: ./.github/workflows/chain-band.yml
     with:
       cell_id: hummingbird-x86_64
@@ -124,6 +132,10 @@ jobs:
 
   band3-x86:
     needs: [plan, band2-x86]
+    # A band with a red shard still collected everything its other shards
+    # built; the next band must consume that and keep going. Only a
+    # cancelled run stops the chain.
+    if: ${{ !cancelled() && needs.plan.result == 'success' }}
     uses: ./.github/workflows/chain-band.yml
     with:
       cell_id: hummingbird-x86_64
@@ -141,6 +153,10 @@ jobs:
 
   band4-x86:
     needs: [plan, band3-x86]
+    # A band with a red shard still collected everything its other shards
+    # built; the next band must consume that and keep going. Only a
+    # cancelled run stops the chain.
+    if: ${{ !cancelled() && needs.plan.result == 'success' }}
     uses: ./.github/workflows/chain-band.yml
     with:
       cell_id: hummingbird-x86_64
@@ -164,7 +180,7 @@ jobs:
       target: hummingbird
       architecture: aarch64
       runner: ubuntu-24.04-arm
-      image: ghcr.io/tuna-os/mock-runner:centos-stream-10
+      image: ghcr.io/tuna-os/mock-runner:centos-stream-10-aarch64
       manifest: build-order-hummingbird-desktops.yml
       mock_config: hummingbird-ci-aarch64
       epoch: ${{ needs.plan.outputs.epoch }}
@@ -175,13 +191,17 @@ jobs:
 
   band1-arm:
     needs: [plan, band0-arm]
+    # A band with a red shard still collected everything its other shards
+    # built; the next band must consume that and keep going. Only a
+    # cancelled run stops the chain.
+    if: ${{ !cancelled() && needs.plan.result == 'success' }}
     uses: ./.github/workflows/chain-band.yml
     with:
       cell_id: hummingbird-aarch64
       target: hummingbird
       architecture: aarch64
       runner: ubuntu-24.04-arm
-      image: ghcr.io/tuna-os/mock-runner:centos-stream-10
+      image: ghcr.io/tuna-os/mock-runner:centos-stream-10-aarch64
       manifest: build-order-hummingbird-desktops.yml
       mock_config: hummingbird-ci-aarch64
       epoch: ${{ needs.plan.outputs.epoch }}
@@ -192,13 +212,17 @@ jobs:
 
   band2-arm:
     needs: [plan, band1-arm]
+    # A band with a red shard still collected everything its other shards
+    # built; the next band must consume that and keep going. Only a
+    # cancelled run stops the chain.
+    if: ${{ !cancelled() && needs.plan.result == 'success' }}
     uses: ./.github/workflows/chain-band.yml
     with:
       cell_id: hummingbird-aarch64
       target: hummingbird
       architecture: aarch64
       runner: ubuntu-24.04-arm
-      image: ghcr.io/tuna-os/mock-runner:centos-stream-10
+      image: ghcr.io/tuna-os/mock-runner:centos-stream-10-aarch64
       manifest: build-order-hummingbird-desktops.yml
       mock_config: hummingbird-ci-aarch64
       epoch: ${{ needs.plan.outputs.epoch }}
@@ -209,13 +233,17 @@ jobs:
 
   band3-arm:
     needs: [plan, band2-arm]
+    # A band with a red shard still collected everything its other shards
+    # built; the next band must consume that and keep going. Only a
+    # cancelled run stops the chain.
+    if: ${{ !cancelled() && needs.plan.result == 'success' }}
     uses: ./.github/workflows/chain-band.yml
     with:
       cell_id: hummingbird-aarch64
       target: hummingbird
       architecture: aarch64
       runner: ubuntu-24.04-arm
-      image: ghcr.io/tuna-os/mock-runner:centos-stream-10
+      image: ghcr.io/tuna-os/mock-runner:centos-stream-10-aarch64
       manifest: build-order-hummingbird-desktops.yml
       mock_config: hummingbird-ci-aarch64
       epoch: ${{ needs.plan.outputs.epoch }}
@@ -226,13 +254,17 @@ jobs:
 
   band4-arm:
     needs: [plan, band3-arm]
+    # A band with a red shard still collected everything its other shards
+    # built; the next band must consume that and keep going. Only a
+    # cancelled run stops the chain.
+    if: ${{ !cancelled() && needs.plan.result == 'success' }}
     uses: ./.github/workflows/chain-band.yml
     with:
       cell_id: hummingbird-aarch64
       target: hummingbird
       architecture: aarch64
       runner: ubuntu-24.04-arm
-      image: ghcr.io/tuna-os/mock-runner:centos-stream-10
+      image: ghcr.io/tuna-os/mock-runner:centos-stream-10-aarch64
       manifest: build-order-hummingbird-desktops.yml
       mock_config: hummingbird-ci-aarch64
       epoch: ${{ needs.plan.outputs.epoch }}

--- a/tests/test_chain_fanout.py
+++ b/tests/test_chain_fanout.py
@@ -179,3 +179,23 @@ def test_fanout_stays_on_free_hosted_runners(fanout):
         "the fan-out exists to use FREE hosted concurrency; the AWS pool "
         "is the one-time bringup tool"
     )
+
+
+def test_arm_bands_use_the_aarch64_image(fanout):
+    for i in range(5):
+        img = fanout["jobs"][f"band{i}-arm"]["with"]["image"]
+        assert img.endswith("-aarch64"), (
+            f"band{i}-arm: an amd64 image on an arm runner dies with "
+            "'Exec format error' at the first rpmspec (maiden run, all 8 "
+            "arm shards)"
+        )
+
+
+def test_bands_continue_past_red_shards(fanout):
+    for arch in ("x86", "arm"):
+        for i in range(1, 5):
+            cond = str(fanout["jobs"][f"band{i}-{arch}"].get("if", ""))
+            assert "!cancelled()" in cond, (
+                f"band{i}-{arch}: default gating skips the rest of the chain "
+                "after one red shard, stranding the collected band"
+            )


### PR DESCRIPTION
Maiden fanout run [33120288603](https://github.com/tuna-os/tunaos-packages/actions/runs/33120288603), two findings, both fixed with guard tests:

1. **All 8 arm shards died at their first `rpmspec` with `Exec format error`**: the workflow hardcoded `mock-runner:centos-stream-10` for both arches, but that tag is amd64-only — the planner gives aarch64 cells `mock-runner:centos-stream-10-aarch64`. The five `band*-arm` blocks now use it.

2. **band1–4 skipped after band0 reported failure**: a band with any red shard concludes failure even though its collector merged everything the other shards built, and the next band's default success gating then strands that work. Bands now run under `!cancelled()` — the posture collect and publish already had.

The x86 side proved the design in the same run: 6/8 shards green, served-NVR skipping live (1358 NVRs listed on arm, ~8400 on x86), one collector merged band0 cleanly, and the publish job queued correctly behind the single-runner publisher on the shared group.

17 fanout tests pass (2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sZp9iEZAJS44joA2Z8mCK

---
_Generated by [Claude Code](https://claude.ai/code/session_015sZp9iEZAJS44joA2Z8mCK)_