### PR TITLE
docs(ptyxis): document the three genuine deltas from Rawhide's current spec

### DIFF
--- a/src/gnome-51/ptyxis/ptyxis.spec
+++ b/src/gnome-51/ptyxis/ptyxis.spec
@@ -5,6 +5,11 @@
 %global libadwaita_version 1.6
 %global libportal_gtk4_version 0.7.1
 
+# Genuine delta vs Rawhide: compute the tarball/major version ourselves
+# instead of relying on %%gnome_tarball_version / %%gnome_major_version
+# (defined by Fedora's redhat-rpm-config macros.gnome). Same output, no
+# dependency on an external macro file we don't control the availability
+# of on every buildroot this repo targets.
 %global tarball_version %%(echo %%{version} | tr '~' '.')
 %global major_version %%(echo %%{tarball_version} | cut -d "." -f 1)
 
@@ -16,6 +21,12 @@ Summary:	A container oriented terminal for GNOME
 License:	GPL-2.0-or-later AND GPL-3.0-or-later AND LGPL-3.0-or-later AND LGPL-2.0-or-later AND CC0-1.0
 URL:		https://gitlab.gnome.org/chergert/ptyxis
 Source0:	https://download.gnome.org/sources/%{name}/%{major_version}/%{name}-%{tarball_version}.tar.xz
+# Fedora branding-flavored gschema override (a11y on, dark theme by default).
+# Kept under its upstream Fedora name and installed byte-identical to
+# Rawhide's own Source1/%%files entries: its content isn't Fedora-branded
+# (no logos/colors, just sane defaults we also want), so renaming it would
+# only create a permanent divergence to re-reconcile on every future sync
+# for no functional gain.
 Source1:	org.gnome.Ptyxis.fedora.gschema.override
 
 BuildRequires:	pkgconfig(gio-unix-2.0) >= %{glib2_version}
@@ -26,6 +37,17 @@ BuildRequires:  pkgconfig(libportal-gtk4) >= %{libportal_gtk4_version}
 BuildRequires:	pkgconfig(json-glib-1.0) >= %{json_glib_version}
 BuildRequires:	desktop-file-utils
 BuildRequires:	gcc
+# Genuine delta vs Rawhide: msgfmt (from gettext) is pulled in transitively
+# on Fedora's own buildroot, but was added here deliberately in the
+# original EL10 fork (8e40c19: "provides msgfmt; implicit on Fedora, absent
+# on EL10") for a real observed gap on a real EL10 chroot. The active
+# hummingbird-ci config happens to be Rawhide-based today so the gap isn't
+# currently exercised, but this spec's own %check/%files don't guarantee
+# that stays true, and a missing msgfmt fails silently -- %find_lang just
+# emits an empty .lang file instead of erroring, so the build would still
+# go green while shipping zero translations. Same call this repo already
+# made for flatpak's redundant gcc/gcc-c++ BRs: zero-cost to keep, real
+# cost to drop and be wrong.
 BuildRequires:	gettext
 BuildRequires:	itstool
 BuildRequires:	meson
@@ -43,13 +65,28 @@ support for user profiles.
 
 
 %prep
-# check for human errors
+# Genuine delta vs Rawhide: same check %%gnome_check_version performs
+# (alpha/beta/rc must use a tilde, not a dot, in Version), spelled out so
+# %%prep doesn't depend on macros.gnome being present -- see the
+# tarball/major_version comment above for why we don't lean on that file.
 if [ `echo "%{version}" | grep -cE "\.alpha|\.beta|\.rc"` = "1" ]; then echo "Error: Use tilde in Version field in front of alpha/beta/rc; checked '%{version}'" 1>&2; exit 1; fi
 
 %autosetup -p1 -n %{name}-%{tarball_version}
 
 
 %build
+# Genuine delta vs Rawhide: explicit meson invocation instead of the
+# %%meson/%%meson_build macros. This spec already did it this way before
+# this fork, matching the same fix applied to glib2, gjs and gtk4 in this
+# repo (see their %%changelog) after %%meson_build's internal job-control
+# (`fg`) tripped "fg: no job control" on non-interactive COPR builders.
+# xdg-desktop-portal went the other way and adopted %%meson_build cleanly
+# under our own mock+podman build-chain.sh, so that failure mode may be
+# COPR-specific rather than universal -- but the explicit form here is
+# already verified working end-to-end (real build, %%check passing), so
+# there's no reason to trade a working, portable build step for a macro
+# whose safety in every environment this repo might build under is
+# unconfirmed.
 meson setup --prefix=%{_prefix} --libdir=%{_libdir} --buildtype=plain build -Dgeneric=terminal
 meson compile -C build
 


