### PR TITLE
fix(gnome51): fork gnome-session from current Rawhide, drop stale globals

### DIFF
--- a/src/gnome-51/gnome-session/gnome-session.spec
+++ b/src/gnome-51/gnome-session/gnome-session.spec
@@ -1,18 +1,28 @@
-%global major_version 51
-%global tarball_version 51.beta
 %define po_package gnome-session
 
 Name:           gnome-session
 Version:        51~beta
-Release:        1%{?dist}
+Release:        %autorelease
 Summary:        GNOME session manager
 
 License:        GPL-2.0-or-later
 URL:            https://gitlab.gnome.org/GNOME/gnome-session
-Source:         https://download.gnome.org/sources/gnome-session/%{major_version}/%{name}-%{tarball_version}.tar.xz
+# %%{gnome_major_version}/%%{gnome_tarball_version}/%%gnome_check_version come
+# from /usr/lib/rpm/macros.d/macros.gnome, confirmed present in our own
+# hummingbird-ci (centos-stream-10) mock buildroot -- not Fedora-only, so we
+# use Rawhide's exact macros instead of re-deriving the same values locally.
+Source:         https://download.gnome.org/sources/%{name}/%{gnome_major_version}/%{name}-%{gnome_tarball_version}.tar.xz
+
+%gnome_check_version
 
 # For https://fedoraproject.org/w/index.php?title=Changes/HiddenGrubMenu
 # This should go upstream once systemd has a generic interface for this
+#
+# Verified against Rawhide (2026-08-28): byte-identical to Rawhide's own
+# 0001-Fedora-Set-grub-boot-flags-on-shutdown-reboot.patch, and Rawhide's
+# current gnome-session.spec still carries this same Patch: line. This is a
+# live Fedora-standard patch, not something only we are keeping alive -- keep
+# it in lockstep with upstream.
 Patch:          0001-Fedora-Set-grub-boot-flags-on-shutdown-reboot.patch
 
 BuildRequires:  meson
@@ -32,7 +42,6 @@ Requires: gsettings-desktop-schemas >= 0.1.7
 
 Requires: dbus
 
-Obsoletes: gnome-session < 50.0
 Conflicts: gnome-desktop3 < 44.4-2
 Conflicts: shared-mime-info < 2.0-4
 Requires: shared-mime-info
@@ -58,29 +67,14 @@ Obsoletes: gnome-session-xsession < %{version}-%{release}
 Desktop file to add GNOME on wayland to display manager session menu.
 
 %prep
-%autosetup -p1 -n %{name}-%{tarball_version}
+%autosetup -p1 -n %{name}-%{gnome_tarball_version}
 
 %build
-meson setup _build \
-    --buildtype=plain \
-    --prefix=%{_prefix} \
-    --libdir=%{_libdir} \
-    --libexecdir=%{_libexecdir} \
-    --bindir=%{_bindir} \
-    --sbindir=%{_sbindir} \
-    --includedir=%{_includedir} \
-    --datadir=%{_datadir} \
-    --mandir=%{_mandir} \
-    --infodir=%{_infodir} \
-    --localedir=%{_datadir}/locale \
-    --sysconfdir=%{_sysconfdir} \
-    --localstatedir=%{_localstatedir} \
-    --sharedstatedir=%{_sharedstatedir} \
-    --wrap-mode=nodownload
-ninja -C _build -j%{_smp_build_ncpus}
+%meson
+%meson_build
 
 %install
-DESTDIR=%{buildroot} ninja -C _build install
+%meson_install
 
 %find_lang %{po_package}
 


### PR DESCRIPTION
## Summary

