### PR TITLE
Let the merge-group gate reuse the PR's evidence

### DIFF
--- a/.github/workflows/package-factory-cell.yml
+++ b/.github/workflows/package-factory-cell.yml
@@ -348,6 +348,21 @@ jobs:
       # Both list paths under .factory/<id>, so upload-artifact roots each
       # zip at that directory either way and the layout a consumer sees is
       # unchanged.
+      # action-key.txt rides along (~70 bytes) so this artifact can be read
+      # back as EVIDENCE and not merely kept as a deliverable: the resume
+      # path accepts a candidate only when the key recorded beside its RPMs
+      # matches the key the reading cell computed, and discards any whose key
+      # is absent.
+      #
+      # That is what lets a merge-queue run skip rebuilding what its own PR
+      # just built. GitHub scopes the Actions cache by ref, so a queue commit
+      # on refs/heads/gh-readonly-queue/... cannot read the cache the PR
+      # wrote on refs/pull/N/merge; the queue rebuilt every src/-touching PR
+      # from zero against a CI timeout of about an hour, and evicted #567
+      # with CI_TIMEOUT on every attempt. Artifacts have no ref scoping.
+      #
+      # NOTE: comments belong HERE, not inside `path:` below -- that is a
+      # YAML block scalar, where a `#` line is a literal path, not a comment.
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success()
         with:
@@ -356,6 +371,7 @@ jobs:
             .factory/${{ matrix.id }}/artifacts/
             .factory/${{ matrix.id }}/metadata/
             .factory/${{ matrix.id }}/action-result.json
+            .factory/${{ matrix.id }}/action-key.txt
           if-no-files-found: error
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()

--- a/scripts/restore-partial-chain-output.py
+++ b/scripts/restore-partial-chain-output.py
@@ -130,11 +130,49 @@ def unexpired_partials(repository: str, name: str, token: str) -> list[dict]:
     The artifacts endpoint filters by name across the whole repository and
     returns newest first, so this is one request rather than a walk over runs.
 
