### PR TITLE
fix(gnome51): re-fork gtk4.spec from current Rawhide, not just #580's two fixes

### DIFF
--- a/src/gnome-51/gtk4/gtk4.spec
+++ b/src/gnome-51/gtk4/gtk4.spec
@@ -3,23 +3,19 @@
 %endif
 
 %global glib2_version 2.84.0
-# 1.58, not 1.56.0: GTK 4.23.3's own meson.build (pango_major_req=1,
-# pango_minor_req=58) requires it. The stale 1.56.0 floor here let this
-# BuildRequires be satisfied by served pango 1.57, so nothing declared the
-# real dependency -- gtk4 silently vendored pango as a meson subproject
-# instead (the tell: libpangoft2-1.0.so.0.5800.0 in the build log) and died
-# under -Werror=unused-but-set-variable in the vendored copy. #567 fixed
-# that failure by bumping SYSTEM pango to 1.58.2; this fixes the spec that
-# should have caught it: with the real floor declared, a buildroot missing
-# pango >= 1.58 fails fast on an unsatisfiable BuildRequires instead of
-# quietly falling back to a subproject build with a different failure mode.
-%global pango_version 1.58
-%global cairo_version 1.18.0
+# Load-bearing, not cosmetic: GTK 4.23.3's own meson.build declares
+# pango_major_req=1, pango_minor_req=58. A floor below 1.58 is satisfiable
+# by an older pango, which used to make gtk4 silently vendor its own copy
+# of pango as a meson subproject instead of failing the BuildRequires
+# (#567/#580). Guarded by tests/test_gtk4_and_libadwaita_floors_match_upstream.py
+# -- don't lower this without re-checking that test.
+%global pango_version 1.58.0
+%global cairo_version 1.18.2
 %global gdk_pixbuf_version 2.30.0
 %global gstreamer_version 1.24.0
-%global harfbuzz_version 8.4
-%global wayland_protocols_version 1.31
-%global wayland_version 1.21.0
+%global harfbuzz_version 8.4.0
+%global wayland_protocols_version 1.48
+%global wayland_version 1.24.0
 %global epoxy_version 1.4
 
 %global bin_version 4.0.0
@@ -37,8 +33,17 @@
 
 Name:           gtk4
 Version:        4.23.3
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        GTK graphical user interface library
+
+# Rawhide's current spec sources the download.gnome.org path segment from a
+# %{gnome_major_minor_version} macro that Fedora's GNOME SIG tooling injects
+# into the Rawhide buildroot; it is not defined in our el10/hummingbird mock
+# config. Compute it locally instead (same pattern already used by
+# src/gnome-51/gobject-introspection.spec) so Source0 stays correct on
+# version bumps without depending on an undefined macro. Must be defined
+# after Version: is set, since %%() shell expansion runs eagerly.
+%global gnome_major_minor_version %(echo %{version} | cut -d. -f1-2)
 
 # Most files are either LGPL-2.0-or-later or LGPL-2.1-or-later.
 # gtk/roaring/ and gtk/timsort/ are Apache-2.0
@@ -81,7 +86,7 @@ Summary:        GTK graphical user interface library
 # The license was last checked for GTK 4.19.3.
 License:        LGPL-2.0-or-later AND LGPL-2.1-or-later AND Apache-2.0 AND CC0-1.0 AND MIT AND MIT-open-group AND HPND-sell-variant AND GPL-2.0-or-later AND GPL-3.0-or-later AND OFL-1.1
 URL:            https://www.gtk.org
-Source0:        https://download.gnome.org/sources/gtk/4.23/gtk-%{version}.tar.xz
+Source0:        https://download.gnome.org/sources/gtk/%{gnome_major_minor_version}/gtk-%{version}.tar.xz
 
 BuildRequires:  cups-devel
 BuildRequires:  desktop-file-utils
@@ -99,6 +104,7 @@ BuildRequires:  pkgconfig(cairo-gobject) >= %{cairo_version}
 BuildRequires:  pkgconfig(colord)
 BuildRequires:  pkgconfig(egl)
 BuildRequires:  pkgconfig(epoxy)
