### PR TITLE
fix(gnome51): fork gnome-desktop3 from Rawhide's current spec, fix stale gtk4 floor

### DIFF
--- a/src/gnome-51/gnome-desktop3/gnome-desktop3.spec
+++ b/src/gnome-51/gnome-desktop3/gnome-desktop3.spec
@@ -17,8 +17,10 @@
 #     rebased forks), so they are not assumed present in the hummingbird-ci
 #     buildroot. We keep our own %%{tarball_version} global instead.
 #   - -Dlegacy_library=false (drops the gtk3-era libgnome-desktop-3.so and
-#     its gtk3 runtime dependency -- hummingbird's desktop stack is GTK4-only
-#     and EL10 does not carry the gtk3 stack this library would need).
+#     its gtk3 runtime dependency -- per af46f91, hummingbird's desktop
+#     stack is GTK4-only and does not want this library, regardless of
+#     whether gtk3 itself is otherwise present in the tree for other
+#     consumers).
 #   - %files trimmed to match what legacy_library=false actually builds
 #     (this is the #580 fix -- see the comment above %files for the story).
 

--- a/src/gnome-51/gnome-desktop3/gnome-desktop3.spec
+++ b/src/gnome-51/gnome-desktop3/gnome-desktop3.spec
@@ -1,10 +1,32 @@
+# Forked from Fedora Rawhide's gnome-desktop3.spec (fetched 2026-08-28) to
+# stop this file from silently drifting the way it had: the gtk4 floor below
+# had rotted to 4.4.0 against upstream's actual >= 4.12.0 (verified against
+# gnome-desktop's own meson.build at the 51.alpha tag we build), the same
+# class of bug #580 fixed in gtk4.spec/libadwaita.spec. Rawhide's build and
+# install steps now use the standard %%meson/%%meson_build/%%meson_install
+# macros (already proven working in this repo's hummingbird-ci mock config
+# by the xdg-desktop-portal fork) instead of a hand-rolled meson invocation,
+# so we adopt that structure too.
+#
+# Hummingbird-specific deltas kept on top of Rawhide's structure, each
+# commented at its point of use below:
+#   - No use of the %%gnome_check_version / %%{gnome_major_version} /
+#     %%{gnome_tarball_version} macros.
+#     Nothing else in this repo's gnome-51 tree uses those macros (checked:
+#     zero hits across src/gnome-51/*/*.spec, including the other already-
+#     rebased forks), so they are not assumed present in the hummingbird-ci
+#     buildroot. We keep our own %%{tarball_version} global instead.
+#   - -Dlegacy_library=false (drops the gtk3-era libgnome-desktop-3.so and
+#     its gtk3 runtime dependency -- hummingbird's desktop stack is GTK4-only
+#     and EL10 does not carry the gtk3 stack this library would need).
+#   - %files trimmed to match what legacy_library=false actually builds
+#     (this is the #580 fix -- see the comment above %files for the story).
+
 %global gdk_pixbuf2_version               2.36.5
-%global gtk3_version                      3.3.6
-%global gtk4_version                      4.4.0
+%global gtk4_version                      4.12.0
 %global glib2_version                     2.53.0
 %global gsettings_desktop_schemas_version 3.27.0
 %global po_package                        gnome-desktop-3.0
-%global _localedir                        %{_datadir}/locale
 
 %global tarball_version %%(echo %{version} | tr '~' '.')
 
@@ -27,6 +49,10 @@ BuildRequires: pkgconfig(gio-2.0) >= %{glib2_version}
 BuildRequires: pkgconfig(glib-2.0) >= %{glib2_version}
 BuildRequires: pkgconfig(gobject-introspection-1.0)
 BuildRequires: pkgconfig(gsettings-desktop-schemas) >= %{gsettings_desktop_schemas_version}
