### PR TITLE
fix(gnome51): fork orca.spec from Rawhide, fix broken mathcat build

### DIFF
--- a/src/gnome-51/orca/orca.spec
+++ b/src/gnome-51/orca/orca.spec
@@ -1,11 +1,13 @@
 Name:           orca
 Version:        51~beta
-Release:        1%{?dist}
+Release:        %autorelease
 Summary:        Assistive technology for people with visual impairments
 
 License:        LGPL-2.1-or-later AND CC-BY-SA-3.0
 URL:            https://wiki.gnome.org/Projects/Orca
-Source0:        https://download.gnome.org/sources/orca/51/orca-51.beta.tar.xz
+Source0:        https://download.gnome.org/sources/%{name}/%{gnome_major_version}/%{name}-%{gnome_tarball_version}.tar.xz
+
+%gnome_check_version
 
 BuildArch:      noarch
 
@@ -21,6 +23,9 @@ BuildRequires:  intltool
 BuildRequires:  gtk3-devel
 BuildRequires:  itstool
 BuildRequires:  meson
+# Rawhide dropped this explicit BR (the %%meson_build macro resolves ninja via
+# meson's own dependency chain). We still call meson/ninja by hand below, so
+# keep it explicit rather than relying on transitivity.
 BuildRequires:  ninja-build
 BuildRequires:  python3-brlapi
 BuildRequires:  python3-dasbus
@@ -38,6 +43,10 @@ Requires:       python3-speechd
 Requires:       speech-dispatcher
 # For the battery and system usage information commands
 Recommends:     python3-psutil
+%if 0%{?fedora}
+# only needed in X11 sessions
+Recommends:     libwnck3
+%endif
 
 %description
 Orca is a screen reader that provides access to the graphical desktop via
@@ -46,10 +55,25 @@ applications and toolkits that support the assistive technology service
 provider interface (AT-SPI), e.g. the GNOME desktop.
 
 %prep
-%autosetup -p1 -n orca-51.beta
+%autosetup -p1 -n %{name}-%{gnome_tarball_version}
 
 %build
-# Expand %%meson macro manually to avoid "fg: no job control" in EL10 mock chroot
+# Expand %%meson/%%meson_build manually instead of using the macros: this
+# repo's gnome-51/glib2, gnome-51/gtk4 and gnome-51/gjs specs all carry the
+# identical workaround, with their changelogs attributing it to an
+# intermittent "fg: no job control" failure from meson's ninja wrapper on
+# COPR builders (a job-control shell builtin with no controlling tty). Not
+# independently reproduced against this specific spec/pipeline, but the
+# failure was non-deterministic where it was found, so one clean build here
+# would not be evidence it's safe to drop -- keeping it matches every other
+# meson-based spec in this tree.
+#
+# -Dmathcat=false: orca 51.beta added MathCAT (math speech/braille) support,
+# on by default (meson_options.txt: `option('mathcat', type: 'boolean',
+# value: true)`). meson.build's own check hard-errors when the option is on
+# and `cargo` isn't found (find_program(required: false) then an explicit
+# error()) -- we don't BuildRequire a Rust toolchain, and neither does
+# Rawhide's current spec, which carries this same flag.
 meson setup redhat-linux-build \
     --buildtype=plain \
     --prefix=%{_prefix} \
@@ -57,7 +81,8 @@ meson setup redhat-linux-build \
     --sysconfdir=%{_sysconfdir} \
     --localstatedir=%{_localstatedir} \
     --wrap-mode=nodownload \
-    -Ddefault_library=shared
+    -Ddefault_library=shared \
+    -Dmathcat=false
 meson compile -C redhat-linux-build
 
 %install
@@ -82,9 +107,4 @@ desktop-file-validate %{buildroot}%{_sysconfdir}/xdg/autostart/orca-autostart.de
 %{_userunitdir}/orca.service
 
 %changelog
-* Tue Aug 25 2026 James Reilly <jreilly1821@gmail.com> - 51~beta-1
-- Update to 51.beta (GNOME 51 beta cycle)
-
-* Mon Mar 23 2026 James <james@example.com> - 50.0.9-1
-- Update to 50.0.9 (GNOME 50)
-- Expand %%meson macro to avoid "fg: no job control" failure in EL10 mock chroot
+%autochangelog


### PR DESCRIPTION
## Summary

