### PR TITLE
fix(mock): stop re-fetching static repo metadata for every package

### DIFF
--- a/mock/hummingbird-ci-aarch64.cfg
+++ b/mock/hummingbird-ci-aarch64.cfg
@@ -33,6 +33,21 @@ include('/etc/mock/fedora-rawhide-aarch64.cfg')
 config_opts['root'] = 'hummingbird-ci-aarch64'
 config_opts['rpmbuild_networking'] = False
 config_opts['use_host_resolv'] = False
+# metadata_expire: this repo does not change while a chain runs, so dnf must
+# not re-fetch its metadata for every package. The Rawhide template these
+# configs include sets metadata_expire=0, and nothing here overrode it, so
+# EVERY package build in EVERY shard re-downloaded repomd.xml and primary.xml
+# from every enabled repo. For repo.tunaos.org that is our own Cloudflare
+# Workers bill: 673 packages x 2 arches x 5 bands, per fan-out run. The
+# account reached 76% of its 100,000/day request limit on 2026-08-28 with
+# four runs.
+#
+# `0` is correct for exactly ONE repo -- [local-build], which grows as the
+# chain builds and whose freshness the root-cache unpack depends on (see
+# build-chain.sh's MOCK_CACHE_ARGS comment). It stays 0 below.
+#
+# Rawhide is deliberately NOT given an expiry here: it is a rolling repo that
+# genuinely does change mid-run.
 config_opts['dnf.conf'] += """
 [local-build]
 name=Local Hummingbird build results
@@ -47,6 +62,8 @@ baseurl=https://packages.redhat.com/api/pulp-content/public-hummingbird/$basearc
 gpgcheck=0
 enabled=1
 priority=10
+# static: the base OS prefix is a fixed dated path
+metadata_expire=6h
 excludepkgs=golang1.26* jsoncpp*
 # jsoncpp* TEMPORARY. The base compose bumped jsoncpp to libjsoncpp.so.27
 # while every cmake it ships (all six releases, 4.3.0-2.1.hum1 through
@@ -94,6 +111,8 @@ baseurl=https://repo.tunaos.org/hummingbird/20251124-$basearch/
 gpgcheck=0
 enabled=1
 priority=11
+# static: our published index changes only when a publish runs, never mid-chain
+metadata_expire=6h
 # TEMPORARY. Remove once a publish has re-synced this prefix.
 #
 # 79 RPMs in this prefix are stored under a filename containing a literal
@@ -169,6 +188,8 @@ metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-44&arch=$basearc
 gpgcheck=0
 enabled=1
 priority=50
+# static: F44 is a frozen release
+metadata_expire=6h
 includepkgs=python3-*,flit,pyproject-rpm-macros,pyproject-srpm-macros,python-rpm-macros,python-srpm-macros,tomcli,asciidoc,go-vendor-tools,xwayland-run,blueprint-compiler,marshalparser,xcb-proto,lirc*,glad2,python3-glad2
 
 [fedora-44-python-updates]
@@ -177,6 +198,8 @@ metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f44&ar
 gpgcheck=0
 enabled=1
 priority=50
+# static: F44 is a frozen release
+metadata_expire=6h
 includepkgs=python3-*,flit,pyproject-rpm-macros,pyproject-srpm-macros,python-rpm-macros,python-srpm-macros,tomcli,asciidoc,go-vendor-tools,xwayland-run,blueprint-compiler,marshalparser,xcb-proto,lirc*,glad2,python3-glad2
 
 [fedora-44-perl]
@@ -185,6 +208,8 @@ metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-44&arch=$basearc
 gpgcheck=0
 enabled=1
 priority=50
+# static: F44 is a frozen release
+metadata_expire=6h
 includepkgs=perl-*
 
 [fedora-44-perl-updates]
@@ -193,6 +218,8 @@ metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f44&ar
 gpgcheck=0
 enabled=1
 priority=50
+# static: F44 is a frozen release
+metadata_expire=6h
 includepkgs=perl-*
 
 [fedora-44-mpich]
@@ -201,6 +228,8 @@ metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-44&arch=$basearc
 gpgcheck=0
 enabled=1
 priority=50
+# static: F44 is a frozen release
+metadata_expire=6h
 includepkgs=mpich*
 
 [fedora-44-mpich-updates]
@@ -209,6 +238,8 @@ metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f44&ar
 gpgcheck=0
 enabled=1
 priority=50
+# static: F44 is a frozen release
+metadata_expire=6h
 includepkgs=mpich*
 """
 config_opts['plugin_conf']['bind_mount_enable'] = True