+    ACROSS THE WHOLE REPOSITORY is the property that makes this work where
+    the action cache cannot. GitHub scopes caches by ref: a run on
+    `refs/pull/N/merge` writes entries only that PR can read, and a merge
+    QUEUE run lives on `refs/heads/gh-readonly-queue/...`, which sees main's
+    caches and never the PR's. The artifacts API has no such scoping, so an
+    artifact is reachable from any run in the repository.
+
     Newest FIRST, deliberately not newest-only: see the walk in main().
     """
     url = f"{API}/repos/{repository}/actions/artifacts?name={name}&per_page=30"
     listing = api_get(url, token)
     return [a for a in (listing.get("artifacts") or []) if not a.get("expired")]
+
+
+def reusable_outputs(repository: str, names: list[str], token: str) -> list[dict]:
+    """Candidates from every name that can carry this cell's packages.
+
+    Two artifacts can: the `-partial` an interrupted attempt banks, and the
+    plain `<cell-id>` a SUCCESSFUL one uploads. Both contain `artifacts/`
+    and, once the success upload carries it, the key that says which inputs
+    produced them -- and the key is the whole basis on which either is
+    accepted, so where the RPMs came from does not matter. A complete
+    attempt is simply a better partial: more packages, same guarantee.
+
+    Reading the success artifact is what lets a merge-queue run reuse the
+    evidence its own PR already produced. The PR's gate builds the cell and
+    stores it in a ref-scoped cache the queue commit cannot read, so the
+    queue rebuilt every `src/`-touching PR from zero -- hours of work
+    against a merge-queue CI timeout of about an hour, which evicted PR #567
+    with CI_TIMEOUT on every attempt and made such PRs unmergeable no matter
+    how green they were.
+
+    Merged newest-first across names, because "newest" is the useful
+    ordering and which name it came from is not.
+    """
+    found: list[dict] = []
+    for name in names:
+        for artifact in unexpired_partials(repository, name, token):
+            artifact = dict(artifact)
+            artifact["_source_name"] = name
+            found.append(artifact)
+    found.sort(key=lambda a: a.get("created_at") or "", reverse=True)
+    return found
 
 
 def extract(blob: bytes, destination: pathlib.Path) -> tuple[str | None, int]:
@@ -187,14 +225,15 @@ def main() -> int:
         log("no token or repository in the environment; building from scratch")
         return 0
 
-    name = f"{args.cell_id}-partial"
+    names = [f"{args.cell_id}-partial", args.cell_id]
     try:
-        candidates = unexpired_partials(args.repository, name, token)
+        candidates = reusable_outputs(args.repository, names, token)
     except (urllib.error.URLError, ValueError, OSError) as error:
         log(f"could not list artifacts ({error}); building from scratch")
         return 0
     if not candidates:
-        log(f"no unexpired `{name}` artifact; building from scratch")
+        log(f"no unexpired {' or '.join(f'`{n}`' for n in names)} artifact; "
+            "building from scratch")
         return 0
 
     # Extract somewhere disposable first. A key mismatch must leave the cell
@@ -212,7 +251,8 @@ def main() -> int:
     # prevent. So walk down the list until one actually carries packages.
     # Downloading a useless candidate is cheap precisely because it is empty.
     for artifact in candidates[:MAX_CANDIDATES]:
-        log(f"found `{name}` from {artifact.get('created_at')} "
+        log(f"found `{artifact.get('_source_name')}` from "
+            f"{artifact.get('created_at')} "
             f"({artifact.get('size_in_bytes', 0) / 1e6:.0f} MB)")
         shutil.rmtree(staging, ignore_errors=True)
         staging.mkdir(parents=True, exist_ok=True)
@@ -234,8 +274,8 @@ def main() -> int:
         break
 
     if source is None:
-        log("no unexpired partial carries usable packages; "
-            "building from scratch")
+        log("no unexpired artifact carries usable packages with a "
+            "matching key; building from scratch")
         shutil.rmtree(staging, ignore_errors=True)
         return 0
 

--- a/tests/test_action_cache_stores_only_output.py
+++ b/tests/test_action_cache_stores_only_output.py
@@ -155,6 +155,15 @@ def test_success_uploads_the_output_and_failure_uploads_the_build_tree():
         ".factory/${{ matrix.id }}/artifacts/",
         ".factory/${{ matrix.id }}/metadata/",
         ".factory/${{ matrix.id }}/action-result.json",
+        # ~70 bytes, and the reason this artifact is EVIDENCE and not merely a
+        # deliverable: GitHub scopes the Actions cache by ref, so a
+        # merge-queue run cannot read the caches its PR wrote, but the
+        # artifacts API is repo-wide. restore-partial-chain-output.py accepts
+        # a candidate only when the key inside the zip matches this cell's, so
+        # without the key riding along the RPMs here can never be reused --
+        # which is what made every src/-touching PR hit the queue's CI
+        # timeout. See test_the_merge_queue_reuses_the_prs_evidence.py.
+        ".factory/${{ matrix.id }}/action-key.txt",
     ]
     # On failure the build tree is exactly what a person debugging wants.
     assert by_condition["failure()"]["with"]["path"].strip() == ".factory/${{ matrix.id }}/"

--- a/tests/test_the_merge_queue_reuses_the_prs_evidence.py
+++ b/tests/test_the_merge_queue_reuses_the_prs_evidence.py
@@ -1,0 +1,193 @@
+"""A merge-queue run must not rebuild what the PR it is merging just built.
+
+GitHub scopes the Actions cache by ref. A PR's gate runs on
+`refs/pull/N/merge` and writes cache entries only that PR can read; a merge
+QUEUE run lives on `refs/heads/gh-readonly-queue/main/pr-N-<sha>`, which can
+read main's caches and never the PR's. So a PR that changes `src/` has an
+action key main has never built, the queue run finds nothing, and it rebuilds
+the cells from zero.
+
+That is not merely slow, it is disqualifying. Measured on 2026-08-28:
+
+    merge-group run   touches src/   duration                  outcome
+    pr-570            no             77 s                      merged
+    pr-567            yes            63 min, still building    CI_TIMEOUT
+
+The queue's CI timeout is about an hour and the gnome cells take hours, so
+every `src/`-touching PR was evicted on every attempt no matter how green it
+was on its own head. #545 and #567 both hit it.
+
+The artifacts API has no ref scoping: an artifact is reachable from any run
+in the repository. The resume path already fetches artifacts across runs and
+accepts one only when its recorded action key matches this cell's -- so the
+fix is to let it also see the artifact a SUCCESSFUL build uploads, and to
+make that artifact carry the key it is judged by.
+
+What keeps this honest is the key, not the name. Same key means the same
+manifest slice, source digests, image digest and epoch, which is exactly the
+basis on which cache hits and partial resumes are already accepted
+everywhere else in this factory. A complete attempt is a better partial:
+more packages, identical guarantee.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts" / "restore-partial-chain-output.py"
+CELL = ROOT / ".github" / "workflows" / "package-factory-cell.yml"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("restore_partial", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def cell_steps():
+    data = yaml.safe_load(CELL.read_text(encoding="utf-8"))
+    for job in data["jobs"].values():
+        if job.get("steps"):
+            return job["steps"]
+    raise AssertionError("no job with steps in the cell workflow")
+
+
+def success_upload():
+    for step in cell_steps():
+        if ("upload-artifact" in str(step.get("uses", ""))
+                and str(step.get("if", "")).strip() == "success()"):
+            return step
+    raise AssertionError("no success-conditioned upload-artifact step")
+
+
+# --- the restore must look at both names -------------------------------------
+
+def test_restore_considers_the_success_artifact_not_only_the_partial():
+    module = load_module()
+    assert hasattr(module, "reusable_outputs"), (
+        "the lookup that spans both artifact names is what makes a "
+        "merge-queue run able to reuse its PR's build"
+    )
+
+
+def test_both_candidate_names_are_queried(monkeypatch):
+    module = load_module()
+    asked: list[str] = []
+
+    def fake(repository, name, token):
+        asked.append(name)
+        return [{"created_at": f"2026-08-28T0{len(asked)}:00:00Z",
+                 "size_in_bytes": 1}]
+
+    monkeypatch.setattr(module, "unexpired_partials", fake)
+    module.reusable_outputs("o/r", ["cell-partial", "cell"], "t")
+    assert asked == ["cell-partial", "cell"], (
+        "a run must see the interrupted attempt AND the validated one"
+    )
+
+
+def test_candidates_are_merged_newest_first(monkeypatch):
+    """Which name it came from must not outrank how recent it is."""
+    module = load_module()
+    by_name = {
+        "cell-partial": [{"created_at": "2026-08-01T00:00:00Z", "id": "old"}],
+        "cell": [{"created_at": "2026-08-28T00:00:00Z", "id": "new"}],
+    }
+    monkeypatch.setattr(module, "unexpired_partials",
+                        lambda repo, name, token: by_name[name])
+    merged = module.reusable_outputs("o/r", ["cell-partial", "cell"], "t")
+    assert [c["id"] for c in merged] == ["new", "old"]
+
+
+def test_each_candidate_remembers_which_name_it_came_from(monkeypatch):
+    """The log line that says what was restored has to be truthful."""
+    module = load_module()
+    monkeypatch.setattr(
+        module, "unexpired_partials",
+        lambda repo, name, token: [{"created_at": "2026-08-28T00:00:00Z"}],
+    )
+    merged = module.reusable_outputs("o/r", ["a-partial", "a"], "t")
+    assert {c["_source_name"] for c in merged} == {"a-partial", "a"}
+
+
+def test_the_ref_scoping_that_makes_this_necessary_is_written_down():
+    doc = load_module().unexpired_partials.__doc__ or ""
+    assert "scopes caches by ref" in doc or "ref-scoped" in doc or "scoping" in doc, (
+        "the next reader must learn why the cache cannot serve this, or they "
+        "will 'simplify' it back to a cache lookup"
+    )
+
+
+# --- the success artifact must carry the key it is judged by ------------------
+
+def test_the_success_artifact_carries_its_action_key():
+    paths = str(success_upload()["with"]["path"])
+    assert "action-key.txt" in paths, (
+        "restore reads the key from the zip and discards any candidate whose "
+        "key is absent -- without this line the success artifact can never be "
+        "reused, however recent it is"
+    )
+
+
+def test_the_success_artifact_still_carries_the_packages():
+    paths = str(success_upload()["with"]["path"])
+    assert "artifacts/" in paths, (
+        "the RPMs are the thing being reused; the key alone restores nothing"
+    )
+
+
+def test_the_two_artifact_names_stay_distinct():
+    """Querying both names is deliberate; COLLIDING them would not be.
+
+    One name for both would make `overwrite: true` on the partial able to
+    replace a validated deliverable.
+    """
+    names = {(s.get("with") or {}).get("name") for s in cell_steps()}
+    assert "${{ matrix.base_id || matrix.id }}-partial" in names
+    assert "${{ matrix.id }}" in names
+
+
+def test_a_key_mismatch_still_discards_the_candidate():
+    """The widened search must not widen what is ACCEPTED.
+
+    Reuse is safe only because the key is checked; if that check ever
+    softens, a merge-queue run could ship RPMs built from other inputs.
+    """
+    body = SCRIPT.read_text(encoding="utf-8")
+    assert "if key != args.action_key:" in body
+    assert "trying an older one" in body
+
+
+def test_main_actually_asks_for_both_names(monkeypatch, tmp_path):
+    """The helper spanning both names is useless if the caller passes one.
+
+    This is the assertion the first draft of this file was missing: deleting
+    the cell id from main()'s `names` list left every other test in here
+    green while restoring nothing a merge-queue run could use.
+    """
+    module = load_module()
+    seen: dict[str, list[str]] = {}
+
+    def fake(repository, names, token):
+        seen["names"] = list(names)
+        return []
+
+    monkeypatch.setattr(module, "reusable_outputs", fake)
+    monkeypatch.setenv("GITHUB_TOKEN", "t")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["restore", "--cell-id", "hummingbird-x86_64",
+         "--action-key", "sha256:abc", "--out-dir", str(tmp_path / "cell"),
+         "--repository", "o/r"],
+    )
+    assert module.main() == 0
+    assert seen["names"] == ["hummingbird-x86_64-partial", "hummingbird-x86_64"], (
+        "main must offer the interrupted attempt AND the validated one"
+    )


