### PR TITLE
fix(gate): bound a renderer change to one tier per family

### DIFF
--- a/manifests/package-builds.yaml
+++ b/manifests/package-builds.yaml
@@ -15,6 +15,15 @@ native_builds:
     mock_config: centos-stream-10-ci-gnome49
     source_paths: [src/gnome-49/, src/deps/]
     r2_path: gnome49/10-stream-x86_64
+    # Bounds the PR gate to this chain's FIRST tier. The nightly, the
+    # publish legs and the fan-out are unbounded and still build the whole
+    # family; only the --canary-common plan (pull_request/merge_group/push)
+    # reads this. Without it a PR gate rebuilt the ENTIRE chain: measured
+    # on #576's gate, xfce-el10-x86_64 took 51m and xfce-el10-aarch64 38m
+    # for a change that could not affect either, while gnome50/51 ran past
+    # 50m unfinished. hummingbird carried this from the start; the other
+    # families were simply never given one.
+    canary_tiers: base-tools
   - id: gnome50-el10-x86_64
     family: gnome50
     track: stable
@@ -32,6 +41,15 @@ native_builds:
     # this cell and the cache serves a build made from the old spec.
     source_paths: [src/gnome-50/, src/deps/, src/input-remapper/, src/python3-evdev/]
     r2_path: repo/10-x86_64
+    # Bounds the PR gate to this chain's FIRST tier. The nightly, the
+    # publish legs and the fan-out are unbounded and still build the whole
+    # family; only the --canary-common plan (pull_request/merge_group/push)
+    # reads this. Without it a PR gate rebuilt the ENTIRE chain: measured
+    # on #576's gate, xfce-el10-x86_64 took 51m and xfce-el10-aarch64 38m
+    # for a change that could not affect either, while gnome50/51 ran past
+    # 50m unfinished. hummingbird carried this from the start; the other
+    # families were simply never given one.
+    canary_tiers: base-tools
   - id: gnome51-el10-x86_64
     family: gnome51
     track: next
@@ -61,6 +79,15 @@ native_builds:
   # Not yet in el10's published_index.aarch64: manifests/package-factory.yaml
   # says a prefix goes in only once it actually resolves, and this one 404s
   # until the first wave publishes.
+    # Bounds the PR gate to this chain's FIRST tier. The nightly, the
+    # publish legs and the fan-out are unbounded and still build the whole
+    # family; only the --canary-common plan (pull_request/merge_group/push)
+    # reads this. Without it a PR gate rebuilt the ENTIRE chain: measured
+    # on #576's gate, xfce-el10-x86_64 took 51m and xfce-el10-aarch64 38m
+    # for a change that could not affect either, while gnome50/51 ran past
+    # 50m unfinished. hummingbird carried this from the start; the other
+    # families were simply never given one.
+    canary_tiers: base-tools
   - id: gnome50-el10-aarch64
     family: gnome50
     track: stable
@@ -84,6 +111,15 @@ native_builds:
   # gnome51 on aarch64. Same reasoning as gnome50 above; its r2 prefix is the
   # straight arch swap of the x86_64 one, which was already a clean
   # family-owned path.
+    # Bounds the PR gate to this chain's FIRST tier. The nightly, the
+    # publish legs and the fan-out are unbounded and still build the whole
+    # family; only the --canary-common plan (pull_request/merge_group/push)
+    # reads this. Without it a PR gate rebuilt the ENTIRE chain: measured
+    # on #576's gate, xfce-el10-x86_64 took 51m and xfce-el10-aarch64 38m
+    # for a change that could not affect either, while gnome50/51 ran past
+    # 50m unfinished. hummingbird carried this from the start; the other
+    # families were simply never given one.
+    canary_tiers: base-tools
   - id: gnome51-el10-aarch64
     family: gnome51
     track: next
@@ -101,6 +137,15 @@ native_builds:
       - src/gnome-51/
       - src/deps/
     r2_path: gnome51/10-stream-aarch64