--- a/mock/hummingbird-ci.cfg
+++ b/mock/hummingbird-ci.cfg
@@ -180,6 +180,21 @@ include('/etc/mock/fedora-rawhide-x86_64.cfg')
 config_opts['root'] = 'hummingbird-ci'
 config_opts['rpmbuild_networking'] = False
 config_opts['use_host_resolv'] = False
+# metadata_expire: this repo does not change while a chain runs, so dnf must
+# not re-fetch its metadata for every package. The Rawhide template these
+# configs include sets metadata_expire=0, and nothing here overrode it, so
+# EVERY package build in EVERY shard re-downloaded repomd.xml and primary.xml
+# from every enabled repo. For repo.tunaos.org that is our own Cloudflare
+# Workers bill: 673 packages x 2 arches x 5 bands, per fan-out run. The
+# account reached 76% of its 100,000/day request limit on 2026-08-28 with
+# four runs.
+#
+# `0` is correct for exactly ONE repo -- [local-build], which grows as the
+# chain builds and whose freshness the root-cache unpack depends on (see
+# build-chain.sh's MOCK_CACHE_ARGS comment). It stays 0 below.
+#
+# Rawhide is deliberately NOT given an expiry here: it is a rolling repo that
+# genuinely does change mid-run.
 config_opts['dnf.conf'] += """
 [local-build]
 name=Local Hummingbird build results
@@ -194,6 +209,8 @@ baseurl=https://packages.redhat.com/api/pulp-content/public-hummingbird/$basearc
 gpgcheck=0
 enabled=1
 priority=10
+# static: the base OS prefix is a fixed dated path
+metadata_expire=6h
 excludepkgs=golang1.26* jsoncpp*
 # jsoncpp* TEMPORARY. The base compose bumped jsoncpp to libjsoncpp.so.27
 # while every cmake it ships (all six releases, 4.3.0-2.1.hum1 through
@@ -241,6 +258,8 @@ baseurl=https://repo.tunaos.org/hummingbird/20251124-$basearch/
 gpgcheck=0
 enabled=1
 priority=11
+# static: our published index changes only when a publish runs, never mid-chain
+metadata_expire=6h
 # TEMPORARY. Remove once a publish has re-synced this prefix.
 #
 # 79 RPMs in this prefix are stored under a filename containing a literal
@@ -316,6 +335,8 @@ metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-44&arch=$basearc
 gpgcheck=0
 enabled=1
 priority=50
+# static: F44 is a frozen release
+metadata_expire=6h
 includepkgs=python3-*,flit,pyproject-rpm-macros,pyproject-srpm-macros,python-rpm-macros,python-srpm-macros,tomcli,asciidoc,go-vendor-tools,xwayland-run,blueprint-compiler,marshalparser,xcb-proto,lirc*,glad2,python3-glad2
 
 [fedora-44-python-updates]
@@ -324,6 +345,8 @@ metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f44&ar
 gpgcheck=0
 enabled=1
 priority=50
+# static: F44 is a frozen release
+metadata_expire=6h
 includepkgs=python3-*,flit,pyproject-rpm-macros,pyproject-srpm-macros,python-rpm-macros,python-srpm-macros,tomcli,asciidoc,go-vendor-tools,xwayland-run,blueprint-compiler,marshalparser,xcb-proto,lirc*,glad2,python3-glad2
 
 [fedora-44-perl]
@@ -332,6 +355,8 @@ metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-44&arch=$basearc
 gpgcheck=0
 enabled=1
 priority=50
+# static: F44 is a frozen release
+metadata_expire=6h
 includepkgs=perl-*
 
 [fedora-44-perl-updates]
@@ -340,6 +365,8 @@ metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f44&ar
 gpgcheck=0
 enabled=1
 priority=50
+# static: F44 is a frozen release
+metadata_expire=6h
 includepkgs=perl-*
 
 [fedora-44-mpich]
@@ -348,6 +375,8 @@ metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-44&arch=$basearc
 gpgcheck=0
 enabled=1
 priority=50
+# static: F44 is a frozen release
+metadata_expire=6h
 includepkgs=mpich*
 
 [fedora-44-mpich-updates]
@@ -356,6 +385,8 @@ metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f44&ar
 gpgcheck=0
 enabled=1
 priority=50
+# static: F44 is a frozen release
+metadata_expire=6h
 includepkgs=mpich*
 """
 config_opts['plugin_conf']['bind_mount_enable'] = True

