### PR TITLE
fix(gnome51): re-fork gnome-online-accounts against Rawhide's current spec

### DIFF
--- a/src/gnome-51/gnome-online-accounts/gnome-online-accounts.spec
+++ b/src/gnome-51/gnome-online-accounts/gnome-online-accounts.spec
@@ -6,14 +6,23 @@
 
 Name:		gnome-online-accounts
 Version:	3.58.1
-Release:	1%{?dist}
+# Explicit numeric Release, not Rawhide's %%autorelease: this package's
+# Release convention was deliberately reset to N%%{?dist} in #521's GNOME 51
+# mass-bump (same as most of src/gnome-51/*), and staying consistent with
+# that sibling convention beats matching Rawhide on this one axis. Bumped to
+# 2 here: this rebase folds in #580's %%files fix, which never got its own
+# Release bump.
+Release:	2%{?dist}
 Summary:	Single sign-on framework for GNOME
 
 # Sources are LGPL-2.0-or-later, icons are CC-BY-SA-4.0.
 License:	LGPL-2.0-or-later AND CC-BY-SA-4.0
 URL:		https://wiki.gnome.org/Projects/GnomeOnlineAccounts
-Source0:	https://download.gnome.org/sources/%{name}/3.58/%{name}-%{version}.tar.xz
+Source0:	https://download.gnome.org/sources/%{name}/%{gnome_major_minor_version}/%{name}-%{version}.tar.xz
 
+# gcc: not in Rawhide's BuildRequires list, kept here for a real EL10/
+# hummingbird buildroot gap (see changelog, 2026-03-15) -- redundant at
+# worst on a Fedora-Rawhide-based chroot, zero-cost safety margin.
 BuildRequires:	gcc
 BuildRequires:	pkgconfig(dbus-1)
 BuildRequires:	pkgconfig(gcr-4)
@@ -75,12 +84,14 @@ The %{name}-devel package contains libraries and header files for
 developing applications that use %{name}.
 
 %prep
-%setup -q
+%autosetup -p1
 
 %build
 %meson \
 %if 0%{?flatpak}
   -Dgoabackend=false \
+  -Ddocumentation=false \
+  -Dman=false \
 %else
   -Dfedora=true \
 %endif
@@ -107,17 +118,18 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/org.gnome.OnlineAcco
 %{_prefix}/libexec/goa-identity-service
 %{_prefix}/libexec/goa-oauth2-handler
 %{_datadir}/applications/org.gnome.OnlineAccounts.OAuth2.desktop
-%{_datadir}/applications/org.gnome.goa-daemon.desktop
 %{_datadir}/dbus-1/services/org.gnome.OnlineAccounts.service
 %{_datadir}/dbus-1/services/org.gnome.Identity.service
 #%%{_datadir}/glib-2.0/schemas/org.gnome.online-accounts.gschema.xml
-%endif
 %{_datadir}/icons/hicolor/*/apps/goa-*.svg
-# data/icons/meson.build installs this one unconditionally too, but its name
-# does not match the goa-*.svg glob above (org.gnome.* prefix, not goa-).
-# Confirmed against gitlab.gnome.org/GNOME/gnome-online-accounts at tag
-# 3.58.1 -- an actual build otherwise fails with "Installed (but
-# unpackaged) file(s) found" for both this and the desktop file above.
+%endif
+# #580: data/meson.build and data/icons/meson.build install this desktop
+# file and symbolic icon with no surrounding `if enable_goabackend` at all
+# (only the goa-account-* icon variants are gated), so they exist even in a
+# flatpak build with goabackend disabled -- hence unconditional here, same
+# as Rawhide's current spec, rather than nested inside the block above like
+# our original #580 fix had them.
+%{_datadir}/applications/org.gnome.goa-daemon.desktop
 %{_datadir}/icons/hicolor/*/apps/org.gnome.goa-daemon-symbolic.svg
 
 %files libs
@@ -146,6 +158,20 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/org.gnome.OnlineAcco
 %{_datadir}/vala/
 
 %changelog