- `src/gnome-51/orca/orca.spec` had drifted from Fedora Rawhide the same way `xdg-desktop-portal` and `flatpak` had this session. Diffed it fully against Rawhide's live spec (`src.fedoraproject.org/rpms/orca`, rawhide branch) rather than assuming the drift was cosmetic.
- **The real bug**: orca 51.beta added MathCAT (math speech/braille) support as a meson option defaulting to `true`. `meson.build` hard-errors (`error('MathML support comes from MathCAT. Install cargo or run setup with -Dmathcat=false.')`) when `cargo` isn't found, and this spec doesn't `BuildRequire` a Rust toolchain. **The pre-fork spec cannot build at all as of 51.beta.** Verified directly from the release tarball's `meson_options.txt`/`meson.build`, and reproduced the exact gate in an isolated throwaway meson project (errors without the flag + no cargo on PATH, passes with `-Dmathcat=false`).
- Adopted Rawhide's current conventions where they're genuinely current, not stale:
  - `Release`/`%changelog` → `%autorelease`/`%autochangelog`, matching Rawhide and this session's xdg-desktop-portal fix. Confirmed rpmautospec resolves correctly via `rpmspec --parse` inside `ghcr.io/tuna-os/mock-runner:centos-stream-10`.
  - `Source0`/`%prep` → Rawhide's `%{gnome_major_version}`/`%{gnome_tarball_version}` templating plus `%gnome_check_version`. I initially assumed these were Fedora-only macros unavailable to us (`gnome-srpm-macros` isn't in CentOS Stream 10 AppStream or EPEL10 — checked live), but that missed where the macros actually need to resolve. Measured directly in the real build image: both resolve correctly (`%{gnome_major_version}` → `51`, `%{gnome_tarball_version}` → `51.beta`), so adopted Rawhide's approach instead of a literal URL that would silently drift on the next GNOME bump.
  - Added Rawhide's `%if 0%{?fedora}` `Recommends: libwnck3` (X11-only mouse review). Flagging explicitly: `hummingbird-ci`'s mock config includes `fedora-rawhide-x86_64.cfg` as its base, so `%fedora` is truthy in this buildroot — this Recommends will actually be emitted in the built RPM, not a no-op.
- Kept two things Rawhide dropped, because they're this repo's own necessity, not staleness:
  - The manual `meson setup`/`meson compile` expansion in `%build` (Rawhide uses `%meson_build`). `gnome-51/glib2`, `gtk4` and `gjs` all carry the identical by-hand expansion, with their own changelogs attributing it to a non-deterministic `"fg: no job control"` failure in meson's ninja wrapper on COPR-style builders. Not independently reproduced fresh against this spec, but a single clean build wouldn't be evidence a non-deterministic failure is gone, so kept for consistency with the rest of the tree (and reworded the code comment to state that provenance honestly instead of asserting a cause).
  - The explicit `ninja-build` `BuildRequires` that manual invocation needs.

## Verification (and its limits — reported plainly)

- `rpmspec --parse` against the real mock-runner image confirms every macro in the new spec resolves exactly as expected.
- **orca is not listed in ANY `build-order*.yml` in this repo**, including `build-order-hummingbird-desktops.yml` and `build-order-gnome51.yml`. The hummingbird-desktops manifest is generated by `measure-target-gap.py` and only includes packages that aren't already in the target image ("Membership is `runtime`... minus everything hummingbird ships"), so orca isn't a gap. Practical effect: `build-chain.sh --package src/gnome-51/orca --manifest build-order-hummingbird-desktops.yml` matches zero tiers and reports a **green run having built nothing** — the same silent-no-op class `test_bootstrap_full_release_ordering.py` exists to catch, just via a different manifest-membership path. Worth a follow-up test guarding this for the rest of `src/gnome-51/*`.
- Built instead against a throwaway single-package manifest (not committed) with the exact prescribed backend/image/mock-config/local-repo. That got a real build attempt through SRPM generation cleanly (`orca-51~beta-1.fc43.src.rpm`), then died in `dnf5 builddep` — before `%build` ever ran. `python3-louis`/`python3-brlapi` resolve from the buildroot's Fedora-44 Python-ABI pin, but their exact-version native library Requires (`liblouis`, `brlapi`) aren't in that repo's `includepkgs` allowlist. **Confirmed pre-existing and unrelated to this change**: those `BuildRequires` lines are byte-identical to the pre-fork spec. Tried the obvious one-line fix locally (uncommitted); it surfaced a deeper chain (`liblouis-tables` next, then a hard Rawhide-vs-F44 `brlapi` version conflict) rather than resolving anything, so reverted rather than ship an incomplete infra fix in an orca-scoped PR.
- Full test suite: the two directly relevant tests pass (`test_no_spec_mixes_manual_and_auto_changelog`, `test_bootstrap_full_release_ordering`). Rest of the suite is green except 7 pre-existing failures unrelated to orca (4 from the 700-package `src/hummingbird/*` distgit import that landed this session, 2 from a missing `dpkg-deb` binary in this environment, 1 a worktree-specific `.git` path issue).

## Test plan

- [x] `rpmspec --parse` inside `ghcr.io/tuna-os/mock-runner:centos-stream-10` — all macros resolve correctly
- [x] Isolated reproduction of the mathcat gate (errors without `-Dmathcat=false` + no cargo, passes with it)
- [x] `pytest tests/test_no_spec_mixes_manual_and_auto_changelog.py tests/test_bootstrap_full_release_ordering.py` — pass
- [x] Full `pytest tests/` — green except 7 pre-existing, unrelated failures (documented above)
- [ ] Full automated `%build`/`%install`/`%check` run — blocked by the pre-existing `liblouis`/`brlapi` Python-ABI-pin gap in `hummingbird-ci.cfg`, tracked above as a separate infra issue

---
_Generated by [Claude Code](https://claude.ai/code)_