--- a/tests/test_static_repos_are_not_refetched_per_package.py
+++ b/tests/test_static_repos_are_not_refetched_per_package.py
@@ -1,0 +1,139 @@
+"""dnf must not re-fetch a static repo's metadata for every package.
+
+The Rawhide template these mock configs include sets `metadata_expire=0`, and
+nothing overrode it. `0` means dnf refuses to trust cached metadata at all, so
+every package build in every shard re-downloaded repomd.xml and primary.xml
+from every enabled repo.
+
+For `repo.tunaos.org` that is our own Cloudflare Workers bill. 673 packages x
+2 arches x 5 bands, per fan-out run; the account reached 76% of its
+100,000/day request limit on 2026-08-28 after four runs, with the reset 16
+hours away and a live run still building.
+
+WHY `0` IS RIGHT FOR EXACTLY ONE REPO
+=====================================
+
+[local-build] is the repo the chain writes into as it builds. build-chain.sh's
+MOCK_CACHE_ARGS comment spells out the dependency: the shared root cache holds
+only the MINIMAL buildroot, and "BuildRequires resolve after the unpack
+against the live repos", which is only true while local-build's metadata is
+never cached. Give it an expiry and a package built sixty seconds ago becomes
+invisible to the next one -- silently, as a dependency-resolution failure
+somewhere down the tier.
+
+So the fix is per-repo, not global, and the assertion below that matters most
+is the one pinning local-build at 0.
+
+WHY RAWHIDE IS LEFT ALONE
+=========================
+
+It is a rolling repo that genuinely changes mid-run. The static ones cannot:
+[hummingbird] is a fixed dated prefix, fedora-44-* is a frozen release, and
+[tunaos-hummingbird] changes only when a publish runs -- never during a chain.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIGS = sorted((ROOT / "mock").glob("*.cfg"))
+
+# Repos that cannot change while a chain runs, and why.
+STATIC = {
+    "hummingbird",
+    "tunaos-hummingbird",
+    "fedora-44-python",
+    "fedora-44-python-updates",
+    "fedora-44-perl",
+    "fedora-44-perl-updates",
+    "fedora-44-mpich",
+    "fedora-44-mpich-updates",
+}
+
+
+def repo_blocks(path: Path) -> dict[str, list[str]]:
+    """{repo name: its config lines} for every [repo] in the dnf.conf heredoc."""
+    blocks: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in path.read_text(encoding="utf-8").splitlines():
+        match = re.match(r"^\[([a-z0-9._-]+)\]\s*$", line)
+        if match:
+            current = match.group(1)
+            blocks[current] = []
+        elif current is not None:
+            if line.startswith("config_opts") or line.strip() == '"""':
+                current = None
+            else:
+                blocks[current].append(line)
+    return blocks
+
+
+def setting(lines: list[str], key: str) -> str | None:
+    for line in lines:
+        match = re.match(rf"^{key}=(.*)$", line.strip())
+        if match:
+            return match.group(1).strip()
+    return None
+
+
+HUMMINGBIRD = [p for p in CONFIGS if p.name.startswith("hummingbird-ci")]
+
+
+def test_the_hummingbird_configs_are_present():
+    """A glob that silently stops matching passes forever."""
+    assert len(HUMMINGBIRD) == 2, [p.name for p in HUMMINGBIRD]
+
+
+@pytest.mark.parametrize("path", HUMMINGBIRD, ids=lambda p: p.name)
+def test_local_build_never_caches_its_metadata(path):
+    """THE assertion. local-build grows as the chain builds; caching its
+    metadata makes a package built moments ago invisible to the next one."""
+    local = repo_blocks(path).get("local-build")
+    assert local is not None, f"{path.name} has no [local-build]"
+    assert setting(local, "metadata_expire") is None, (
+        f"{path.name}: [local-build] must inherit metadata_expire=0. The chain "
+        "resolves BuildRequires against this repo WHILE writing into it."
+    )
+
+
+@pytest.mark.parametrize("path", HUMMINGBIRD, ids=lambda p: p.name)
+def test_every_static_repo_has_an_expiry(path):
+    blocks = repo_blocks(path)
+    missing = [
+        name for name in sorted(STATIC)
+        if name in blocks and setting(blocks[name], "metadata_expire") is None
+    ]
+    assert not missing, (
+        f"{path.name}: {missing} re-fetch metadata for every package. "
+        "repo.tunaos.org is our own Cloudflare request budget."
+    )
+
+
+@pytest.mark.parametrize("path", HUMMINGBIRD, ids=lambda p: p.name)
+def test_the_published_index_is_covered(path):
+    """The one that actually costs money, named explicitly so a future edit
+    that drops it from STATIC still fails here."""
+    block = repo_blocks(path).get("tunaos-hummingbird")
+    assert block is not None, f"{path.name} has no [tunaos-hummingbird]"
+    assert "repo.tunaos.org" in "\n".join(block), (
+        "this test is pinned to the Cloudflare-served index; if the baseurl "
+        "moved, re-point it rather than deleting the assertion"
+    )
+    assert setting(block, "metadata_expire") is not None
+
+
+@pytest.mark.parametrize("path", HUMMINGBIRD, ids=lambda p: p.name)
+def test_no_file_url_repo_is_given_an_expiry(path):
+    """Generalises the local-build rule: a file:// repo is local, mutable and
+    free to read, so caching its metadata only ever costs correctness."""
+    for name, lines in repo_blocks(path).items():
+        baseurl = setting(lines, "baseurl") or ""
+        if baseurl.startswith("file://"):
+            assert setting(lines, "metadata_expire") is None, (
+                f"{path.name}: [{name}] is a local file:// repo and must not "
+                "cache metadata"
+            )


