### PR TITLE
fix(publish): the single-runner leg must skip what the index already serves

### DIFF
--- a/.github/workflows/publish-build-chain-rpms.yml
+++ b/.github/workflows/publish-build-chain-rpms.yml
@@ -194,9 +194,32 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           python3 scripts/restore-partial-chain-output.py             --cell-id '${{ matrix.id }}'             --action-key '${{ steps.identity.outputs.key }}'             --out-dir '.factory/${{ matrix.id }}'
+      # What the published index already serves, so the chain skips it.
+      #
+      # Without this, "already built" means only the local repo, seeded from
+      # an action-key-MATCHED partial -- and the key moves whenever the mock
+      # runner image is rebuilt, which every mock/*.cfg merge does. Leg
+      # 33113528651 is the measurement: dispatched minutes after #565 edited
+      # a cfg, it spent its whole 4.5h budget rebuilding packages the repo
+      # had served for hours, and published an index byte-identical to the
+      # one before it (8397 binaries, 580/673 sources, same NVRs). That is
+      # #544's deeper half, and it costs a leg every time a fix lands.
+      #
+      # An unreachable index prints nothing and the file is empty: the chain
+      # then behaves exactly as it did before this step.
+      - name: List what the published index already serves
+        if: steps.verdict.outputs.hit != 'true'
+        env:
+          R2_PATH: ${{ matrix.r2_path }}
+        run: |
+          set -euo pipefail
+          python3 scripts/list-served-nvrs.py \
+            "https://repo.tunaos.org/${R2_PATH}/" > /tmp/served-nvrs-${{ matrix.id }}.txt
+          echo "served NVRs for ${{ matrix.id }}: $(wc -l < /tmp/served-nvrs-${{ matrix.id }}.txt)"
       - name: Build the cell
         id: build
         env:
+          CHAIN_SERVED_NVRS: /tmp/served-nvrs-${{ matrix.id }}.txt
           CELL_ID: ${{ matrix.id }}
           ENGINE: build-chain
           # No RECIPE or FORMAT: the build-chain branch of the runner exits

--- a/tests/test_chain_fanout.py
+++ b/tests/test_chain_fanout.py
@@ -199,3 +199,40 @@ def test_bands_continue_past_red_shards(fanout):
                 f"band{i}-{arch}: default gating skips the rest of the chain "
                 "after one red shard, stranding the collected band"
             )
+
+
+# --- the single-runner publisher must skip served packages too ---------------
+
+PUBLISHER = ROOT / ".github" / "workflows" / "publish-build-chain-rpms.yml"
+
+
+@pytest.fixture(scope="module")
+def publisher():
+    return yaml.safe_load(PUBLISHER.read_text(encoding="utf-8"))
+
+
+def test_publisher_lists_the_served_index(publisher):
+    steps = publisher["jobs"]["build"]["steps"]
+    lister = [s for s in steps if "list-served-nvrs.py" in str(s.get("run", ""))]
+    assert lister, (
+        "leg 33113528651 burned its whole 4.5h budget rebuilding served "
+        "packages and republished a byte-identical index: without this the "
+        "publisher restarts at tier 0 on every mock-cfg merge (#544)"
+    )
+
+
+def test_publisher_feeds_the_served_list_to_the_chain(publisher):
+    steps = publisher["jobs"]["build"]["steps"]
+    build = [s for s in steps if s.get("id") == "build"]
+    assert build, "the build step must keep its id"
+    assert "CHAIN_SERVED_NVRS" in build[0]["env"], (
+        "listing the served NVRs is useless unless the chain is told to read them"
+    )
+
+
+def test_the_served_list_is_per_cell(publisher):
+    text = PUBLISHER.read_text(encoding="utf-8")
+    assert "/tmp/served-nvrs-${{ matrix.id }}.txt" in text, (
+        "both arches share a runner-local /tmp in the matrix; one filename "
+        "would let x86_64's list decide what aarch64 skips"
+    )


### PR DESCRIPTION
Measured, not inferred. Leg [33113528651](https://github.com/tuna-os/tunaos-packages/actions/runs/33113528651) was dispatched at 18:45Z, minutes after #565 edited a mock cfg — which rebuilds the mock-runner image, whose digest is an action-key input. The key moved, the partial was rejected, the chain restarted at tier 0, and 4.5 hours later it published an index **byte-identical** to the one before it:

| | binaries | sources served |
|---|---|---|
| before (15:22Z publish) | 8397 | 580/673 |
| after (23:47Z publish) | 8397 | 580/673 |

The repomd revision moved only because reindexing stamps a timestamp. Four and a half hours of runner time bought nothing.

#568 gave `build-chain` its `--served-nvrs` flag and wired it into the fan-out, but the single-runner publisher never passed it, so it kept paying the full cost of every cfg merge — and every cfg merge tonight was a fix we wanted. It now lists the served NVRs for its own `r2_path` before building and hands the list to the chain.

Two details that are load-bearing:
- **Per-cell filename** (`/tmp/served-nvrs-${{ matrix.id }}.txt`): both arches share a runner-local `/tmp` inside the matrix, and one shared name would let x86_64's list decide what aarch64 skips.
- **Empty is safe**: an unreachable index writes an empty file, and the chain then behaves exactly as it did before this step.

3 new tests (20 in the fanout suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sZp9iEZAJS44joA2Z8mCK

---
_Generated by [Claude Code](https://claude.ai/code/session_015sZp9iEZAJS44joA2Z8mCK)_