+# No pkgconfig(gtk+-3.0) BuildRequires: -Dlegacy_library=false below makes
+# gtk3_dep non-required in gnome-desktop's own meson.build, and the gtk3-only
+# library it would build is exactly what hummingbird does not want (see the
+# top-of-file note).
 BuildRequires: pkgconfig(gtk4) >= %{gtk4_version}
 BuildRequires: pkgconfig(iso-codes)
 BuildRequires: pkgconfig(libseccomp)
@@ -68,6 +94,8 @@ developing applications that use %{name}.
 %package -n gnome-desktop4
 Summary: Library with common API for various GNOME modules
 License: GPL-2.0-or-later AND LGPL-2.0-or-later
+# Depend on base package for translations, help, and version.
+Requires: %{name}%{?_isa} = %{version}-%{release}
 
 %description -n gnome-desktop4
 gnome-desktop4 contains the libgnome-desktop library.
@@ -98,31 +126,11 @@ the functionality of the installed %{name} package.
 %autosetup -p1 -n gnome-desktop-%{tarball_version}
 
 %build
-mkdir -p redhat-linux-build
-meson setup \
-    --prefix=%{_prefix} \
-    --libdir=%{_libdir} \
-    --libexecdir=%{_libexecdir} \
-    --bindir=%{_bindir} \
-    --sbindir=%{_sbin} \
-    --includedir=%{_includedir} \
-    --datadir=%{_datadir} \
-    --mandir=%{_mandir} \
-    --infodir=%{_infodir} \
-    --localedir=%{_localedir} \
-    --sysconfdir=%{_sysconfdir} \
-    --localstatedir=%{_localstatedir} \
-    --sharedstatedir=%{_sharedstatedir} \
-    --wrap-mode=nodownload \
-    --buildtype=plain \
-    -Dgtk_doc=true -Dinstalled_tests=true \
-    -Dlegacy_library=false \
-    redhat-linux-build
-
-ninja -C redhat-linux-build %{?_smp_mflags} -v
+%meson -Dgtk_doc=true -Dinstalled_tests=true -Dlegacy_library=false
+%meson_build
 
 %install
-DESTDIR=%{buildroot} ninja -C redhat-linux-build install
+%meson_install
 
 %find_lang %{po_package} --all-name --with-gnome
 
@@ -136,9 +144,14 @@ DESTDIR=%{buildroot} ninja -C redhat-linux-build install
 # every NON-rhel target (this spec's own hummingbird-ci mock config among
 # them), where legacy_library is equally false. Confirmed by an actual
 # build: `error: Directory not found: .../usr/libexec/gnome-desktop-debug`.
+# For the same reason, this package also carries none of the legacy 3.x
+# runtime files (libgnome-desktop-3.so.*, its typelib) that Rawhide's
+# upstream spec ships -- they are never built here either.
 
 %files devel
-%{_datadir}/gtk-doc/html/gnome-desktop3/
+%dir %{_datadir}/gtk-doc/
+%dir %{_datadir}/gtk-doc/html/
+%doc %{_datadir}/gtk-doc/html/gnome-desktop3/
 
 %files -n gnome-desktop4
 %doc AUTHORS NEWS README.md

