### PR TITLE
ci: skip package factory on merge queue refs

### DIFF
--- a/.github/workflows/package-factory.yml
+++ b/.github/workflows/package-factory.yml
@@ -2,7 +2,6 @@ name: Package Factory
 
 on:
   pull_request:
-  merge_group:
   push:
     branches: [main]
   schedule:


### PR DESCRIPTION
## Summary
- stop Package Factory from running on `merge_group` events
- keep the package factory on pull requests, main pushes, schedules, and manual dispatches

The merge queue now requires only the stable `required-checks` and `actionlint` contexts. Running the multi-hour Package Factory again on the queue ref is redundant and burns runner capacity.