+BuildRequires:  pkgconfig(libdrm)
 BuildRequires:  pkgconfig(gdk-pixbuf-2.0) >= %{gdk_pixbuf_version}
 BuildRequires:  pkgconfig(glib-2.0) >= %{glib2_version}
 BuildRequires:  pkgconfig(gobject-introspection-1.0)
@@ -120,10 +126,6 @@ BuildRequires:  pkgconfig(sysprof-capture-4)
 BuildRequires:  pkgconfig(tracker-sparql-3.0)
 %endif
 BuildRequires:  pkgconfig(vulkan)
-# gtk 4.23 re-grew a hard libdrm dependency (meson.build:723) for dmabuf
-# support; the 4.21-era changelog note about it being removed no longer
-# holds, and the el10 gate fails resolution without it.
-BuildRequires:  pkgconfig(libdrm)
 BuildRequires:  pkgconfig(wayland-client) >= %{wayland_version}
 BuildRequires:  pkgconfig(wayland-cursor) >= %{wayland_version}
 BuildRequires:  pkgconfig(wayland-egl) >= %{wayland_version}
@@ -206,43 +208,38 @@ This package contains helpful applications for developers using GTK.
 
 %build
 export CFLAGS='-std=c11 -fno-strict-aliasing -DG_DISABLE_CAST_CHECKS -DG_DISABLE_ASSERT %optflags'
-meson setup _build \
-    --buildtype=plain \
-    --prefix=%{_prefix} \
-    --libdir=%{_libdir} \
-    --libexecdir=%{_libexecdir} \
-    --bindir=%{_bindir} \
-    --sbindir=%{_sbindir} \
-    --includedir=%{_includedir} \
-    --datadir=%{_datadir} \
-    --mandir=%{_mandir} \
-    --infodir=%{_infodir} \
-    --localedir=%{_datadir}/locale \
-    --sysconfdir=%{_sysconfdir} \
-    --localstatedir=%{_localstatedir} \
-    --sharedstatedir=%{_sharedstatedir} \
-    --wrap-mode=nodownload \
-    --auto-features=enabled \
+# --wrap-mode=nodownload and --auto-features=enabled are pinned explicitly
+# here (Rawhide's own %%meson invocation leaves them implicit, relying on
+# Fedora's redhat-rpm-config default). Losing --wrap-mode=nodownload is
+# exactly the regression #567/#580 diagnosed: without it, an unsatisfied
+# BuildRequires makes meson silently fetch/vendor a subproject (e.g. pango)
+# instead of failing fast. Our el10-based buildroot's redhat-rpm-config
+# isn't guaranteed to default the same way Fedora's does, so both flags are
+# spelled out rather than trusted to %%meson's default.
+%meson \
+        --wrap-mode=nodownload \
+        --auto-features=enabled \
 %if 0%{?with_broadway}
-    -Dbroadway-backend=true \
+        -Dbroadway-backend=true \
 %endif
-    -Dsysprof=enabled \
+        -Dsysprof=enabled \
 %if 0%{?rhel}
-    -Dmedia-gstreamer=disabled \
-    -Dtracker=disabled \
+        -Dmedia-gstreamer=disabled \
+        -Dtracker=disabled \
 %else
-    -Dtracker=enabled \
+        -Dtracker=enabled \
 %endif
-    -Dcolord=enabled \
-    -Ddocumentation=true \
-    -Dman-pages=true \
-    -Dbuild-testsuite=false \
-    -Dbuild-tests=false \
-    -Dbuild-examples=false
-ninja -C _build -j%{_smp_build_ncpus}
+        -Dcolord=enabled \
+        -Ddocumentation=true \
+        -Dman-pages=true \
+        -Dbuild-testsuite=false \
+        -Dbuild-tests=false \
+        -Dbuild-examples=false
+
+%meson_build
 
 %install
-DESTDIR=%{buildroot} ninja -C _build install
+%meson_install
 
 %find_lang gtk40
 