+* Fri Aug 28 2026 James Reilly <jreilly1821@gmail.com> - 3.58.1-2
+- Re-fork against Fedora Rawhide's current spec: Source0 now uses
+  %%{gnome_major_minor_version} instead of a hardcoded "3.58" path segment,
+  %%prep switched to %%autosetup -p1, and the flatpak %%build variant picks
+  up Rawhide's -Ddocumentation=false -Dman=false (not exercised by this
+  pipeline, kept for parity).
+- Moved #580's desktop-file/symbolic-icon %%files fix out of the
+  non-flatpak-only block to match Rawhide's now-unconditional placement --
+  Rawhide independently hit and fixed the same "Installed (but unpackaged)
+  file(s)" gap, and its fix is strictly broader (also correct for a
+  goabackend=false flatpak build, which ours was not).
+- Release bumped to -2: #580's %%files fix landed without ever bumping
+  Release off of -1.
+
 * Tue Aug 25 2026 James Reilly <jreilly1821@gmail.com> - 3.58.1-1
 - Update to 3.58.1 (GNOME 51 beta cycle)
 


### PR DESCRIPTION
## Summary

- Re-forked `src/gnome-51/gnome-online-accounts/gnome-online-accounts.spec` against a live fetch of Fedora Rawhide's current spec (src.fedoraproject.org/rpms/gnome-online-accounts, `rawhide` branch), diffed line by line rather than assuming the drift was only the already-known #580 gap.
- Version was already current (3.58.1 in both sides); every other difference was structural staleness:
  - `Source0` hardcoded the `3.58` download.gnome.org path segment — Rawhide parameterizes it as `%{gnome_major_minor_version}`. Confirmed the macro already resolves in our buildroot (34+ `src/hummingbird` distgit-import specs use it) and the verification build's log shows it expanding correctly.
  - `%prep` used `%setup -q` — switched to Rawhide's `%autosetup -p1` (future-proofs for patches we don't have yet).
  - The flatpak `%build` variant was missing Rawhide's `-Ddocumentation=false -Dman=false` (not exercised by this pipeline since `flatpak` is never set in `mock/hummingbird-ci.cfg`, kept for parity).
  - **#580's fix, preserved and improved**: our `%files` fix nested the desktop file and symbolic icon inside the non-flatpak `%if` block. Rawhide independently hit and fixed the identical "Installed (but unpackaged) file(s)" bug on its own spec, and placed its fix *unconditionally* — correctly, since `data/meson.build`/`data/icons/meson.build` install both files with no `if enable_goabackend` guard at all, so they exist even in a flatpak build with goabackend disabled. Adopted Rawhide's (strictly more correct) placement; #580's fix itself is preserved and still explicitly commented.
- Kept two genuine hummingbird-specific deltas rather than matching Rawhide: the `gcc` BuildRequires (real EL10 buildroot gap, changelogged since 2026-03-15), and the explicit numeric `Release` scheme instead of Rawhide's `%autorelease` — consistent with the convention #521's GNOME 51 mass-bump deliberately established across most of `src/gnome-51/*`. Release bumped 1 → 2, since #580's fix landed without ever bumping it.

## Test plan

- [x] Full diff of our spec vs. a freshly re-fetched live Rawhide spec, read completely (not assumed trivial)
- [x] `renovate.json`'s separate `src/deps/gnome-online-accounts` custom manager confirmed untouched
- [x] Real local build: `build-chain.sh --package src/gnome-51/gnome-online-accounts` against `build-order-hummingbird-desktops.yml`, `hummingbird-ci` mock config, podman+mock backend, dedicated empty `--local-repo`, `--with-checks` — built clean through all 22 tiers, producing 6 RPMs
- [x] `rpm -ql` on the built RPM confirms `org.gnome.goa-daemon.desktop` and `org.gnome.goa-daemon-symbolic.svg` are both packaged
- [x] Spec-scoped pytest (`test_no_spec_mixes_manual_and_auto_changelog`, `test_spec_comments_do_not_open_a_section`, `test_fetch_rawhide_specs`, `test_local_specs_use_fedora_cmake`): 1751 passed
- [x] Package-specific tests (`test_gnome_online_accounts_packages_the_goa_daemon_desktop_file`, `test_gnome_parity_gap`): 12 passed
- [x] Full `tests/` suite: 3368 passed, 7 failed — all pre-existing/environmental and unrelated to this package (missing `dpkg-deb`/`enchant` binaries, other distgit-imported specs' invalid SPDX LicenseRefs, a cosmic/dual-maintained-list drift from the just-completed distgit import, a worktree `.git`-file artifact in a canary-guard test)

---
_Generated by [Claude Code](https://claude.ai/code)_