### PR TITLE
fix(gnome51): re-fork gdm.spec from current Rawhide, drop stale GTK3 build deps

### DIFF
--- a/src/gnome-51/gdm/gdm.spec
+++ b/src/gnome-51/gdm/gdm.spec
@@ -1,7 +1,5 @@
 %global _hardened_build 1
 
-%define gtk3_version 2.99.2
-
 %global major_version %%(echo %{version} | cut -d '.' -f1 | cut -d '~' -f1)
 %global tarball_version %%(echo %{version} | tr '~' '.')
 
@@ -25,6 +23,8 @@ Source0:        https://download.gnome.org/sources/gdm/%{major_version}/gdm-%{ta
 Source1:        org.gnome.login-screen.gschema.override
 Source2:        gdm.sysusers
 
+# Upstream patches
+
 # Downstream patches
 Patch:          0001-Honor-initial-setup-being-disabled-by-distro-install.patch
 Patch:          0001-data-add-system-dconf-databases-to-gdm-profile.patch
@@ -41,13 +41,9 @@ BuildRequires:  pkgconfig(accountsservice) >= 0.6.3
 BuildRequires:  pkgconfig(audit)
 BuildRequires:  pkgconfig(check)
 BuildRequires:  pkgconfig(gobject-introspection-1.0)
-BuildRequires:  pkgconfig(gtk+-3.0) >= %{gtk3_version}
 BuildRequires:  pkgconfig(gudev-1.0)
 BuildRequires:  pkgconfig(iso-codes)
 BuildRequires:  pkgconfig(json-glib-1.0)
-%if !0%{?rhel}
-BuildRequires:  pkgconfig(libcanberra-gtk3)
-%endif
 BuildRequires:  pkgconfig(libkeyutils)
 BuildRequires:  pkgconfig(libselinux)
 BuildRequires:  pkgconfig(libsystemd)
@@ -127,35 +123,20 @@ GDM specific authentication features.
 %autosetup -S git -p1 -n gdm-%{tarball_version}
 
 %build
-meson setup _build \
-    --buildtype=plain \
-    --prefix=%{_prefix} \
-    --libdir=%{_libdir} \
-    --libexecdir=%{_libexecdir} \
-    --bindir=%{_bindir} \
-    --sbindir=%{_sbindir} \
-    --includedir=%{_includedir} \
-    --datadir=%{_datadir} \
-    --mandir=%{_mandir} \
-    --infodir=%{_infodir} \
-    --localedir=%{_datadir}/locale \
-    --sysconfdir=%{_sysconfdir} \
-    --localstatedir=%{_localstatedir} \
-    --sharedstatedir=%{_sharedstatedir} \
-    --wrap-mode=nodownload \
-    -Ddbus-sys=%{_datadir}/dbus-1/system.d \
-    -Ddefault-path=/usr/local/bin:/usr/bin \
-    -Ddefault-pam-config=redhat \
-    -Ddistro=redhat \
+%meson -Ddbus-sys=%{_datadir}/dbus-1/system.d \
+       -Ddefault-path=/usr/local/bin:/usr/bin \
+       -Ddefault-pam-config=redhat \
+       -Ddistro=redhat \
 %if %{with x11}
-    -Dx11-support=true
+       -Dx11-support=true \
 %else
-    -Dx11-support=false
+       -Dx11-support=false \
 %endif
-ninja -C _build -j%{_smp_build_ncpus}
+
+%meson_build
 
 %install
-DESTDIR=%{buildroot} ninja -C _build install
+%meson_install
 
 cp -a %{SOURCE1} %{buildroot}%{_datadir}/glib-2.0/schemas
 
@@ -186,12 +167,17 @@ ln -sf ../X11/xinit/Xsession %{buildroot}%{_sysconfdir}/gdm/
 # GNOME 51 installs PAM services into the PAM VENDOR directory, not /etc:
 # gdm's meson.build computes
 #   pam_sys_services_dir = pam_prefix / 'lib' / 'pam.d'
-# so every gdm-*.pam lands in /usr/lib/pam.d. All six previously listed
+# so every gdm-*.pam lands in /usr/lib/pam.d. Files previously listed
 # under %%{_sysconfdir}/pam.d were reported missing by rpmbuild for exactly
 # this reason. They are vendor defaults now, so they are no longer %%config
 # (an admin override belongs in /etc/pam.d, which PAM still reads first).
-# The glob also covers the gdm-*-substack files meson generates for the
-# redhat config, which did not exist before.
+# Rawhide's own spec enumerates these individually instead (gdm-autologin,
+# gdm-password(-auth-substack), gdm-smartcard(-auth-substack),
+# gdm-fingerprint(-auth-substack), gdm-switchable-auth(-substack),
+# gdm-launch-environment) -- ten files today, six when this glob was first
+# written here. We keep the glob rather than switching to match: it already
+# absorbed that growth for free, and confirmed via a real local build that
+# all ten current names are still covered by it.
 %{_prefix}/lib/pam.d/gdm-*
 # not config files
 %if %{with x11}

