### PR TITLE
fix(gnome51): drop vte291's stale hand-rolled meson build in favor of Rawhide's macros

### DIFF
--- a/src/gnome-51/vte291/vte291.spec
+++ b/src/gnome-51/vte291/vte291.spec
@@ -18,8 +18,6 @@
 %bcond bundled_fast_float 0
 %endif
 
-%global major_minor_version %%(echo %%{version} | cut -d "." -f 1-2)
-
 Name:           vte291
 Version:        0.84.1
 Release:        %autorelease
@@ -29,7 +27,7 @@ Summary:        GTK terminal emulator library
 License:        GPL-3.0-or-later AND LGPL-3.0-or-later AND MIT AND X11 AND CC-BY-4.0
 
 URL:            https://wiki.gnome.org/Apps/Terminal/VTE
-Source0:        https://download.gnome.org/sources/vte/%{major_minor_version}/vte-%{version}.tar.xz
+Source0:        https://download.gnome.org/sources/vte/%{gnome_major_minor_version}/vte-%{version}.tar.xz
 
 BuildRequires:  pkgconfig(fmt) >= %{fmt_version}
 BuildRequires:  pkgconfig(fribidi) >= %{fribidi_version}
@@ -155,11 +153,11 @@ rm -rf subprojects/
 %endif
 
 %build
-meson setup --prefix=%{_prefix} --libdir=%{_libdir} --buildtype=plain build -Ddocs=true -Dgtk3=true -Dgtk4=true
-meson compile -C build
+%meson --buildtype=plain -Ddocs=true -Dgtk3=true -Dgtk4=true
+%meson_build
 
 %install
-DESTDIR=%{buildroot} meson install -C build
+%meson_install
 rm %{buildroot}/%{_datadir}/applications/org.gnome.Vte.App.Gtk3.desktop
 rm %{buildroot}/%{_datadir}/applications/org.gnome.Vte.App.Gtk4.desktop
 


### PR DESCRIPTION
## Summary

Fedora Rawhide's `vte291.spec` and our `src/gnome-51/vte291/vte291.spec` were already at the same version (0.84.1), so it was tempting to assume they matched -- they didn't, quite. A full line-by-line diff against a freshly re-fetched live Rawhide spec found exactly three lines of drift, all in the same family:

- A hand-defined `%global major_minor_version %%(echo %%{version} | cut -d "." -f 1-2)` used only to build `Source0`, where Rawhide's spec relies on the system-provided `%gnome_major_minor_version` macro instead.
- A hand-rolled `%build`:
  ```
  meson setup --prefix=%{_prefix} --libdir=%{_libdir} --buildtype=plain build -Ddocs=true -Dgtk3=true -Dgtk4=true
  meson compile -C build
  ```
  where Rawhide now uses `%meson --buildtype=plain -Ddocs=true -Dgtk3=true -Dgtk4=true` / `%meson_build`.
- A hand-rolled `%install`: `DESTDIR=%{buildroot} meson install -C build` where Rawhide uses `%meson_install`.

Everything else -- Version, `%autorelease`, every `BuildRequires`/`Requires`, all five `%files` sections, package splits/descriptions, licenses, and `%changelog` (bare `%autochangelog`) -- was already byte-identical to Rawhide.

### Why this was staleness, not a genuine EL10 need

Traced with `git log --diff-filter=A` and `git log -p`: this file was created by copying gnome-50's `vte291.spec` "mirroring gnome-50 structure" (#320), which itself carries the same manual `major_minor_version` global and manual meson invocation, which in turn traces back to gnome-49's original fork (which didn't even have the macro -- it hardcoded `0.82` directly in `Source0`). None of the three forks added a comment explaining an EL10-specific reason for avoiding the macros.

That theory needed a real test, because `%gnome_major_minor_version`/`%meson`/`%meson_build`/`%meson_install` could plausibly be Fedora-only macros missing from the CentOS-Stream-10-image mock buildroot this repo targets. Two checks ruled that out:

1. Every other gnome-51 spec that calls meson (gjs, glib2, gnome-online-accounts, gobject-introspection, gtk4, orca, xdg-desktop-portal) already uses `%meson`/`%meson_build`/`%meson_install` successfully in this exact `hummingbird-ci` mock config.
2. `mock/hummingbird-ci.cfg`'s own header documents that the buildroot base was deliberately moved from an F43-alike image to Rawhide itself, specifically because Rawhide is "the correct base for everything" the desktop stack needs (only Python/Perl/systemd get pinned exceptions, none of which touch this macro family).

Same fix pattern already applied to `xdg-desktop-portal` and `flatpak` this session.

## What changed

- Removed the `%global major_minor_version ...` line.
- `Source0` now uses `%{gnome_major_minor_version}` (matches Rawhide).
- `%build`/`%install` now use `%meson`/`%meson_build`/`%meson_install` (matches Rawhide).

No version bump, no patches added or removed, `sources` file untouched (already matches Rawhide's sha512 for `vte-0.84.1.tar.xz`). `renovate.json`'s existing `src/gnome-51/vte291/vte291.spec` custom manager only matches the `Version:` line, which this PR doesn't touch, so no renovate changes needed. (The separate `src/deps/vte291` custom manager, for the unrelated `src/deps/vte291/vte291.spec` file, was left alone as instructed.)

## Test plan

- [x] Re-fetched Rawhide's live spec (`curl .../rpms/vte291/raw/rawhide/f/vte291.spec`) and confirmed it's byte-identical to the pre-staged reference copy, then diffed it against ours line by line (version, Release, BuildRequires, Requires, %files, %changelog all already matched).
- [x] Real local build: `scripts/build-chain.sh --manifest build-order-hummingbird-desktops.yml --backend podman --image ghcr.io/tuna-os/mock-runner:centos-stream-10 --mock-config hummingbird-ci --local-repo .../verify/artifacts --package src/gnome-51/vte291 --with-checks` -- exit 0, 22 tiers processed, 1 package built, 11 RPMs produced (`vte291`, `-gtk4`, `-devel`, `-gtk4-devel`, `vte-profile`, plus debuginfo/debugsource), confirming `%meson_build`/`%meson_install`/`%gnome_major_minor_version` all resolve cleanly in this buildroot.
- [x] `python3 -m pytest tests/` spec-focused subset (changelog ordering, fedora-cmake usage, spec-comment escaping, renovate vendored-pin guard, gap-drift reporting, rawhide-spec fetch) -- 1764 passed, 1 skipped.
- [x] Full `python3 -m pytest tests/` -- 3368 passed, 2 skipped, 7 pre-existing failures unrelated to vte291 (confirmed identical failure set exists on the unmodified branch via `git stash`): a worktree-local `.git/canary-guard-changed.txt` path collision, a stale `DUAL_MAINTAINED` package list, missing `dpkg-deb` binary in this environment, and pre-existing spec-lint findings in unrelated distgit-imported `src/hummingbird/*` files (anaconda, hplip, mdadm, pykickstart, libnotify, firefox, game-music-emu, gstreamer1-plugins-bad-free, gtk2, etc.).

---
_Generated by [Claude Code](https://claude.ai/code)_