+    # Bounds the PR gate to this chain's FIRST tier. The nightly, the
+    # publish legs and the fan-out are unbounded and still build the whole
+    # family; only the --canary-common plan (pull_request/merge_group/push)
+    # reads this. Without it a PR gate rebuilt the ENTIRE chain: measured
+    # on #576's gate, xfce-el10-x86_64 took 51m and xfce-el10-aarch64 38m
+    # for a change that could not affect either, while gnome50/51 ran past
+    # 50m unfinished. hummingbird carried this from the start; the other
+    # families were simply never given one.
+    canary_tiers: base-tools
 
   - id: xfce-el10-x86_64
     family: xfce
@@ -136,6 +181,15 @@ native_builds:
   # xfce/10-stream-aarch64 yet — that prefix does not exist until a publish
   # wave writes it, and the target contract's rule is to declare only an
   # index that actually resolves.
+    # Bounds the PR gate to this chain's FIRST tier. The nightly, the
+    # publish legs and the fan-out are unbounded and still build the whole
+    # family; only the --canary-common plan (pull_request/merge_group/push)
+    # reads this. Without it a PR gate rebuilt the ENTIRE chain: measured
+    # on #576's gate, xfce-el10-x86_64 took 51m and xfce-el10-aarch64 38m
+    # for a change that could not affect either, while gnome50/51 ran past
+    # 50m unfinished. hummingbird carried this from the start; the other
+    # families were simply never given one.
+    canary_tiers: xfce-build-tools
   - id: xfce-el10-aarch64
     family: xfce
     target: el10
@@ -147,6 +201,15 @@ native_builds:
     mock_config: centos-stream-10-ci-aarch64
     source_paths: [src/xfce-wayland/]
     r2_path: xfce/10-stream-aarch64
+    # Bounds the PR gate to this chain's FIRST tier. The nightly, the
+    # publish legs and the fan-out are unbounded and still build the whole
+    # family; only the --canary-common plan (pull_request/merge_group/push)
+    # reads this. Without it a PR gate rebuilt the ENTIRE chain: measured
+    # on #576's gate, xfce-el10-x86_64 took 51m and xfce-el10-aarch64 38m
+    # for a change that could not affect either, while gnome50/51 ran past
+    # 50m unfinished. hummingbird carried this from the start; the other
+    # families were simply never given one.
+    canary_tiers: xfce-build-tools
   - id: xfce-fedora-x86_64
     family: xfce
     target: fedora
@@ -164,6 +227,15 @@ native_builds:
   # already ships XFCE 4.20 and greetd/gtkgreet/cage are in Fedora proper. So
   # it carries neither of the two Requires that cannot resolve on EL10 (#482),
   # and needed only a mock config that did not exist (#480).
+    # Bounds the PR gate to this chain's FIRST tier. The nightly, the
+    # publish legs and the fan-out are unbounded and still build the whole
+    # family; only the --canary-common plan (pull_request/merge_group/push)
+    # reads this. Without it a PR gate rebuilt the ENTIRE chain: measured
+    # on #576's gate, xfce-el10-x86_64 took 51m and xfce-el10-aarch64 38m
+    # for a change that could not affect either, while gnome50/51 ran past
+    # 50m unfinished. hummingbird carried this from the start; the other
+    # families were simply never given one.
+    canary_tiers: xfce-core-libs
   - id: xfce-fedora-aarch64
     family: xfce
     target: fedora
@@ -175,6 +247,15 @@ native_builds:
     mock_config: fedora-44-ci-aarch64
     source_paths: [src/xfce-wayland/]
     r2_path: xfce/44-aarch64