--- a/tests/test_gnome_desktop3_gtk4_floor_matches_upstream.py
+++ b/tests/test_gnome_desktop3_gtk4_floor_matches_upstream.py
@@ -1,0 +1,50 @@
+"""gnome-desktop3's gtk4 floor must not go stale again.
+
+gnome-desktop3.spec pinned gtk4_version=4.4.0. gnome-desktop's own meson.build
+at the exact tag this spec builds -- 51.alpha, not main, which can drift --
+declares:
+
+    gtk4_req = '>= 4.12.0'
+
+(fetched from gitlab.gnome.org/GNOME/gnome-desktop at tag 51.alpha). 4.4.0 was
+low enough to be satisfied by nearly any gtk4 build in this repo's history,
+so the BuildRequires never caught a too-old gtk4 -- exactly the same class of
+bug #580's sibling fix (0e716e7, "gtk4 and libadwaita declared floors below
+what they need") found and fixed in gtk4.spec and libadwaita.spec. That fix
+did not touch gnome-desktop3.spec, so its own floor kept the stale number.
+
+This mirrors test_gtk4_and_libadwaita_floors_match_upstream.py's shape:
+one test pins the real floor, one test pins the exact stale value gone for
+good (mutation-verified -- reverting to 4.4.0 turns it red).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SPEC = ROOT / "src/gnome-51/gnome-desktop3/gnome-desktop3.spec"
+
+
+def _global_version(spec: pathlib.Path, name: str) -> tuple[int, ...]:
+    text = spec.read_text(encoding="utf-8")
+    match = re.search(rf"^%global {re.escape(name)}\s+([0-9.]+)", text, re.MULTILINE)
+    assert match, f"no %global {name} in {spec}"
+    return tuple(int(part) for part in match.group(1).split("."))
+
+
+def test_gnome_desktop3_declares_gtk4s_real_floor():
+    assert _global_version(SPEC, "gtk4_version") >= (4, 12, 0), (
+        "gnome-desktop's own meson.build at tag 51.alpha requires gtk4 >= "
+        "4.12.0 (gtk4_req = '>= 4.12.0') -- a lower floor here is satisfiable "
+        "by an older gtk4 than this release actually needs"
+    )
+
+
+def test_the_previously_stale_floor_is_gone():
+    text = SPEC.read_text(encoding="utf-8")
+    assert "%global gtk4_version                      4.4.0" not in text, (
+        "gnome-desktop3.spec regressed to the stale gtk4_version=4.4.0 that "
+        "let a too-old gtk4 satisfy the BuildRequires"
+    )


### PR DESCRIPTION
## Summary

- Forked `src/gnome-51/gnome-desktop3/gnome-desktop3.spec` from Fedora Rawhide's current live spec (fetched 2026-08-28) instead of continuing to hand-maintain a copy that had silently drifted.
- Fixed a real stale-floor bug: `gtk4_version` was pinned at `4.4.0`. gnome-desktop's own `meson.build` at the exact tag we build (`51.alpha`) declares `gtk4_req = '>= 4.12.0'` (verified live against gitlab.gnome.org/GNOME/gnome-desktop), matching what Rawhide's own spec already carries. This is the same class of bug #580's sibling fix (0e716e7) caught in `gtk4.spec`/`libadwaita.spec`, but that fix never touched `gnome-desktop3.spec`.
- Adopted Rawhide's `%meson`/`%meson_build`/`%meson_install` macros in place of the hand-rolled `meson setup` + bare `ninja -C redhat-linux-build` invocation (pre-macro Fedora packaging style) — the same swap already proven working in this repo's hummingbird-ci mock config by the xdg-desktop-portal fork.
- Kept our genuine hummingbird-specific deltas, each commented at its point of use:
  - `-Dlegacy_library=false` (hummingbird's desktop stack is GTK4-only; drops the gtk3-era `libgnome-desktop-3.so` and its gtk3 runtime dependency that Rawhide's own spec still builds).
  - The #580 `%files` fix: `gnome-desktop-debug` is never produced because `legacy_library=false` is unconditional, so it must never be listed — this gap doesn't exist upstream since Rawhide never disables `legacy_library`.
  - Our own `%{tarball_version}` global instead of Rawhide's `%gnome_check_version` / `%{gnome_major_version}` / `%{gnome_tarball_version}` macros — zero other specs in `src/gnome-51/*/*.spec` use those macros, including the other already-rebased forks, so they aren't assumed present in the hummingbird-ci buildroot.
- Dropped the now-unused `gtk3_version` global and adopted Rawhide's `Requires: %{name}%{?_isa} = %{version}-%{release}` on `gnome-desktop4` so it correctly pulls in the base package's translations/help/version.
- Added `tests/test_gnome_desktop3_gtk4_floor_matches_upstream.py`, mirroring `test_gtk4_and_libadwaita_floors_match_upstream.py`'s shape — mutation-verified against the exact stale `4.4.0` value.

## How this was found and fixed

First local build attempt failed at the SRPM stage:

```
error: line 6: Unknown tag:   CFLAGS="${CFLAGS:--O2 -flto=auto...
```

RPM expands macros inside preamble `#` comments, and my own top-of-file comment named `%meson`/`%meson_build`/`%meson_install` unescaped — the same class of bug `tests/test_spec_comments_do_not_open_a_section.py` guards against, just with a *defined* multi-line macro instead of an undefined section keyword. Escaped every macro mentioned in that comment (`%%meson`, `%%gnome_check_version`, etc.) and reran clean.

## Build result

Real local build via `build-chain.sh --package src/gnome-51/gnome-desktop3` (podman+mock backend, `hummingbird-ci` mock config, `--with-checks`) produced all 9 expected RPMs: `gnome-desktop3`, `-devel`, `-tests`, `-debuginfo`, `-debugsource`, `gnome-desktop4`, `-devel`, and two more `-debuginfo` splits.

`rpm -qlp` on the artifacts confirms:
- `gnome-desktop3` (base) carries only lang/doc/license files — no legacy 3.x library, matching #580.
- `gnome-desktop3-devel` carries the gtk-doc html under the same `%{_datadir}/gtk-doc/html/gnome-desktop3/` path as before (the `%doc` keyword did not relocate it).
- `gnome-desktop4` / `gnome-desktop4-devel` carry the full expected library/header/gir set, including the QR libraries GNOME 51 added.
- `gnome-desktop4`'s new `Requires` resolves to `gnome-desktop3(x86-64) = 51~alpha-1.fc43` as intended.

Neither spec has a `%check` section, so `--with-checks` was a no-op here — no claim that `%check` ran.

I was not able to retrieve the actual expanded `meson setup` command line from mock's `build.log` (the podman container's temp builddir is not retained after a successful build), so I can't directly confirm whether `%meson`'s `--auto-features=enabled` flips the `systemd`/`udev` meson features from `auto` to hard-required relative to the old hand-rolled invocation. The build succeeded either way, and Rawhide's spec (our base) has the identical gap, so no new BuildRequires was added speculatively — flagging this as a known unknown rather than asserting it's fine.

Full test suite: 3364 passed, 6 failed, 2 skipped, 1 deselected. All 6 failures are unrelated to this change — 4 are pre-existing scans over packages newly landed by this session's `src/hummingbird/` distgit import (anaconda changelog macros, libnotify docbook stylesheet, firefox/gtk2 SPDX license refs, the cosmic/niri dual-maintained list), and 2 are tideforge deb-packaging tests failing on `dpkg-deb` missing from this host (same class of unrelated failure #567/0e716e7 both noted). One test was deselected (`test_the_flag_actually_removes_the_full_chain`): it writes into `.git/`, which is a file, not a directory, in a worktree checkout — unrelated to this change.

## Test plan

- [x] `tests/test_gnome_desktop3_gtk4_floor_matches_upstream.py` — new, mutation-verified
- [x] `tests/test_gnome_desktop3_does_not_package_the_disabled_legacy_library.py` — still passes (#580 fix preserved)
- [x] `tests/test_spec_comments_do_not_open_a_section.py`, `test_no_spec_mixes_manual_and_auto_changelog.py`, `test_local_specs_use_fedora_cmake.py` — still pass
- [x] Real local build via `build-chain.sh` against `hummingbird-ci` mock config: all 9 RPMs produced, file manifests verified with `rpm -qlp`
- [x] Full `pytest` suite run; all failures independently confirmed unrelated

---
_Generated by [Claude Code](https://claude.ai/code)_