@@ -340,6 +337,36 @@ desktop-file-validate $RPM_BUILD_ROOT%{_datadir}/applications/*.desktop
 %{_mandir}/man1/gtk4-widget-factory.1*
 
 %changelog
+* Fri Aug 28 2026 James Reilly <jreilly1821@gmail.com> - 4.23.3-3
+- Re-fork from Fedora Rawhide's current gtk4.spec. #580's two fixes
+  (pango_version floor, removed gtk4-encode-symbolic-svg/gtk4-icon-editor
+  tools) are naturally inherited: Rawhide's own spec now declares
+  pango_version 1.58.0 and no longer packages either tool.
+- Bump cairo_version 1.18.0 -> 1.18.2, harfbuzz_version 8.4 -> 8.4.0,
+  wayland_protocols_version 1.31 -> 1.48, wayland_version 1.21.0 -> 1.24.0
+  to match Rawhide's current floors; these had drifted stale since this
+  spec was last hand-forked.
+- Drop the local libdrm BuildRequires comment: Rawhide now carries
+  pkgconfig(libdrm) unconditionally (no longer behind any gate), so this
+  is no longer our delta to explain.
+- Define %%{gnome_major_minor_version} locally (Fedora's GNOME SIG tooling
+  injects it; our buildroot doesn't have that tooling), matching the
+  precedent in src/gnome-51/gobject-introspection.spec, and switch Source0
+  to use it instead of a hardcoded "4.23" path component.
+- Adopt Rawhide's %%meson/%%meson_build/%%meson_install in place of the
+  hand-rolled meson setup/ninja invocation (a COPR-era workaround from
+  4.22.1-2 that predates this repo's mock+podman build backend; proven
+  unnecessary on this backend by xdg-desktop-portal's %%meson adoption
+  this session), but pin --wrap-mode=nodownload and --auto-features=enabled
+  explicitly rather than trust %%meson's default, since losing
+  --wrap-mode=nodownload silently reopens the #567/#580 vendoring bug.
+- Preserve our genuine EL10 deltas Rawhide doesn't carry: the RHEL-only
+  gates (behind %%if !0%%{?rhel}) on gstreamer-player-1.0/tracker-sparql-3.0
+  BuildRequires, the gstreamer1-plugins-bad-free-libs Requires, and the
+  -Dmedia-gstreamer=disabled/-Dtracker=disabled %%build branch (gtk3 was
+  removed on EL10 and gstreamer1-plugins-bad-free-devel still depends on
+  it; tracker3/tinysparql isn't available on EL10 either).
+
 * Wed Aug 26 2026 James Reilly <jreilly1821@gmail.com> - 4.23.3-2
 - Drop 0001-gtkapplication-wayland-null-check.patch: upstream carries the
   same GDK_IS_WAYLAND_TOPLEVEL check in 4.23.3 (MR 9643 landed), so the hunk


### PR DESCRIPTION
## Summary

- Re-forked `src/gnome-51/gtk4/gtk4.spec` from Fedora Rawhide's **current** live spec instead of only carrying #580's two point-fixes forward. #580's fixes (pango floor, two removed tools in `%files`) are naturally inherited: Rawhide's own spec already declares `pango_version 1.58.0` and no longer packages `gtk4-encode-symbolic-svg`/`gtk4-icon-editor`/`org.gtk.Shaper*`.
- Replaced genuine staleness with Rawhide's current values: `cairo_version` 1.18.0 → 1.18.2, `harfbuzz_version` 8.4 → 8.4.0, `wayland_protocols_version` 1.31 → 1.48, `wayland_version` 1.21.0 → 1.24.0. Dropped the local libdrm comment (Rawhide carries it unconditionally now). Adopted Rawhide's `%meson`/`%meson_build`/`%meson_install` in place of the hand-rolled meson/ninja invocation left over from a March-2026 COPR workaround that doesn't apply to this repo's mock+podman backend (already proven fine on that backend by `xdg-desktop-portal`'s prior `%meson` adoption) — but pinned `--wrap-mode=nodownload`/`--auto-features=enabled` explicitly on the `%meson` line rather than trusting its default, since losing `--wrap-mode=nodownload` is exactly the regression #567/#580 diagnosed. Defined `%{gnome_major_minor_version}` locally (Fedora's GNOME SIG tooling injects it in Rawhide; our buildroot doesn't have that tooling), matching the `gobject-introspection.spec` precedent, so `Source0` isn't hardcoded to `4.23`.
- Kept our genuine EL10/hummingbird deltas Rawhide doesn't carry: the `%if !0%{?rhel}` gates on `gstreamer-player-1.0`/`tracker-sparql-3.0` BuildRequires and the `gstreamer1-plugins-bad-free-libs` Requires (gtk3 was removed on EL10 and `gstreamer1-plugins-bad-free-devel` still depends on it; tracker3/tinysparql isn't available on EL10 either), and the `-Dmedia-gstreamer=disabled`/`-Dtracker=disabled` `%build` branch.
- Kept an explicit `Release` (bumped 2 → 3) with a hand-written `%changelog` entry rather than switching to Rawhide's `%autorelease`/`%autochangelog` — `tests/test_no_spec_mixes_manual_and_auto_changelog.py` enforces this per-spec, and gtk4's changelog already carries real curated history worth preserving.

## Verification

Confirmed `gtk4` actually appears in `build-order-hummingbird-desktops.yml` before assuming it (`grep -c "src/gnome-51/gtk4" build-order-hummingbird-desktops.yml` → 1) — unlike `glib2`/`orca` earlier this session, gtk4 is not excluded.

Ran a real local build:
```
./scripts/build-chain.sh --manifest build-order-hummingbird-desktops.yml \
  --backend podman --image ghcr.io/tuna-os/mock-runner:centos-stream-10 \
  --mock-config hummingbird-ci \
  --local-repo <dedicated .factory/verify/artifacts dir> \
  --package src/gnome-51/gtk4 --with-checks
```
Built clean through all 22 tiers: `gtk4-4.23.3-3.fc43` (release bumped past the already-served `-2`), 8 RPMs, `%check` passing.

Directly inspected the built RPMs for the two things that mattered most:
- `rpm -qp --requires gtk4-4.23.3-3.fc43.x86_64.rpm` shows `pango(x86-64) >= 1.58.0` as a real system `Requires` — confirms system pango is linked, not vendored as a meson subproject.
- `rpm -qp --list` on `gtk4`/`gtk4-devel-tools` has no `gtk4-encode-symbolic-svg`/`gtk4-icon-editor`/`org.gtk.Shaper*` entries.
- `cairo`/`harfbuzz`/`wayland-client`/`wayland-cursor` Requires all resolved and built against the bumped floors (1.18.2/8.4.0/1.24.0/1.24.0) with no dependency-resolution failures.

The build resolved with `dist .fc43` — the Fedora branch of the `%if !0%{?rhel}` gates, not the EL10 branch. Statically confirmed the EL10 branch separately (this build didn't exercise it):
```
rpmspec --parse --define "rhel 10" --define "dist .el10" src/gnome-51/gtk4/gtk4.spec
```
parses clean and drops exactly the three RHEL-gated BuildRequires/Requires lines; the default (no `rhel` defined) parse includes them.

## Test plan

- [x] `pytest tests/test_gtk4_and_libadwaita_floors_match_upstream.py` — 9/9 pass
- [x] `pytest tests/test_no_spec_mixes_manual_and_auto_changelog.py` — pass
- [x] Spec-related test subset (393 tests: preflight buildrequires, source paths, published hygiene, fedora-cmake, spec-comment hygiene, etc.) — all pass
- [x] Full suite — 1972 passed, 2 skipped, 3 pre-existing unrelated failures (`dpkg-deb` missing on this host; confirmed identical against unmodified `origin/main`)
- [x] Real local build via `build-chain.sh` against `build-order-hummingbird-desktops.yml`, `--with-checks` — 8/8 RPMs built, `%check` passing

---
_Generated by [Claude Code](https://claude.ai/code)_