### PR DESCRIPTION
A merge-queue run rebuilds from zero everything the PR it is merging just built. GitHub scopes the Actions cache **by ref**: a PR gate runs on `refs/pull/N/merge` and writes entries only that PR can read, while the queue run lives on `refs/heads/gh-readonly-queue/main/pr-N-<sha>` and can read only `main`'s. A PR that touches `src/` therefore presents an action key `main` has never built, the queue run finds nothing, and it starts over.

Measured 2026-08-28:

| merge-group run | touches `src/` | duration | outcome |
| --- | --- | --- | --- |
| pr-570 | no | 77 s | merged |
| pr-567 | yes | 63 min, still building | `CI_TIMEOUT` |

The queue's CI timeout is about an hour and the gnome cells take hours, so every `src/`-touching PR was evicted on every attempt however green it was on its own head (#545, #567).

## The fix

The artifacts API has **no ref scoping**, and `restore-partial-chain-output.py` already fetches artifacts across runs, accepting one only when the action key recorded inside the zip matches this cell's. Two changes make that path serve the queue:

- `reusable_outputs()` searches both `<cell>-partial` and `<cell>`, merging candidates newest-first, so a run sees the interrupted attempt **and** the validated one. A complete attempt is a better partial: more packages, identical guarantee.
- the success upload now carries `action-key.txt` (~70 bytes), the key it is judged by — without it the RPMs it holds can never be reused, however recent.

What is *accepted* does not widen. The key still gates reuse, and the same key means the same manifest slice, source digests, image digest and epoch — the same basis on which cache hits and partial resumes are already accepted everywhere in this factory. The two artifact names stay distinct, so `overwrite: true` on the partial can never replace a validated deliverable.

## Tests

`tests/test_the_merge_queue_reuses_the_prs_evidence.py` (10 tests): both names queried, candidates merged newest-first, each candidate remembers its source name, the ref-scoping rationale stays written down, the success artifact carries both the key and the packages, the two names stay distinct, and a key mismatch still discards.

`test_main_actually_asks_for_both_names` is mutation-driven: deleting the cell id from `main()`'s `names` list left every other test green while restoring nothing a merge-queue run could use.

`tests/test_action_cache_stores_only_output.py` updated for the fourth success path, with the reasoning inline.

Full suite: **1710 passed, 1 skipped**.

---
_Generated by [Claude Code](https://claude.ai/code/session_015sZp9iEZAJS44joA2Z8mCK)_