### PR DESCRIPTION
## ⏸ Hold until fan-out run [33142177991](https://github.com/tuna-os/tunaos-packages/actions/runs/33142177991) finishes

Editing `mock/*.cfg` triggers `build-mock-runner.yml`, which rebuilds and pushes the image and re-keys every cell. Run 4 is mid-flight.

## The problem

The Rawhide template these configs include sets `metadata_expire=0`, and nothing overrode it. `0` means dnf refuses to trust cached metadata **at all**, so every package build in every shard re-downloads `repomd.xml` and `primary.xml` from every enabled repo.

For `repo.tunaos.org` that is **our own Cloudflare Workers bill**. Every package resolves BuildRequires against the published index at priority 11, and mock runs each package in its own `--uniqueext` root: 673 packages × 2 arches × 5 bands, per fan-out run.

The account hit **76% of its 100,000/day request limit** on 2026-08-28 after four runs, with the reset 16 hours away and a run still building. Exhausting it takes the index offline, which fails every buildroot at once — and would look like a wave of package bugs.

## Why this is per-repo, not global

**`0` is correct for exactly one repo.** `[local-build]` is what the chain writes into *as it builds*, and `build-chain.sh`'s `MOCK_CACHE_ARGS` comment records the dependency: the shared root cache holds only the minimal buildroot, and *"BuildRequires resolve after the unpack against the live repos"* — true only while local-build's metadata is never cached. Give it an expiry and a package built sixty seconds ago goes invisible to the next one, surfacing as a resolution failure some tier later. **It keeps inheriting `0`.**

**Rawhide is deliberately left alone** — it is a rolling repo that genuinely changes mid-run.

The eight repos given `metadata_expire=6h` cannot change during a chain:

| repo | why static |
| --- | --- |
| `[hummingbird]` | fixed dated prefix |
| `[tunaos-hummingbird]` | our published index — changes only when a publish runs |
| `fedora-44-{python,perl,mpich}[-updates]` | F44 is a frozen release |

## Guards (9)

Two mutation-verified **in both directions**:

- adding `metadata_expire` to `[local-build]` → fails the assertion protecting the growing repo, *and* the `file://` generalisation of it;
- removing it from `[tunaos-hummingbird]` → fails both the static-repo sweep and the assertion naming the index that actually costs money.

Full suite: **1957 passed, 1 skipped**. Both configs still parse as Python.

## Not in scope

`yum_cache` is deliberately un-shared (see the same comment), so every BuildRequires **RPM** is also re-downloaded per package. Sharing it would cut far more traffic but risks the ENOSPC failure mode that comment warns about — that needs a measured disk-headroom run, not a guess.

---
_Generated by [Claude Code](https://claude.ai/code/session_015sZp9iEZAJS44joA2Z8mCK)_