- Forked `src/gnome-51/gnome-session/gnome-session.spec` from Fedora Rawhide's **current** spec (fetched live from `src.fedoraproject.org/rpms/gnome-session`) instead of continuing to hand-maintain a copy that had quietly drifted.
- The headline finding: **gnome-session needed zero genuine hummingbird/EL10 deltas.** Every difference from Rawhide turned out to be plain staleness, not something EL10 requires. The forked spec is Rawhide's current spec verbatim, plus two comments documenting non-obvious verification results so a future agent doesn't "fix" it back.
- Dropped three stale things and adopted Rawhide's current approach for each:
  1. **Local `%global major_version`/`%global tarball_version`** → replaced with Rawhide's `%{gnome_major_version}` / `%{gnome_tarball_version}` / `%gnome_check_version`. These come from `/usr/lib/rpm/macros.d/macros.gnome`, which I initially assumed was Fedora-only and *not* present in our CentOS-Stream-10-based `hummingbird-ci` buildroot — that assumption was wrong. I confirmed by `podman run --rm ghcr.io/tuna-os/mock-runner:centos-stream-10 grep ... /usr/lib/rpm/macros.d/macros.gnome` that the macro file **is** shipped in our real buildroot and derives the exact same values from `Version:`. Adopting it removes a second edit site on every version bump and gains `%gnome_check_version`'s free drift guard (it fails the build if a future alpha/beta/rc version forgets the required tilde).
  2. **Hand-rolled `meson setup ... ninja -C _build`** in `%build`/`%install` → replaced with `%meson`/`%meson_build`/`%meson_install`, matching Rawhide and our own `gnome-online-accounts.spec`.
  3. **`Obsoletes: gnome-session < 50.0`** → dropped. This was a one-time GNOME-50-transition upgrade path that Rawhide's own spec has already removed. hummingbird never shipped a sub-50 `gnome-session`, and a repo-wide grep found nothing else in this tree depending on it.

## Patch disposition: `0001-Fedora-Set-grub-boot-flags-on-shutdown-reboot.patch`

Investigated whether this Fedora-specific patch is still needed, and whether Rawhide carries it too:

- Fetched Rawhide's current patch of the same name directly (`src.fedoraproject.org/rpms/gnome-session/raw/rawhide/f/0001-...patch`) and diffed it against ours: **byte-identical**.
- Rawhide's own `gnome-session.spec` still carries the exact same `Patch:` line with the exact same comment.
- The `sources` file (tarball checksum for `gnome-session-51.beta.tar.xz`) also matches Rawhide's exactly.

Conclusion: this is a live, currently-maintained Fedora-standard patch, not something only hummingbird keeps alive. Kept as-is, unmodified, in lockstep with upstream. Its `system("/usr/sbin/grub2-set-bootflag boot_success")` call is a best-effort shell-out (same as upstream) — no new `Requires` were added for it, matching Rawhide's own spec.

## Build verification

Real local build via `build-chain.sh`:

```
--manifest build-order-hummingbird-desktops.yml
--backend podman --image ghcr.io/tuna-os/mock-runner:centos-stream-10
--mock-config hummingbird-ci
--package src/gnome-51/gnome-session --with-checks
```

against a dedicated `local-repo` (never shared with another mock config/target, per this session's earlier CentOS-Stream-10/Fedora-Rawhide cross-contamination lesson).

- First attempt failed spec parsing with `error: gnome_tarball_version can be used only after the Version field is declared` — traced to an RPM gotcha: **macros are expanded inside `#` comments too**, and my own explanatory comment had an unescaped `%{gnome_tarball_version}` sitting above the `Version:` line. Fixed by escaping it (`%%{...}`) and verified locally with `rpmspec -P` before rebuilding. That same error is also what proved `macros.gnome`'s macros are real, live macros in this buildroot (not just undefined tokens), which led to the decision to adopt them rather than keep the local re-derivation.
- Second build: **succeeded**, exit code 0. Produced `gnome-session-51~beta-1.fc43.x86_64.rpm` plus `wayland-session`/`debuginfo`/`debugsource` subpackages.
- Neither our spec nor Rawhide's has a `%check` section, so `--with-checks` is a no-op for this package — noting this so the verification claim is accurate rather than implying a real check suite ran.
- Note: the release ordinal (`1` from `%autorelease`'s first count on a fresh fork) **ties** rather than exceeds our previous hand-maintained `Release: 1%{?dist}`. It does not regress the shipped NEVRA, but flagging it since a tie (rather than an increase) means the next real rebuild is what actually moves the release forward for upgrade purposes.

## Tests

- Targeted spec-related tests (changelog/autorelease conventions, bcond args, parity/drift guards, tier checks), run against the final spec content: 964 passed.
- Full `tests/` suite: 3368 passed, 7 failed, 2 skipped. All 7 failures are pre-existing and unrelated to this change: 6 are findings in freshly distgit-imported `src/hummingbird/*` specs (unescaped changelog macros, a missing docbook BuildRequires, license-ref formatting, a stale dual-maintained package list) that landed in this worktree from this session's separate `import-fedora-distgit.py` run, and 1 (`test_tideforge_intermediate`/deb chain) needs a local `dpkg-deb` binary this host doesn't have. None touch `gnome-session.spec` or anything under `src/gnome-51/`.

---
_Generated by [Claude Code](https://claude.ai/code)_