### PR DESCRIPTION
## Summary

Part of the ongoing audit of `src/gnome-51/` hand-maintained forks against
live Fedora Rawhide (same pattern as the xdg-desktop-portal and flatpak
fixes this session). Unlike those two, **ptyxis has no functional drift to
fix** — it's already at Rawhide's current version (50.1) and the diff
against the live spec (`src.fedoraproject.org/rpms/ptyxis/raw/rawhide/f/ptyxis.spec`)
is exactly four hunks, all of which turned out to be deliberate choices
this spec already made rather than staleness:

- **Manual `tarball_version`/`major_version` globals** instead of Rawhide's
  `%gnome_tarball_version`/`%gnome_major_version` (from Fedora's
  `redhat-rpm-config` macros.gnome). Kept — same output, but doesn't
  depend on an external macro file whose availability isn't guaranteed on
  every buildroot this repo targets.
- **Manual alpha/beta/rc tilde check in `%prep`** instead of
  `%gnome_check_version` (same macro file). Kept for the same reason.
- **Explicit `meson setup`/`meson compile`/`DESTDIR= meson install`**
  instead of `%meson`/`%meson_build`/`%meson_install`. This repo already
  made the same call for glib2, gjs and gtk4 after `%meson_build`'s
  internal job-control tripped `fg: no job control` on non-interactive
  COPR builders. (xdg-desktop-portal adopted the macros cleanly under our
  own mock+podman `build-chain.sh` in a separate PR this session, so the
  failure mode may be COPR-specific rather than universal — but the
  explicit form here is already verified working, so there's no reason to
  swap a working step for an unconfirmed one.)
- **`BuildRequires: gettext`**, which Rawhide's spec doesn't carry. Added
  deliberately in the original EL10 fork (`8e40c19`): "provides msgfmt;
  implicit on Fedora, absent on EL10." `hummingbird-ci` happens to be
  Fedora-Rawhide-based today so the gap isn't currently exercised, but a
  missing `msgfmt` fails *silently* — `%find_lang` just emits an empty
  `.lang` file instead of erroring, so the build would stay green while
  shipping zero translations. Same call this repo already made keeping
  flatpak's redundant `gcc`/`gcc-c++` BRs: zero-cost to keep, real cost to
  drop and be wrong.

Also reviewed `org.gnome.Ptyxis.fedora.gschema.override` (a11y-on,
dark-theme-by-default) for a hummingbird-specific rename. **Left it as-is**
— its content isn't Fedora-branded despite the name, it's installed
byte-identical to Rawhide's own `Source1`/`%files` entries, and renaming it
would only create a permanent divergence to reconcile on every future sync
for no functional gain.

**Net effect: comments only, no behavioral change.** This documents *why*
each delta exists so the next drift-audit cycle doesn't have to
re-investigate the same four hunks from scratch.

## Test plan

- [x] Diffed our spec against the live Rawhide spec (`curl -s
      https://src.fedoraproject.org/rpms/ptyxis/raw/rawhide/f/ptyxis.spec`)
      and against the original EL10 fork commit (`8e40c19`) to confirm the
      intent behind each delta.
- [x] Real local build: `build-chain.sh --manifest
      build-order-hummingbird-desktops.yml --backend podman --image
      ghcr.io/tuna-os/mock-runner:centos-stream-10 --mock-config
      hummingbird-ci --package src/gnome-51/ptyxis --with-checks` against a
      dedicated `--local-repo`. `ptyxis-50.1-1.fc43` built clean in ~6.5
      minutes, `%check` (appstream-util + desktop-file-validate) passed.
- [x] `rpm -qlp` on the resulting RPM confirms
      `org.gnome.Ptyxis.fedora.gschema.override` and all 37 upstream
      `.mo` locale files are present (validates the `gettext` BR decision).
- [x] Spec-quality pytest subset (comment placement, changelog
      macro-escaping, license refs, bcond args, gap-drift) — 914 passed,
      1 deselected, 0 failed for the changed file.
- [x] Full local pytest suite — 1768 passed, 2 pre-existing failures
      unrelated to this change (macro-escaping and license-ref checks
      against freshly distgit-imported `src/hummingbird/*` specs, not
      touched here).

---
_Generated by [Claude Code](https://claude.ai/code)_