### PR TITLE
fix(gnome51): fork xdg-desktop-portal-gnome from Rawhide's current spec

### DIFF
--- a/src/gnome-51/xdg-desktop-portal-gnome/xdg-desktop-portal-gnome.spec
+++ b/src/gnome-51/xdg-desktop-portal-gnome/xdg-desktop-portal-gnome.spec
@@ -1,11 +1,21 @@
+# Kept as our own %%global instead of Rawhide's newer %%gnome_check_version /
+# %%{gnome_major_version} / %%{gnome_tarball_version} macro trio: zero other
+# specs in src/gnome-51/*/*.spec use those macros (including every sibling
+# already re-forked from Rawhide this session -- gnome-desktop3,
+# gnome-control-center, gnome-online-accounts), so they are not assumed
+# present in the hummingbird-ci buildroot.
 %global tarball_version %%(echo %{version} | tr '~' '.')
 
-# src/meson.build: dependency('xdg-desktop-portal', version: '>= 1.21.1')
+# src/meson.build: dependency('xdg-desktop-portal', version: '>= 1.21.1').
+# Rawhide's own live spec already carries this same 1.21.1 floor (fetched
+# 2026-08-28), so #580's fix (e918d72) is no longer a local-only delta -- it
+# has since landed upstream too. Kept explicit here regardless, since dnf5
+# builddep only enforces what this file states, not what meson.build states.
 %global xdg_desktop_portal_version 1.21.1
 
 Name:           xdg-desktop-portal-gnome
 Version:        51~alpha
-Release:        1%{?dist}
+Release:        %autorelease
 Summary:        Backend implementation for xdg-desktop-portal using GNOME
 
 License:        LGPL-2.1-or-later
@@ -45,27 +55,18 @@ org.gnome.SessionManager D-Bus interfaces.
 
 
 %build
-meson setup _build \
-    --buildtype=plain \
-    --prefix=%{_prefix} \
-    --libdir=%{_libdir} \
-    --libexecdir=%{_libexecdir} \
-    --bindir=%{_bindir} \
-    --sbindir=%{_sbindir} \
-    --includedir=%{_includedir} \
-    --datadir=%{_datadir} \
-    --mandir=%{_mandir} \
-    --infodir=%{_infodir} \
-    --localedir=%{_datadir}/locale \
-    --sysconfdir=%{_sysconfdir} \
-    --localstatedir=%{_localstatedir} \
-    --sharedstatedir=%{_sharedstatedir} \
-    --wrap-mode=nodownload \
-    -Dsystemduserunitdir=%{_userunitdir}
-ninja -C _build -j%{_smp_build_ncpus}
+# Rawhide's current spec has since collapsed the hand-rolled `meson setup`
+# (every path flag spelled out, pre-%%meson-macro Fedora packaging style) plus
+# `DESTDIR=%%{buildroot} ninja -C _build install` down to the %%meson /
+# %%meson_build / %%meson_install macro trio. Adopted here too: the same form
+# already proven in this repo's hummingbird-ci mock config by the
+# xdg-desktop-portal fork (src/gnome-51/xdg-desktop-portal/xdg-desktop-portal.spec)
+# and by gnome-desktop3's re-fork.
+%meson -Dsystemduserunitdir=%{_userunitdir}
+%meson_build
 
 %install
-DESTDIR=%{buildroot} ninja -C _build install
+%meson_install
 desktop-file-validate %{buildroot}/%{_datadir}/applications/%{name}.desktop
 %find_lang %{name}
 


### PR DESCRIPTION
## Summary

- Diffed our hand-maintained `xdg-desktop-portal-gnome.spec` against Fedora Rawhide's live spec (fetched 2026-08-28) rather than assuming drift since #580 was purely cosmetic. Found two real staleness points, both in build-system shape:
  - `%build`/`%install` still hand-rolled a `meson setup` invocation with every path flag spelled out. Rawhide's current spec collapsed this to `%meson` / `%meson_build` / `%meson_install`, already proven in this repo's hummingbird-ci mock config by the `xdg-desktop-portal` fork and by `gnome-desktop3`'s re-fork this session. Adopted the same three-line form.
  - `Release` was `1%{?dist}`; Rawhide and every other already-rebased gnome-51 sibling use `%autorelease`. Switched to match (built RPM still resolves to `1.fc43` in this buildroot either way).
- Kept, with comments explaining why:
  - #580's `xdg_desktop_portal_version` floor at 1.21.1 -- Rawhide's own live spec now carries this same value too (the fix has since landed upstream), but it stays explicit here since `dnf5 builddep` only enforces what this file states.
  - Our own `%{tarball_version}` global instead of Rawhide's newer `%gnome_check_version` / `%{gnome_major_version}` / `%{gnome_tarball_version}` macro trio -- zero other specs in `src/gnome-51/*/*.spec` use those macros, so they're not assumed present in the hummingbird-ci buildroot.
  - The EL10 composefs `ExcludeArch` workaround, BuildRequires/Requires, and `%files` already matched Rawhide's current spec verbatim.

## Test plan

- [x] Existing regression guard `tests/test_xdg_desktop_portal_gnome_floor_matches_upstream.py` (from #580) still passes unmodified.
- [x] `tests/test_spec_comments_do_not_open_a_section.py` passes (all new comments escaped correctly).
- [x] Real local build: `build-chain.sh --manifest build-order-hummingbird-desktops.yml --backend podman --image ghcr.io/tuna-os/mock-runner:centos-stream-10 --mock-config hummingbird-ci --package src/gnome-51/xdg-desktop-portal-gnome --with-checks` -- produced the expected 3 RPMs (base, `-debugsource`, `-debuginfo`).
- [x] `rpm -qp -R` on the built base package confirms `Requires: xdg-desktop-portal >= 1.21.1` -- the #580 floor fix survived the fork.
- [x] No `%check` section upstream, so `--with-checks` was a no-op (same as noted by the `xdg-desktop-portal` and `gnome-desktop3` forks).
- [x] Full suite: 1972 passed, 3 failed, 2 skipped -- all 3 failures are pre-existing and unrelated (2 tideforge deb-packaging tests need `dpkg-deb`, missing from this host; 1 test writes into `.git/`, which is a file in a worktree checkout).

---
_Generated by [Claude Code](https://claude.ai/code)_