### PR TITLE
fix(hummingbird): rename our rebuild dist tag from .fc43 to .bfin1

### DIFF
--- a/build-order-hummingbird-desktops.yml
+++ b/build-order-hummingbird-desktops.yml
@@ -16,8 +16,8 @@
 # from the buildroot's inherited Rawhide fallback at priority 99
 # (the target's mock config), never from this build order.
 #
-# Measured 2026-08-28T14:23:39.682222+00:00
-# target primary.xml   sha256 4d5405996d0dd91568bea8e6a708e408bb6aa686df4247ffafdbe42ad464100b
+# Measured 2026-08-29T05:27:36.965970+00:00
+# target primary.xml   sha256 aebd0d9863f17bf3b2dd903b2af8c540f75c4444b12874c0b6fca88c001eaf1d
 # reference primary.xml sha256 f623cd97d2e8b8ad2ae1c684094f654c025a9df54628e7026d3a07884e6a729d
 #
 # `distgit:` means the packaging is imported from Fedora Rawhide

--- a/docs/hummingbird-desktop-gap.json
+++ b/docs/hummingbird-desktop-gap.json
@@ -8064,7 +8064,7 @@
       "unresolved_capabilities": {}
     }
   },
-  "measured_at": "2026-08-28T14:23:39.682222+00:00",
+  "measured_at": "2026-08-29T05:27:36.965970+00:00",
   "membership": "runtime",
   "reference_index": {
     "baseurl": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/",
@@ -8084,7 +8084,7 @@
   },
   "target": {
     "baseurl": "https://packages.redhat.com/api/pulp-content/public-hummingbird/$arch/",
-    "dist": ".fc43",
+    "dist": ".bfin1",
     "id": "hummingbird-20251124-x86_64",
     "r2_path": "hummingbird/20251124-x86_64",
     "reference": "fedora-rawhide",
@@ -8093,11 +8093,11 @@
   "target_binary_packages": 3510,
   "target_index": {
     "baseurl": "https://packages.redhat.com/api/pulp-content/public-hummingbird/x86_64/",
-    "primary_bytes": 4131165,
-    "primary_href": "repodata/4d5405996d0dd91568bea8e6a708e408bb6aa686df4247ffafdbe42ad464100b-primary.xml.gz",
-    "primary_sha256": "4d5405996d0dd91568bea8e6a708e408bb6aa686df4247ffafdbe42ad464100b",
-    "primary_sha256_declared": "4d5405996d0dd91568bea8e6a708e408bb6aa686df4247ffafdbe42ad464100b",
-    "revision": "1787895673"
+    "primary_bytes": 4132638,
+    "primary_href": "repodata/aebd0d9863f17bf3b2dd903b2af8c540f75c4444b12874c0b6fca88c001eaf1d-primary.xml.gz",
+    "primary_sha256": "aebd0d9863f17bf3b2dd903b2af8c540f75c4444b12874c0b6fca88c001eaf1d",
+    "primary_sha256_declared": "aebd0d9863f17bf3b2dd903b2af8c540f75c4444b12874c0b6fca88c001eaf1d",
+    "revision": "1787959363"
   },
   "tier_ordering": "buildrequires"
 }

--- a/manifests/hummingbird-desktops.yaml
+++ b/manifests/hummingbird-desktops.yaml
@@ -50,7 +50,7 @@ target:
   id: hummingbird-20251124-x86_64
   baseurl: https://packages.redhat.com/api/pulp-content/public-hummingbird/$arch/
   r2_path: hummingbird/20251124-x86_64
-  dist: .fc43
+  dist: .bfin1
   # Sources come from Fedora Rawhide dist-git, imported at build time by
   # scripts/import-fedora-distgit.py.  Rawhide is the right branch and this is
   # measured, not assumed: of 38 core packages present in both indexes, 30 are
@@ -59,12 +59,15 @@ target:
   # 6.11.1-5, rust 1.97.1-2, meson 1.11.2-2, …).  Fedora 43 ships glib2 2.86.5
   # and systemd 258.10; the target is nowhere near it.
   reference: fedora-rawhide
-  # The target's own packages carry .hum1, not .fc43 — every one of the 16506
-  # (name, evr, arch) tuples in its primary.xml ends in .hum1.  `.fc43` above
-  # is what build-chain.sh stamps on OUR rebuilds; it is deliberately distinct
-  # from the target's own tag so a rebuild is identifiable, but note it sorts
-  # BELOW .hum1 for the same version, so it can never shadow a package the
-  # target later starts shipping itself.
+  # The target's own packages carry .hum1, not .bfin1 — every one of the 16506
+  # (name, evr, arch) tuples in its primary.xml ends in .hum1.  `.bfin1` above
+  # is what build-chain.sh stamps on OUR rebuilds (named for the Bluefin
+  # parity this desktop targets, was .fc43 through 2026-08-29 -- retired for
+  # reading as a real Fedora 43 tie-in, which it never was); it is
+  # deliberately distinct from the target's own tag so a rebuild is
+  # identifiable, but note it sorts BELOW .hum1 for the same version
+  # ('b' < 'h'), so it can never shadow a package the target later starts
+  # shipping itself.
 
 desktops:
   gnome:

--- a/manifests/package-builds.yaml
+++ b/manifests/package-builds.yaml
@@ -261,7 +261,7 @@ native_builds:
     target: hummingbird
     architecture: x86_64
     image: ghcr.io/tuna-os/mock-runner:centos-stream-10
-    # The mock contract emits .fc43 packages against Python 3.14. Verify the
+    # The mock contract emits .bfin1 packages against Python 3.14. Verify the
     # same ABI rather than rolling Rawhide, which has already moved to 3.15.
     verify_image: registry.fedoraproject.org/fedora:43
     manifest: build-order-hummingbird-desktops.yml

--- a/scripts/build-chain.sh
+++ b/scripts/build-chain.sh
@@ -352,17 +352,20 @@ derive_dist() {
             ;;
         # Hummingbird's own packages carry .hum1 — every one of the 16506
         # (name, evr, arch) tuples in its primary.xml does, measured
-        # 2026-08-06. .fc43 here is deliberately NOT that tag: it marks a
-        # TunaOS rebuild, and because "fc43" sorts below "hum1" for the same
-        # version, a rebuild can never shadow a package Hummingbird later
-        # starts shipping itself.
+        # 2026-08-06. .bfin1 here is deliberately NOT that tag: it marks a
+        # TunaOS/Bluefin rebuild, and because "bfin1" sorts below "hum1" for
+        # the same version ('b' < 'h'), a rebuild can never shadow a package
+        # Hummingbird later starts shipping itself. (Was .fc43 through
+        # 2026-08-29 -- changed because it read as a real Fedora 43 tie-in,
+        # which it never was; any alpha prefix sorting before "hum" is
+        # equally safe, this just says what the rebuild actually is.)
         #
         # It is not a claim about ABI. The buildroot ABI comes from
         # mock/hummingbird-ci.cfg, which tracks Fedora Rawhide because that is
         # what the target measurably tracks: glib2 2.89.3-1, systemd 261.2-1
         # and gcc 16.1.1 are Rawhide's versions, not F43's 2.86.5 / 258.10 /
         # 15.3.1. See docs/hummingbird-desktop-gap.md.
-        hummingbird-20251124*)   echo ".fc43" ;;
+        hummingbird-20251124*)   echo ".bfin1" ;;
         fedora-*)                 echo ".fc${target#fedora-}" | sed 's/-.*//' ;;
         centos-stream-10*|epel-10*|almalinux*-10*) echo ".el10" ;;
         centos-stream-9*|epel-9*) echo ".el9" ;;


### PR DESCRIPTION
## Summary
`.fc43` was picked solely because it sorts below the target's own `.hum1` tag in RPM version comparisons (rpmvercmp compares the alpha prefix as a string: `"fc" < "hum"`). It carried no real Fedora 43 tie-in — this buildroot tracks Rawhide (glib2 2.89.3-1, systemd 261.2-1, gcc 16.1.1), nowhere near Fedora 43's 2.86.5 / 258.10 / 15.3.1 — but reading it, people assumed it meant Fedora 43. Confusing, per feedback.

`.bfin1` (for the Bluefin parity this desktop targets) satisfies the same safety property: `"bfin" < "hum"` (`'b' < 'h'`), so a rebuild still can never shadow a package Hummingbird later starts shipping itself.

## Scope
Only the two authoritative sources:
- `scripts/build-chain.sh`'s `derive_dist()`
- `manifests/hummingbird-desktops.yaml`'s `target.dist`

plus a doc comment in `manifests/package-builds.yaml`, then regenerated `build-order-hummingbird-desktops.yml` and `docs/hummingbird-desktop-gap.json` via `measure-target-gap.py` so the generated artifacts match.

Deliberately left untouched: `mock/hummingbird-ci*.cfg` and test fixture data recording real, already-published `.fc43` NVRs as historical measurements. Already-published `.fc43` packages are unaffected; only builds from this commit forward stamp `.bfin1`.

## Test plan
- [x] `bash -n scripts/build-chain.sh`
- [x] Direct `derive_dist()` check against the real manifest
- [x] Full `pytest tests/` — no new failures
- [ ] CI build for `hummingbird-ci` target

---
_Generated by [Claude Code](https://claude.ai/code)_