### PR TITLE
fix(gnome51): fork libadwaita.spec from current Rawhide, drop sassc requirement

### DIFF
--- a/src/gnome-51/libadwaita/fix-sassc-requirement-for-tarball-builds.patch
+++ b/src/gnome-51/libadwaita/fix-sassc-requirement-for-tarball-builds.patch
@@ -1,0 +1,29 @@
+From 954ef6ce80838b7e96cfc7f43287e99238c9639c Mon Sep 17 00:00:00 2001
+From: Jan Grulich <jgrulich@redhat.com>
+Date: Tue, 4 Aug 2026 16:13:26 +0200
+Subject: [PATCH] Fix sassc requirement for tarball builds
+
+The meson build checks for base.css to determine if pre-generated CSS
+is available, but the tarball ships gtk.css instead. This causes sassc
+to be required even for tarball builds where the compiled stylesheet
+is already present. Fix the check to look for gtk.css.
+---
+ src/stylesheet/meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/stylesheet/meson.build b/src/stylesheet/meson.build
+index 023ebf7b7..1acc22ee4 100644
+--- a/src/stylesheet/meson.build
++++ b/src/stylesheet/meson.build
+@@ -3,7 +3,7 @@ fs = import('fs')
+ stylesheet_deps = []
+ 
+ # For git checkouts, but not for tarballs...
+-if not fs.exists('base.css')
++if not fs.exists('gtk.css')
+   sassc = find_program('sassc', required: false)
+   if not sassc.found()
+     subproject('sassc', default_options: ['warning_level=0', 'werror=false'])
+-- 
+GitLab
+

--- a/src/gnome-51/libadwaita/libadwaita.spec
+++ b/src/gnome-51/libadwaita/libadwaita.spec
@@ -5,20 +5,36 @@
 # have drifted since this beta). The stale 4.21.1 floor was satisfiable by
 # whatever gtk4 build happened to exist, including one still vendoring
 # pango -- see gtk4.spec's pango_version comment for that failure mode.
+# #580 fixed this by hand; Rawhide's own spec has since caught up to the
+# same 4.23.1 floor, so this fork now inherits it directly instead of
+# needing a standing correction -- comment kept for the institutional memory.
 %global gtk_version 4.23.1
-%global glib_version 2.80.0
-
-%global tarball_version %%(echo %{version} | tr '~' '.')
+# 2.84.0, not 2.80.0: matches Rawhide's current floor, and gtk4.spec's own
+# glib2_version in this tree (see gtk4.spec's comment for why that one was
+# bumped) -- the stale 2.80.0 here was satisfiable by an older glib2 than
+# what actually gets built alongside it.
+%global glib_version 2.84.0
 
 Name:           libadwaita
 Version:        1.10~beta.1
-Release:        1%{?dist}
+Release:        %autorelease
 Summary:        Building blocks for modern GNOME applications
 
 # part of src/adw-spring-animation.c is MIT
 License:        LGPL-2.1-or-later AND MIT
 URL:            https://gitlab.gnome.org/GNOME/libadwaita
-Source0:        https://download.gnome.org/sources/%{name}/1.10/%{name}-%{tarball_version}.tar.xz
+Source0:        https://download.gnome.org/sources/%{name}/%{gnome_major_minor_version}/%{name}-%{gnome_tarball_version}.tar.xz
+
+# https://gitlab.gnome.org/GNOME/libadwaita/-/merge_requests/1802
+# Fixes stylesheet/meson.build to check for gtk.css (what tarball releases
+# actually ship) instead of base.css (only present in git checkouts), so
+# tarball builds stop being told they need sassc at all -- verified against
+# the 1.10.beta.1 tarball, which does ship src/stylesheet/gtk.css. With this
+# applied the sassc BuildRequires below is no longer needed; Rawhide's
+# current spec has already dropped it for the same reason.
+Patch0:         fix-sassc-requirement-for-tarball-builds.patch
+
+%gnome_check_version
 
 BuildRequires:  desktop-file-utils
 BuildRequires:  gcc
@@ -27,7 +43,6 @@ BuildRequires:  gi-docgen
 BuildRequires:  libappstream-glib
 BuildRequires:  meson >= 0.63.0
 BuildRequires:  vala
-BuildRequires:  /usr/bin/sassc
 BuildRequires:  pkgconfig(appstream)
 BuildRequires:  pkgconfig(fribidi)
 BuildRequires:  pkgconfig(glib-2.0) >= %{glib_version}
@@ -78,10 +93,16 @@ Demo files for %{name}.
 
 
 %prep
-%autosetup -p1 -n %{name}-%{tarball_version}
+%autosetup -p1 -n %{name}-%{gnome_tarball_version}
 
 
 %build
+# Explicit meson setup/ninja, not the meson RPM macros (meson, meson_build,
+# meson_install) that Rawhide's current spec uses: glib2.spec in this tree
+# (see its changelog) had to revert away from those macros because "fg: no
+# job control" fails the build under COPR-style builders that run rpmbuild
+# under --console=pipe non-interactive bash. Keeping the explicit form here
+# avoids reintroducing that failure mode.
 meson setup _build \
     --buildtype=plain \
     --prefix=%{_prefix} \

--- a/tests/test_gtk4_and_libadwaita_floors_match_upstream.py
+++ b/tests/test_gtk4_and_libadwaita_floors_match_upstream.py
@@ -60,11 +60,23 @@ def test_libadwaita_declares_gtk4s_real_floor():
     )
 
 