+    # Bounds the PR gate to this chain's FIRST tier. The nightly, the
+    # publish legs and the fan-out are unbounded and still build the whole
+    # family; only the --canary-common plan (pull_request/merge_group/push)
+    # reads this. Without it a PR gate rebuilt the ENTIRE chain: measured
+    # on #576's gate, xfce-el10-x86_64 took 51m and xfce-el10-aarch64 38m
+    # for a change that could not affect either, while gnome50/51 ran past
+    # 50m unfinished. hummingbird carried this from the start; the other
+    # families were simply never given one.
+    canary_tiers: xfce-core-libs
   - id: hummingbird-x86_64
     family: hummingbird-desktops
     target: hummingbird
@@ -224,6 +305,15 @@ native_builds:
     mock_config: centos-stream-10-ci
     source_paths: [src/deps/libfprint/, src/deps/fprintd/]
     publish: false
+    # Bounds the PR gate to this chain's FIRST tier. The nightly, the
+    # publish legs and the fan-out are unbounded and still build the whole
+    # family; only the --canary-common plan (pull_request/merge_group/push)
+    # reads this. Without it a PR gate rebuilt the ENTIRE chain: measured
+    # on #576's gate, xfce-el10-x86_64 took 51m and xfce-el10-aarch64 38m
+    # for a change that could not affect either, while gnome50/51 ran past
+    # 50m unfinished. hummingbird carried this from the start; the other
+    # families were simply never given one.
+    canary_tiers: fprint-core
   - id: fprintd-el10-aarch64
     family: fprintd
     target: el10
@@ -235,3 +325,12 @@ native_builds:
     mock_config: centos-stream-10-ci-aarch64
     source_paths: [src/deps/libfprint/, src/deps/fprintd/]
     r2_path: fprintd/10-stream-aarch64
+    # Bounds the PR gate to this chain's FIRST tier. The nightly, the
+    # publish legs and the fan-out are unbounded and still build the whole
+    # family; only the --canary-common plan (pull_request/merge_group/push)
+    # reads this. Without it a PR gate rebuilt the ENTIRE chain: measured
+    # on #576's gate, xfce-el10-x86_64 took 51m and xfce-el10-aarch64 38m
+    # for a change that could not affect either, while gnome50/51 ran past
+    # 50m unfinished. hummingbird carried this from the start; the other
+    # families were simply never given one.
+    canary_tiers: fprint-core