--- a/tests/test_gdm_does_not_carry_a_stale_gtk3_dependency.py
+++ b/tests/test_gdm_does_not_carry_a_stale_gtk3_dependency.py
@@ -1,0 +1,118 @@
+"""gdm.spec must not carry build dependencies GDM itself dropped upstream.
+
+Our copy of gdm.spec was hand-maintained since GNOME 51 packaging started
+(#320) and had drifted from Fedora Rawhide's own gdm.spec in ways nobody
+had re-checked since -- unlike the sibling GNOME 51 packages that already
+got a from-Rawhide refork this session (xdg-desktop-portal, flatpak,
+glib2, gnome-control-center, etc.).
+
+Fetched Rawhide's live spec (src.fedoraproject.org/rpms/gdm/raw/rawhide)
+and diffed it fully against ours. Two concrete pieces of staleness:
+
+1. `%define gtk3_version 2.99.2`, `BuildRequires: pkgconfig(gtk+-3.0) >=
+   %{gtk3_version}`, and the `%if !0%{?rhel} BuildRequires:
+   pkgconfig(libcanberra-gtk3) %endif` block are all gone from Rawhide's
+   current spec (read in full, not just diffed). Cross-checked against
+   gitlab.gnome.org/GNOME/gdm's meson.build (main branch, fetched live,
+   323 lines): there is no "gtk" or "canberra" token anywhere in it --
+   GDM no longer builds any GTK3 UI itself (the greeter is gnome-shell's
+   job; gdm's own X11 fallback UI was removed when it went wayland-only).
+   These BuildRequires were pure drift with no effect other than pulling
+   in a dependency the build no longer touches. A real local build with
+   them removed (build-chain.sh, podman+mock, hummingbird-ci/.fc43)
+   produced all 5 expected RPMs.
+
+2. The hand-rolled `meson setup ... ; ninja -C _build` / `ninja -C _build
+   install` in %build/%install predates the %meson/%meson_build/
+   %meson_install macro family that Rawhide's current spec uses instead
+   (same options, same behavior, already proven working elsewhere in this
+   tree -- gnome-online-accounts, xdg-desktop-portal).
+
+What did NOT change, because Rawhide's own spec still carries them
+unmodified byte-for-byte (diffed against the live fetch):
+  - all three downstream patches (Honor-initial-setup-being-disabled,
+    data-add-system-dconf-databases, Add-headless-session-files)
+  - org.gnome.login-screen.gschema.override and gdm.sysusers
+  - the #580 el10-compat Requires fix (93305ee) -- Rawhide has no concept
+    of gnome50-el10-compat at all, so there is nothing to adopt from it;
+    the gap this fix closed is hummingbird-local and stays hummingbird-local
+  - the %files pam.d glob (35bee73) -- kept over Rawhide's literal file
+    enumeration (which has grown from six names to ten since this glob
+    was written); the built RPM was inspected directly (`rpm -qlp`) and
+    all ten of Rawhide's current names are covered by the glob as-is
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SPEC = ROOT / "src/gnome-51/gdm/gdm.spec"
+
+
+def _spec_text() -> str:
+    return SPEC.read_text(encoding="utf-8")
+
+
+def test_no_gtk3_build_dependency():
+    text = _spec_text()
+    assert "gtk+-3.0" not in text, (
+        "gdm.spec still requires pkgconfig(gtk+-3.0) -- GDM dropped its "
+        "GTK3 usage entirely (verified against gitlab.gnome.org/GNOME/gdm "
+        "meson.build, which has no gtk/canberra references at all)"
+    )
+    assert "libcanberra-gtk3" not in text, (
+        "gdm.spec still requires pkgconfig(libcanberra-gtk3), a GTK3-era "
+        "dependency GDM no longer builds against"
+    )
+    assert "gtk3_version" not in text, (
+        "gdm.spec still defines an unused gtk3_version macro"
+    )
+
+
+def test_build_install_use_the_standard_meson_macros():
+    text = _spec_text()
+    assert "%meson " in text or "%meson\n" in text, (
+        "gdm.spec should use the %meson macro (matches Rawhide's current "
+        "spec) instead of a hand-rolled `meson setup` invocation"
+    )
+    assert "%meson_build" in text
+    assert "%meson_install" in text
+    assert "ninja -C" not in text, (
+        "gdm.spec still hand-invokes ninja instead of using "
+        "%meson_build/%meson_install"
+    )
+
+
+def test_all_three_downstream_patches_are_kept():
+    text = _spec_text()
+    patches = [
+        "0001-Honor-initial-setup-being-disabled-by-distro-install.patch",
+        "0001-data-add-system-dconf-databases-to-gdm-profile.patch",
+        "0001-Add-headless-session-files.patch",
+    ]
+    for patch in patches:
+        assert patch in text, (
+            f"{patch} should still be applied -- Fedora Rawhide's own "
+            "gdm.spec still carries this patch unmodified"
+        )
+        assert (ROOT / "src/gnome-51/gdm" / patch).exists(), (
+            f"{patch} is referenced by the spec but missing from the tree"
+        )
+
+
+def test_el10_compat_fix_from_pr_580_survives():
+    """#580 (93305ee) made gnome50-el10-compat conditional on %{?rhel}
+    because it only exists in build-order-gnome51.yml's deps, not
+    build-order-hummingbird-desktops.yml, and was breaking dnf5 builddep
+    on the hummingbird (Fedora Rawhide) target unconditionally. Rawhide's
+    own spec has no equivalent -- gnome50-el10-compat is a hummingbird/
+    EL10-only package -- so there is nothing upstream to adopt instead;
+    the explicit guard must stay.
+    """
+    text = _spec_text()
+    assert "gnome50-el10-compat" in text
+    assert "%if 0%{?rhel}\nRequires:       gnome50-el10-compat\n%endif" in text, (
+        "the gnome50-el10-compat Requires must stay guarded behind "
+        "%{?rhel}, or it will again break dnf5 builddep on hummingbird"
+    )


### PR DESCRIPTION
## Summary

gdm was one of the last GNOME 51 packages never fully re-forked from Rawhide since packaging started (#320) -- #580 only ever fixed its specific el10-compat Requires bug, not the rest of the spec's drift. This does the full re-fork the other 11 GNOME 51 siblings already got this session (xdg-desktop-portal, flatpak, glib2, gnome-control-center, gnome-online-accounts, etc.).

Fetched Rawhide's live spec (src.fedoraproject.org/rpms/gdm/raw/rawhide) and diffed it in full against ours -- not just a quick skim.

## What changed, and why

- Dropped `%define gtk3_version`, `BuildRequires: pkgconfig(gtk+-3.0)`, and the `libcanberra-gtk3` conditional. These are gone from Rawhide's current spec. Cross-checked against gitlab.gnome.org/GNOME/gdm's meson.build (main, fetched live, 323 lines): there is no "gtk" or "canberra" token anywhere in it. GDM dropped its own GTK3 UI entirely once it went wayland-only -- the login greeter is gnome-shell's job now, not gdm's. These BuildRequires were pulling in a dependency the build no longer touches.
- Switched `%build`/`%install` to the `%meson`/`%meson_build`/`%meson_install` macro family, matching Rawhide's current spec. The old hand-rolled `meson setup` with every path flag spelled out plus a bare `ninja -C _build` predates these standard RPM macros -- same simplification already applied to xdg-desktop-portal this session (1109606).

## What did NOT change, and why

Diffed byte-for-byte against the live Rawhide fetch:
- All three downstream patches (0001-Honor-initial-setup-being-disabled-by-distro-install.patch, 0001-data-add-system-dconf-databases-to-gdm-profile.patch, 0001-Add-headless-session-files.patch) are identical to Rawhide's current copies. Fedora itself still carries all three unmodified -- nothing to drop, nothing to rebase.
- org.gnome.login-screen.gschema.override and gdm.sysusers are also byte-identical to Rawhide's.
- The #580 el10-compat Requires guard survives untouched. Rawhide has no equivalent to adopt -- gnome50-el10-compat is a hummingbird/EL10-only package that doesn't exist in Fedora's world at all, so the gap #580 closed stays hummingbird-local.
- The %files pam.d glob (35bee73) is kept over Rawhide's literal 10-file enumeration. Rawhide lists each gdm-* PAM service file by name; we glob instead. Confirmed via `rpm -qlp` on the actual built RPM that the glob covers all ten of Rawhide's current names -- including four Rawhide added after this glob was originally written for six.

## Build verification

Real local build, not a dry run:

```
scripts/build-chain.sh --manifest build-order-hummingbird-desktops.yml \
  --backend podman --image ghcr.io/tuna-os/mock-runner:centos-stream-10 \
  --mock-config hummingbird-ci --local-repo <local-repo> \
  --package src/gnome-51/gdm --with-checks
```

build-order-hummingbird-desktops.yml does list src/gnome-51/gdm (confirmed via grep -c), so this is the correct target/manifest -- unlike glib2/orca, which were excluded from it this session.

Result: built clean, producing all 5 expected RPMs (gdm, gdm-devel, gdm-pam-extensions-devel, gdm-debugsource, gdm-debuginfo) against hummingbird-ci/.fc43. gdm carries no %check section (neither our spec nor Rawhide's), so --with-checks was a no-op here.

## Test plan

- [x] Added tests/test_gdm_does_not_carry_a_stale_gtk3_dependency.py (4 tests) locking in: no GTK3 build deps, %meson macro usage, all three patches present and referenced, and the el10-compat guard intact
- [x] pytest tests/test_gdm_does_not_carry_a_stale_gtk3_dependency.py -- 4 passed
- [x] pytest tests/ (spec-lint + broader suite) -- 1976 passed, 2 skipped, 3 pre-existing failures unrelated to this change (missing local dpkg-deb tooling for tideforge deb tests, and an unrelated push-to-main race test)
- [x] Real local mock+podman build against build-order-hummingbird-desktops.yml -- 5/5 RPMs built

---
_Generated by [Claude Code](https://claude.ai/code)_