### PR TITLE
fix(gnome51): fork gnome-settings-daemon onto Rawhide's current spec

### DIFF
--- a/src/gnome-51/gnome-settings-daemon/gnome-settings-daemon.spec
+++ b/src/gnome-51/gnome-settings-daemon/gnome-settings-daemon.spec
@@ -9,23 +9,22 @@
 
 %global systemd_units org.gnome.SettingsDaemon.A11ySettings.service org.gnome.SettingsDaemon.Color.service org.gnome.SettingsDaemon.Datetime.service org.gnome.SettingsDaemon.Housekeeping.service org.gnome.SettingsDaemon.Keyboard.service org.gnome.SettingsDaemon.MediaKeys.service org.gnome.SettingsDaemon.Power.service org.gnome.SettingsDaemon.PrintNotifications.service org.gnome.SettingsDaemon.Rfkill.service org.gnome.SettingsDaemon.ScreensaverProxy.service org.gnome.SettingsDaemon.Sharing.service org.gnome.SettingsDaemon.Smartcard.service org.gnome.SettingsDaemon.Sound.service org.gnome.SettingsDaemon.UsbProtection.service org.gnome.SettingsDaemon.Wwan.service org.gnome.SettingsDaemon.XSettings.service
 
-%global tarball_version %%(echo %{version} | tr '~' '.')
-%global major_version %%(echo %{version} | cut -f 1 -d '~' | cut -f 1 -d '.')
-
 Name:           gnome-settings-daemon
 Version:        51~beta
-Release:        1%{?dist}
+Release:        %autorelease
 Summary:        The daemon sharing settings from GNOME to GTK+/KDE applications
 
 License:        GPL-2.0-or-later AND LGPL-2.1-or-later
 URL:            https://gitlab.gnome.org/GNOME/gnome-settings-daemon
-Source0:        https://download.gnome.org/sources/%{name}/%{major_version}/%{name}-%{tarball_version}.tar.xz
+Source0:        https://download.gnome.org/sources/%{name}/%{gnome_major_version}/%{name}-%{gnome_tarball_version}.tar.xz
 
 # gsetting overrides for RHEL in general
 Source1:    	org.gnome.settings-daemon.plugins.housekeeping.gschema.override
 
 # gsetting overrides for the "Server with GUI" installation
 Source100:    	org.gnome.settings-daemon.plugins.power.gschema.override
+
+%gnome_check_version
 
 BuildRequires:  gcc
 BuildRequires:  gettext
@@ -47,8 +46,13 @@ BuildRequires:  pkgconfig(gtk4) >= %{gtk4_version}
 BuildRequires:  pkgconfig(gudev-1.0)
 BuildRequires:  pkgconfig(gweather4)
 BuildRequires:  pkgconfig(lcms2) >= 2.2
-# libcanberra-gtk3 requires gtk3 (removed from EL10); gate on non-RHEL
-# libcanberra (base, without gtk3) is required unconditionally by meson.build:105
+# hummingbird delta: Rawhide requires pkgconfig(libcanberra-gtk3) unconditionally,
+# but hummingbird's own runtime index (unlike the Fedora-Rawhide buildroot that
+# compiles it) does not ship gtk3 at all. libcanberra-gtk3 only provides optional
+# gtk3-integrated sound-theme lookups; meson.build:105 requires the gtk3-free
+# libcanberra unconditionally, so we keep the base and drop the gtk3 extra to
+# avoid an auto-generated Requires: on a library hummingbird never installs.
+# Matches mutter.spec's independent note on the same EL10/hummingbird gap.
 BuildRequires:  pkgconfig(libcanberra)
 %if !0%{?rhel}
 BuildRequires:  pkgconfig(libcanberra-gtk3)
@@ -106,29 +110,14 @@ for the default behavior of Workstation in the Server with GUI product.
 %endif
 
 %prep
-%autosetup -p1 -n %{name}-%{tarball_version}
+%autosetup -p1 -n %{name}-%{gnome_tarball_version}
 
 %build
-meson setup _build \
-    --buildtype=plain \
-    --prefix=%{_prefix} \
-    --libdir=%{_libdir} \
-    --libexecdir=%{_libexecdir} \
-    --bindir=%{_bindir} \
-    --sbindir=%{_sbindir} \
-    --includedir=%{_includedir} \
-    --datadir=%{_datadir} \
-    --mandir=%{_mandir} \
-    --infodir=%{_infodir} \
-    --localedir=%{_datadir}/locale \
-    --sysconfdir=%{_sysconfdir} \
-    --localstatedir=%{_localstatedir} \
-    --sharedstatedir=%{_sharedstatedir} \
-    --wrap-mode=nodownload
-ninja -C _build -j%{_smp_build_ncpus}
+%meson
+%meson_build
 
 %install
-DESTDIR=%{buildroot} ninja -C _build install
+%meson_install
 
 %if 0%{?rhel}
 cp %{SOURCE1} %{SOURCE100} $RPM_BUILD_ROOT%{_datadir}/glib-2.0/schemas
@@ -195,8 +184,8 @@ cp %{SOURCE1} %{SOURCE100} $RPM_BUILD_ROOT%{_datadir}/glib-2.0/schemas
 %{_libexecdir}/gsd-wwan
 %{_datadir}/glib-2.0/schemas/org.gnome.settings-daemon.plugins.wwan.gschema.xml
 