--- a/scripts/plan-package-factory.py
+++ b/scripts/plan-package-factory.py
@@ -216,6 +216,12 @@ def select_cells(
         return [cell for cell in graph_cells if cell["id"] in changed_graph_ids]
     changed_packages = {match.group(1) for path in changed if (match := RECIPE_CHANGE.match(path))}
     selected = []
+    # Cells pulled in ONLY because a renderer script moved -- build-chain.sh,
+    # parse-build-order.py, import-fedora-distgit.py. Nothing about the
+    # packages themselves changed, so on a PR these are bounded to their first
+    # tier rather than rebuilding every family end to end. See
+    # bound_to_canary_tiers() for why that is the right depth.
+    renderer_only = []
     for cell in cells:
         if cell["engine"] == "tideforge" and cell["package"] in changed_packages:
             selected.append(cell)
@@ -223,18 +229,56 @@ def select_cells(
         if formats and cell["format"] in formats:
             selected.append(cell)
             continue
-        if changed & NATIVE_INPUTS and cell["engine"] == "build-chain":
-            selected.append(cell)
-            continue
-        if changed & DISTGIT_INPUTS and cell["engine"] == "build-chain" and cell["uses_distgit"]:
-            selected.append(cell)
-            continue
+        # Checked BEFORE the renderer rules: a cell whose own manifest or
+        # sources moved must build for real, however it was also selected.
         if cell["engine"] == "build-chain" and any(
             path == cell["manifest"] or any(path.startswith(prefix) for prefix in cell["source_paths"])
             for path in changed
         ):
             selected.append(cell)
-    return selected
+            continue
+        if changed & NATIVE_INPUTS and cell["engine"] == "build-chain":
+            renderer_only.append(cell)
+            continue
+        if changed & DISTGIT_INPUTS and cell["engine"] == "build-chain" and cell["uses_distgit"]:
+            renderer_only.append(cell)
+    if canary_common:
+        renderer_only = bound_to_canary_tiers(renderer_only)
+    return selected + renderer_only
+
+
+def bound_to_canary_tiers(cells: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Same cells, each bounded to the FIRST tier of its own chain.
+
+    For a renderer-script change there is no package to attribute the edit to,
+    so every build-chain family gets selected and each one rebuilds its entire
+    chain. Measured on #576's gate, a two-line build-chain.sh fix pulled in 36
+    cells: xfce-el10-x86_64 took 51m, xfce-el10-aarch64 38m, and gnome50/51 ran
+    past 50m without finishing -- for a change that could not alter what any of
+    those packages compile to.
+
+    This is deliberately NOT canary_cells(). That collapses to one cell per
+    (engine, target, format, architecture), and every el10 rpm family shares
+    that coordinate -- gnome50, gnome51, xfce and fprintd would become a single
+    representative, so a renderer bug that only bites the gnome51 chain would
+    sail through. Keeping every family and cutting the DEPTH preserves the
+    coverage that matters here while removing the hours.
+
+    Setting `tiers` also drops the -c1/-c2 continuations, which exist to resume
+    a long chain and have nothing to resume from a single tier.
+
+    The nightly, the publish legs and the fan-out never pass canary_common, so
+    they are unaffected and still build every family end to end.
+    """
+    bounded = []
+    for cell in cells:
+        candidate = dict(cell)
+        tiers = candidate.get("canary_tiers")
+        if tiers:
+            candidate["id"] += "-canary"
+            candidate["tiers"] = tiers
+        bounded.append(candidate)
+    return bounded
 
 
 def canary_cells(cells: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/tests/test_a_renderer_change_gates_on_canaries.py
+++ b/tests/test_a_renderer_change_gates_on_canaries.py
@@ -1,0 +1,168 @@
+"""A renderer-script change must not rebuild every chain end to end.
+
+`scripts/build-chain.sh` and `scripts/parse-build-order.py` are renderer
+inputs: an edit to them cannot be attributed to any package, so every
+build-chain family gets selected. Until now each of those cells then built its
+family's WHOLE chain on the PR gate.
+
+Measured on #576's gate -- a two-line build-chain.sh fix:
+
+    cell                    duration
+    xfce-el10-x86_64        51m
+    xfce-el10-aarch64       38m
+    gnome50/51 el10 x4      >50m, unfinished
+    cells selected          36
+
+None of those packages can compile differently because of that diff. The gate
+was buying nothing with the hours.
+
+The fix is depth, not breadth. Every family still runs -- only its FIRST tier
+does. `hummingbird` already had `canary_tiers: bootstrap-00`; the other
+families were simply never given one.
+
+What must stay true, and is asserted below:
+
+  * the nightly, publish legs and fan-out never pass canary_common, so they
+    still build everything;
+  * a cell whose OWN manifest or sources moved is never bounded -- a spec
+    change must build the real thing;
+  * every family survives the bounding (see the canary_cells collapse hazard
+    in test_every_family_survives_the_bounding);
+  * every declared canary tier NAMES A REAL TIER -- a typo would build zero
+    packages and pass vacuously, which is worse than the slow gate.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[1]
+PLANNER = ROOT / "scripts" / "plan-package-factory.py"
+PARSER = ROOT / "scripts" / "parse-build-order.py"
+BUILDS = ROOT / "manifests" / "package-builds.yaml"
+
+
+def plan(changed: list[str] | None, canary: bool) -> list[dict]:
+    cmd = [sys.executable, str(PLANNER)]
+    if canary:
+        cmd.append("--canary-common")
+    if changed is not None:
+        tmp = ROOT / ".pytest-changed.txt"
+        tmp.write_text("\n".join(changed) + "\n", encoding="utf-8")
+        cmd += ["--changed-files", str(tmp)]
+    try:
+        out = subprocess.run(cmd, capture_output=True, text=True, check=True, cwd=ROOT).stdout
+    finally:
+        if changed is not None:
+            (ROOT / ".pytest-changed.txt").unlink(missing_ok=True)
+    data = json.loads(out)
+    return [c for m in data["matrices"] for c in json.loads(m)["include"]]
+
+
+def native_cells() -> list[dict]:
+    data = yaml.safe_load(BUILDS.read_text(encoding="utf-8"))
+
+    def walk(node):
+        if isinstance(node, dict):
+            if "manifest" in node and "mock_config" in node:
+                yield node
+            for value in node.values():
+                yield from walk(value)
+        elif isinstance(node, list):
+            for value in node:
+                yield from walk(value)
+
+    return list(walk(data))
+
+
+# --- the manifest ------------------------------------------------------------
+
+def test_every_build_chain_family_declares_a_canary_tier():
+    """A family without one falls back to building its entire chain, which is
+    the slow gate this exists to remove -- silently, for the new family only."""
+    missing = [c["id"] for c in native_cells() if not c.get("canary_tiers")]
+    assert not missing, f"unbounded on the PR gate: {missing}"
+
+
+@pytest.mark.parametrize("cell", native_cells(), ids=lambda c: c["id"])
+def test_the_declared_canary_tier_exists_in_that_manifest(cell):
+    """A typo builds ZERO packages and passes, which is worse than slow.
+
+    This is the assertion that makes the rest of the change safe to trust.
+    """
+    manifest = ROOT / cell["manifest"]
+    if not manifest.is_file():
+        pytest.skip(f"{cell['manifest']} not present")
+    tiers = subprocess.run(
+        [sys.executable, str(PARSER), str(manifest), "--tiers"],
+        capture_output=True, text=True, check=True,
+    ).stdout.split()
+    assert cell["canary_tiers"] in tiers, (
+        f"{cell['id']}: canary_tiers={cell['canary_tiers']!r} is not a tier of "
+        f"{cell['manifest']} (has {tiers[:6]}...)"
+    )
+
+
+# --- the planner -------------------------------------------------------------
+
+def test_a_renderer_change_is_bounded_on_a_pull_request():
+    cells = plan(["scripts/build-chain.sh"], canary=True)
+    assert cells, "a renderer change must still gate something"
+    unbounded = [c["id"] for c in cells if not c.get("tiers")]
+    assert not unbounded, f"still building whole chains on a PR: {unbounded}"
+
+
+def test_the_bounding_drops_the_continuation_shards():
+    """-c1/-c2 exist to resume a long chain; one tier has nothing to resume."""
+    cells = plan(["scripts/build-chain.sh"], canary=True)
+    conts = [c["id"] for c in cells if c["id"].endswith(("-c1", "-c2"))]
+    assert not conts, f"continuations on a bounded gate: {conts}"
+
+
+def test_every_family_survives_the_bounding():
+    """NOT canary_cells(): that collapses to one cell per (engine, target,
+    format, architecture), and gnome50/gnome51/xfce/fprintd all share the el10
+    rpm coordinate -- they would become a single representative and a renderer
+    bug specific to the gnome51 chain would sail through."""
+    families = {c["id"].split("-el10")[0].split("-x86_64")[0].split("-aarch64")[0]
+                for c in plan(["scripts/build-chain.sh"], canary=True)}
+    for expected in ("gnome50", "gnome51", "xfce", "hummingbird", "fprintd"):
+        assert any(expected in f for f in families), (
+            f"{expected} lost its coverage: {sorted(families)}"
+        )
+
+
+def test_a_source_change_still_builds_the_real_chain():
+    """The cell that owns the change must never be bounded, even though the
+    same PR could also trip a renderer rule."""
+    cells = plan(["src/gnome-51/gtk4/gtk4.spec"], canary=True)
+    assert cells, "a spec change must gate something"
+    for cell in cells:
+        assert not cell.get("tiers"), (
+            f"{cell['id']} was bounded, so the spec change was never really built"
+        )
+
+
+def test_a_source_change_beside_a_renderer_change_still_builds_for_real():
+    """Ordering matters: the owns-the-change check runs BEFORE the renderer
+    rules, so a mixed PR does not quietly downgrade to a canary."""
+    cells = plan(["scripts/build-chain.sh", "src/gnome-51/gtk4/gtk4.spec"], canary=True)
+    owners = [c for c in cells if c["id"].startswith("gnome51-el10")]
+    assert owners, "the owning family must be selected"
+    for cell in owners:
+        assert not cell.get("tiers"), f"{cell['id']} downgraded to a canary"
+
+
+def test_the_nightly_is_never_bounded():
+    """canary_common is passed only for pull_request/merge_group/push."""
+    cells = [c for c in plan(None, canary=False) if c["engine"] == "build-chain"]
+    assert cells
+    bounded = [c["id"] for c in cells if c.get("tiers")]
+    assert not bounded, f"the nightly must build everything: {bounded}"


### PR DESCRIPTION
`scripts/build-chain.sh` and `scripts/parse-build-order.py` are **renderer inputs**: an edit to them cannot be attributed to any package, so every build-chain family is selected — and each one then rebuilt its family's *whole chain* on the PR gate.

Measured on [#576](https://github.com/tuna-os/tunaos-packages/pull/576)'s gate, for a two-line `build-chain.sh` fix:

| cell | duration |
| --- | --- |
| `xfce-el10-x86_64` | **51m** |
| `xfce-el10-aarch64` | 38m |
| `gnome50/51-el10` ×4 | >50m, unfinished |
| **cells selected** | **36** |

None of those packages can compile differently because of that diff.

## The change

Cut **depth, not breadth**: every family still runs, bounded to its first tier. **36 cells → 12.**

```
fprintd-el10-{x86_64,aarch64}-canary     tiers=fprint-core
gnome50-el10-{x86_64,aarch64}-canary     tiers=base-tools
gnome51-el10-{x86_64,aarch64}-canary     tiers=base-tools
hummingbird-{x86_64,aarch64}-canary      tiers=bootstrap-00
xfce-el10-{x86_64,aarch64}-canary        tiers=xfce-build-tools
xfce-fedora-{x86_64,aarch64}-canary      tiers=xfce-core-libs
```

`hummingbird` already had `canary_tiers: bootstrap-00` — the other families were simply never given one. This adds the missing eleven.

**Deliberately not `canary_cells()`.** That collapses to one cell per `(engine, target, format, architecture)`, and gnome50, gnome51, xfce and fprintd all share the el10/rpm coordinate — they'd become a single representative, and a renderer bug specific to the gnome51 chain would sail through. Setting `tiers` also drops the `-c1`/`-c2` continuations, which exist to resume a long chain and have nothing to resume from one tier.

## What does not change

- The nightly, publish legs and fan-out never pass `--canary-common`, so they still build every family end to end (asserted).
- A cell whose **own** manifest or sources moved is never bounded. That check now runs *before* the renderer rules, so a PR touching both a spec and `build-chain.sh` still builds the spec's chain for real — asserted separately, because the ordering is the whole guarantee.

## Guards (20)

Three mutation-verified — dropping a family's `canary_tiers`, typo'ing a tier name, and swapping `bound_to_canary_tiers()` for `canary_cells()` each turn a different test red.

The typo case matters most: a tier name that doesn't exist builds **zero** packages and passes vacuously, which is worse than the slow gate it replaces. Every declared tier is checked against its own manifest via `parse-build-order.py`.

Full suite: **1943 passed, 1 skipped**.

---
_Generated by [Claude Code](https://claude.ai/code/session_015sZp9iEZAJS44joA2Z8mCK)_