### PR TITLE
fix(gnome51): rebase gsettings-desktop-schemas onto Rawhide's current spec

### DIFF
--- a/src/gnome-51/gsettings-desktop-schemas/gsettings-desktop-schemas.spec
+++ b/src/gnome-51/gsettings-desktop-schemas/gsettings-desktop-schemas.spec
@@ -4,15 +4,29 @@
 
 Name:           gsettings-desktop-schemas
 Version:        51~beta
-Release:        1%{?dist}
+# Rawhide fork: adopt %%autorelease like our other src/gnome-51 packages
+# (xdg-desktop-portal, gnome-desktop3, ptyxis, vte291, gobject-introspection)
+# instead of the stale hand-bumped Release: 1%%{?dist}.
+Release:        %autorelease
 Summary:        A collection of GSettings schemas
 
 License:        LGPL-2.1-or-later
 # no homepage exists for this component
 URL:            https://gitlab.gnome.org/GNOME/gsettings-desktop-schemas
 Source0:        https://download.gnome.org/sources/%{name}/51/%{name}-%{tarball_version}.tar.xz
+# RHEL/EL10 default-font override (font-name, document-font-name,
+# monospace-font-name in org.gnome.desktop.interface). This isn't a
+# hummingbird-local invention -- it matches Fedora's own rawhide spec
+# byte-for-byte, including the %{?rhel} >= 10 install guard below. Verified
+# the three keys are unrenamed/unmoved in gsettings-desktop-schemas 51
+# (checked schemas/org.gnome.desktop.interface.gschema.xml.in on the GNOME
+# gsettings-desktop-schemas main branch), so kept as-is.
 Source1:        org.gnome.desktop.interface.rhel.gschema.override
 
+# Rawhide's own spec replaces this block with a bare "%%gnome_check_version"
+# macro call. We don't have that macro (or %%gnome_major_version /
+# %%gnome_tarball_version) verified in the hummingbird-ci buildroot, so -- same
+# as our other src/gnome-51 forks -- we keep BuildRequires explicit instead.
 BuildRequires:  gcc
 BuildRequires:  gettext
 BuildRequires:  glib2-devel >= 2.31.0
@@ -49,27 +63,16 @@ and header files for developing applications that use %{name}.
 
 
 %build
-meson setup _build \
-    --buildtype=plain \
-    --prefix=%{_prefix} \
-    --libdir=%{_libdir} \
-    --libexecdir=%{_libexecdir} \
-    --bindir=%{_bindir} \
-    --sbindir=%{_sbindir} \
-    --includedir=%{_includedir} \
-    --datadir=%{_datadir} \
-    --mandir=%{_mandir} \
-    --infodir=%{_infodir} \
-    --localedir=%{_datadir}/locale \
-    --sysconfdir=%{_sysconfdir} \
-    --localstatedir=%{_localstatedir} \
-    --sharedstatedir=%{_sharedstatedir} \
-    --wrap-mode=nodownload \
-    -Dintrospection=true
-ninja -C _build -j%{_smp_build_ncpus}
+# Rawhide fork: use the standard %%meson/%%meson_build macros (same pattern
+# already verified working for xdg-desktop-portal and gobject-introspection
+# in this repo) instead of the hand-rolled meson setup + ninja invocation.
+# -Dintrospection=true is dropped because it's the meson_options.txt default
+# upstream (verified against GNOME gsettings-desktop-schemas main branch).
+%meson
+%meson_build
 
 %install
-DESTDIR=%{buildroot} ninja -C _build install
+%meson_install
 
 %if 0%{?rhel} && 0%{?rhel} >= 10
 cp %{SOURCE1} $RPM_BUILD_ROOT%{_datadir}/glib-2.0/schemas


### PR DESCRIPTION
## Summary

`src/gnome-51/gsettings-desktop-schemas/gsettings-desktop-schemas.spec` was
already pinned to the right upstream version (`51~beta`), but the packaging
plumbing had quietly drifted from Fedora Rawhide's current spec the same way
xdg-desktop-portal and flatpak had earlier this session:

- `Release: 1%{?dist}` (hand-bumped) instead of `%autorelease`.
- A verbose hand-rolled `meson setup ... && ninja -C _build` build/install
  sequence that predates the `%meson` / `%meson_build` / `%meson_install`
  macro family Rawhide's spec has since collapsed onto — the same pattern
  already adopted for xdg-desktop-portal and gobject-introspection in this
  repo.

## What changed

- `Release:` -> `%autorelease` (matches xdg-desktop-portal, gnome-desktop3,
  ptyxis, vte291, gobject-introspection).
- `%build`/`%install` -> `%meson` / `%meson_build` / `%meson_install`.
  Dropped the explicit `-Dintrospection=true` flag since it's the
  `meson_options.txt` default upstream (verified against GNOME
  gsettings-desktop-schemas' current schemas/meson_options.txt).

## What I deliberately did NOT change

- Rawhide's spec replaces the explicit `BuildRequires` block with a bare
  `%gnome_check_version` macro call (which also defines
  `%gnome_major_version` / `%gnome_tarball_version`). We don't have that
  macro verified against the hummingbird-ci buildroot, and none of our other
  src/gnome-51 forks (gnome-desktop3, ptyxis, vte291) use it either — they
  all keep an explicit `BuildRequires: gcc` and a hand-defined
  `%global tarball_version`. Kept consistent with that house convention
  rather than introducing a new, unverified macro dependency.
- `org.gnome.desktop.interface.rhel.gschema.override` (overrides
  `font-name`, `document-font-name`, `monospace-font-name`) — this is not
  hummingbird-local drift. It matches Fedora's own rawhide spec
  byte-for-byte, including the `%{?rhel} >= 10` install guard. Verified the
  three schema keys are still present and unrenamed in
  `schemas/org.gnome.desktop.interface.gschema.xml.in` on the GNOME
  gsettings-desktop-schemas main branch (GNOME 51 dev cycle), so left as-is.

## Test plan

- [x] Diffed our spec against a freshly-fetched
  `https://src.fedoraproject.org/rpms/gsettings-desktop-schemas/raw/rawhide/f/gsettings-desktop-schemas.spec`
  line by line (version, Release, BuildRequires, %build/%install, %files,
  %changelog).
- [x] Verified with a real local build:
  `./scripts/build-chain.sh --manifest build-order-hummingbird-desktops.yml
  --backend podman --image ghcr.io/tuna-os/mock-runner:centos-stream-10
  --mock-config hummingbird-ci --package src/gnome-51/gsettings-desktop-schemas
  --with-checks` — built clean through all 22 tiers; `%check`'s
  `glib-compile-schemas --dry-run --strict` passed; both the base and
  `-devel` RPMs were produced.
- [x] Confirmed the RHEL font override correctly stays uninstalled on
  hummingbird's own Fedora-style buildroot (no `%rhel` macro defined there),
  matching upstream Fedora behavior on non-RHEL targets.
- [x] Ran the spec-related test suite (`test_spec_comments_do_not_open_a_section`,
  `test_no_spec_mixes_manual_and_auto_changelog`,
  `test_changelog_text_does_not_expand_as_macros`,
  `test_license_tags_are_valid_spdx_refs`, `test_check_bcond_args`,
  `test_gnome_sources_are_fetchable`, `test_source_paths_cover_the_build_order`)
  plus the full suite. The only failures are pre-existing issues in freshly
  distgit-imported `src/hummingbird/*` packages (anaconda, hplip, mdadm,
  pykickstart, signon-plugin-oauth2, firefox, gtk2, etc.) and a
  missing-`dpkg-deb`-in-this-sandbox tideforge test — unrelated to this
  change, nothing involving gsettings-desktop-schemas failed.

---
_Generated by [Claude Code](https://claude.ai/code)_