-%dir %{_libdir}/gnome-settings-daemon-%{major_version}
-%{_libdir}/gnome-settings-daemon-%{major_version}/libgsd.so
+%dir %{_libdir}/gnome-settings-daemon-%{gnome_major_version}
+%{_libdir}/gnome-settings-daemon-%{gnome_major_version}/libgsd.so
 
 %{_sysconfdir}/xdg/Xwayland-session.d/00-xrdb
 %{_userunitdir}/gnome-session-x11-services-ready.target.wants/
@@ -211,7 +200,7 @@ cp %{SOURCE1} %{SOURCE100} $RPM_BUILD_ROOT%{_datadir}/glib-2.0/schemas
 %{_datadir}/glib-2.0/schemas/org.gnome.settings-daemon.plugins.gschema.xml
 
 %files devel
-%{_includedir}/gnome-settings-daemon-%{major_version}
+%{_includedir}/gnome-settings-daemon-%{gnome_major_version}
 %{_libdir}/pkgconfig/gnome-settings-daemon.pc
 
 %if 0%{?rhel}


### PR DESCRIPTION
## Summary

- Our `gnome-settings-daemon.spec` had drifted structurally from Fedora Rawhide since the GNOME 51 kickoff: Rawhide now uses `%autorelease`/`%autochangelog`, `%meson`/`%meson_build`/`%meson_install`, and (as of upstream's "Switch to gnome-srpm-macros macros", 2026-06-29) the new `%gnome_check_version`/`%{gnome_tarball_version}`/`%{gnome_major_version}` macros from the `gnome-srpm-macros` package. Our copy still had the hand-rolled `%global tarball_version`/`major_version` and a manual `meson setup _build --buildtype=plain ...` invocation left over from the original packaging kickoff. Version was already in sync at `51~beta` — this was pure structural staleness, not a version gap.
- Re-forked onto Rawhide's current spec and kept exactly **one** genuine hummingbird delta: the `libcanberra-gtk3` EL10 gate. Rawhide requires `pkgconfig(libcanberra-gtk3)` unconditionally, but hummingbird's own runtime index (distinct from the Fedora-Rawhide buildroot that compiles it) ships no gtk3 at all. `libcanberra-gtk3` only adds an optional gtk3-integrated sound-theme lookup on top of the gtk3-free `libcanberra` that `meson.build:105` already requires unconditionally, so keeping the base and dropping the gtk3 extra avoids an auto-generated `Requires:` on a library hummingbird never installs — the same gap `mutter.spec`'s own independent comment documents.
- Verified the two gsettings overrides this spec carries (`org.gnome.settings-daemon.plugins.housekeeping/power.gschema.override`) against GNOME 51 beta's actual `gschema.xml.in` and `gsd-enums.h`: all three keys they touch (`donation-reminder-enabled`, `sleep-inactive-ac-timeout`, `power-button-action`) still exist unrenamed, and `nothing` is still a valid `GsdPowerButtonActionType` nick.

## A finding worth flagging

Both override files, and the entire `-server-defaults` subpackage, live behind `%if 0%{?rhel}` — byte-identical between Rawhide's spec and ours. The gdm `el10-compat` fix earlier this session already established that `%rhel` is unset on the hummingbird/Fedora-Rawhide target, so **none of this ships here**, on hummingbird or on vanilla Fedora. This isn't a hummingbird-specific gap; it's upstream's own inert RHEL-only branch. Confirmed empirically below.

## Test plan

- [x] Real local build: `build-chain.sh --package src/gnome-51/gnome-settings-daemon` (podman+mock, `--with-checks`) against `build-order-hummingbird-desktops.yml`'s `hummingbird-ci` mock config, dedicated empty `--local-repo`.
- [x] Built clean: 4 RPMs (`gnome-settings-daemon`, `-devel`, `-debuginfo`, `-debugsource`), no `-server-defaults` package.
- [x] `rpm -qlp`/`rpm -qRp` confirm `%{gnome_major_version}`/`%{gnome_tarball_version}` expanded correctly (`gnome-settings-daemon-51` paths, not literal/empty macros) — proof `gnome-srpm-macros` resolves fine in this buildroot.
- [x] Main package's `Requires:` lists only `libcanberra.so.0`, no `libcanberra-gtk3`-derived requirement.
- [x] Main package ships neither gschema override file, confirming the `%if 0%{?rhel}` finding above.
- [x] A transient `createrepo_c` "getcwd: cannot access parent directories" (parallel-build resource contention) was retried directly and passed clean.
- [x] Spec-related test files (`test_buildroot_simulator.py`, `test_check_reverse_deps.py`, `test_docbook_man_pages_name_the_right_stylesheets.py`, `test_gnome_parity_gap.py`, `test_gnome_sources_are_fetchable.py`, `test_preflight_buildrequires.py`, `test_rpm_vercmp.py`, `test_the_gnome_chains_build_what_el10_is_too_old_for.py`): 120 passed.
- [x] Full `pytest` suite: 1972 passed, 2 skipped, 3 pre-existing failures unrelated to this change (`tideforge-intermediate` deb-packaging tests failing on a missing `dpkg-deb` binary in this environment).

---
_Generated by [Claude Code](https://claude.ai/code)_