+def test_libadwaita_declares_glib2s_real_floor():
+    """libadwaita.spec re-forked from Rawhide: glib_version must match gtk4.spec's
+    own glib2_version floor in this tree, and Rawhide's current spec, not the
+    stale 2.80.0 that predated the re-fork."""
+    assert _global_version(LIBADWAITA_SPEC, "glib_version") >= (2, 84, 0), (
+        "Rawhide's current libadwaita.spec (and gtk4.spec's glib2_version in "
+        "this tree) declare glib_version >= 2.84.0 -- a lower floor here is "
+        "satisfiable by an older glib2 than what actually gets built alongside it"
+    )
+
+
 @pytest.mark.parametrize(
     "spec,name,stale",
     [
         (GTK4_SPEC, "pango_version", "1.56.0"),
         (LIBADWAITA_SPEC, "gtk_version", "4.21.1"),
+        (LIBADWAITA_SPEC, "glib_version", "2.80.0"),
     ],
 )
 def test_the_previously_stale_floor_is_gone(spec, name, stale):
@@ -103,3 +115,44 @@ def test_gtk4_files_does_not_reference_a_tool_upstream_removed(stale_file):
         f"at that tag) -- referencing it in %files fails the whole package "
         f"build with 'File not found', at the very end of a from-scratch build"
     )
+
+
+# libadwaita.spec was re-forked from Rawhide's current spec (which now uses
+# the %meson/%meson_build/%meson_install macros). This tree deliberately does
+# NOT adopt those macros: glib2.spec's changelog in this same tree records
+# reverting away from them because "fg: no job control" fails the build
+# under COPR-style builders that run rpmbuild under --console=pipe
+# non-interactive bash. A future naive re-fork from Rawhide is the most
+# likely way to silently reintroduce that failure, so guard it explicitly.
+def test_libadwaita_does_not_use_the_meson_macros_that_break_under_console_pipe():
+    text = LIBADWAITA_SPEC.read_text(encoding="utf-8")
+    for macro in ("%meson \\", "%meson\n", "%meson_build", "%meson_install"):
+        assert macro not in text, (
+            f"{LIBADWAITA_SPEC} uses {macro!r} -- glib2.spec's changelog in this "
+            f"tree documents this exact macro causing 'fg: no job control' under "
+            f"COPR-style non-interactive builders; use explicit meson setup / "
+            f"ninja / DESTDIR install instead"
+        )
+
+
+# Rawhide's current libadwaita.spec carries Patch0 (fix-sassc-requirement-for-
+# tarball-builds.patch, https://gitlab.gnome.org/GNOME/libadwaita/-/merge_requests/1802)
+# and has dropped the `BuildRequires: /usr/bin/sassc` that the patch makes
+# unnecessary for tarball builds (verified: the 1.10.beta.1 tarball ships
+# src/stylesheet/gtk.css, which is what the patched meson.build check looks
+# for). Losing either half of this pair independently regresses the fork:
+# the patch without dropping the BuildRequires is harmless but the
+# BuildRequires without the patch is what caused the extra dependency.
+def test_libadwaita_carries_the_sassc_patch_and_drops_its_buildrequires():
+    text = LIBADWAITA_SPEC.read_text(encoding="utf-8")
+    assert "Patch0:" in text and "fix-sassc-requirement-for-tarball-builds.patch" in text, (
+        "libadwaita.spec is missing the sassc tarball-build fix patch that "
+        "Rawhide's current spec carries"
+    )
+    assert "/usr/bin/sassc" not in text, (
+        "libadwaita.spec still declares BuildRequires: /usr/bin/sassc, which "
+        "the sassc tarball-build fix patch makes unnecessary -- Rawhide's "
+        "current spec has already dropped it"
+    )
+    patch_path = LIBADWAITA_SPEC.parent / "fix-sassc-requirement-for-tarball-builds.patch"
+    assert patch_path.is_file(), f"{patch_path} referenced by Patch0 but missing from disk"


### PR DESCRIPTION
## Summary
- Re-forked `libadwaita.spec` from Rawhide's current spec: adopted `%{gnome_major_minor_version}`/`%{gnome_tarball_version}`/`%gnome_check_version` macros in place of a hardcoded `tarball_version`.
- Bumped `glib_version` 2.80.0 → 2.84.0 to match `gtk4.spec`'s own floor in this tree — the stale 2.80.0 was satisfiable by an older glib2 than what actually gets built alongside it.
- Backported [GNOME/libadwaita!1802](https://gitlab.gnome.org/GNOME/libadwaita/-/merge_requests/1802) (`fix-sassc-requirement-for-tarball-builds.patch`): upstream's `stylesheet/meson.build` checked for `base.css` (only present in git checkouts) instead of `gtk.css` (what tarball releases actually ship), so tarball builds were unnecessarily told they needed `sassc`. Verified the `1.10.beta.1` tarball ships `src/stylesheet/gtk.css`; dropped the now-unnecessary `BuildRequires: /usr/bin/sassc`.

## Verification
Real `build-chain.sh` build against `hummingbird-ci` (podman, `--with-checks`), dedicated local-repo:
- 6 RPMs built (main, debuginfo, debugsource, demo, devel, doc)
- `%check` passed
- `tests/test_gtk4_and_libadwaita_floors_match_upstream.py`: 13/13 passed

## Test plan
- [x] Local `build-chain.sh --package src/gnome-51/libadwaita --with-checks` build passed
- [x] `pytest tests/test_gtk4_and_libadwaita_floors_match_upstream.py`
- [ ] CI build for `hummingbird-ci` target

---
_Generated by [Claude Code](https://claude.ai/code)_