### PR TITLE
fix(ci): cancel a PR's stale build the moment it merges or closes

### DIFF
--- a/.github/workflows/package-factory.yml
+++ b/.github/workflows/package-factory.yml
@@ -1,7 +1,20 @@
 name: Package Factory
 
 on:
+  # `closed` added alongside the default [opened, synchronize, reopened] so a
+  # merged (or simply closed) PR gets ONE MORE event on this exact
+  # concurrency group (see below: pull_request's group key is
+  # refs/pull/N/merge, stable across the PR's whole lifetime). That new run
+  # does no real work (the `plan` job short-circuits to zero packages for a
+  # closed action) but its mere queuing is what makes `cancel-in-progress`
+  # kill the PR's own still-running build -- which otherwise runs to
+  # completion or its 360m timeout for a result nothing will ever read,
+  # since nothing re-triggers this workflow once a PR has no more commits.
+  # Measured: PRs #590-#609 this session left 18 such runs alive for hours
+  # after merging, several still mid-build, holding runners a genuinely
+  # queued nightly family build then waited behind for over an hour.
   pull_request:
+    types: [opened, synchronize, reopened, closed]
   # NOT merge_group. A cell build takes ~2.5h; the merge queue's CI timeout is
   # about an hour, so the queue would evict src/-touching PRs before completion.
   # The PR gate already builds refs/pull/N/merge -- the merge result -- and the
@@ -138,10 +151,30 @@ jobs:
           REQUESTED_CELL: ${{ inputs.cell || '' }}
           REQUESTED_SELECTOR: ${{ inputs.selector || '' }}
           EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action || '' }}
           SCHEDULE: ${{ github.event.schedule || '' }}
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
         run: |
           set -euo pipefail
+          # This run's only job is to occupy the refs/pull/N/merge concurrency
+          # group so cancel-in-progress kills whatever build the PR's last
+          # real (opened/synchronize/reopened) event left running -- see the
+          # `on.pull_request.types` comment above. Emit the same zero-package
+          # shape plan-package-factory.py would for an empty selection and
+          # stop, rather than spending a checkout+plan invocation to arrive
+          # at the same answer.
+          if [ "$EVENT_NAME" = pull_request ] && [ "$EVENT_ACTION" = closed ]; then
+            {
+              echo "count=0"
+              echo 'matrix_0={"include":[]}'
+              echo "count_0=0"
+              echo 'matrix_1={"include":[]}'
+              echo "count_1=0"
+              echo 'matrix_2={"include":[]}'
+              echo "count_2=0"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           args=(--github-output "$GITHUB_OUTPUT")
           [ ! -f changed-files.txt ] || args+=(--changed-files changed-files.txt)
           [ -z "${BASE_SHA:-}" ] || args+=(--base "$BASE_SHA")


### PR DESCRIPTION
## Summary
Root cause: `on.pull_request:` only fires on the default `[opened, synchronize, reopened]` types. Package Factory's concurrency group for pull_request events is keyed on `github.ref`, which for a PR is the stable `refs/pull/N/merge` — constant across that PR's whole lifetime. So new commits correctly cancel the PR's own prior run via `cancel-in-progress`, but once a PR merges (or is closed without merging), nothing ever fires another event on that same ref again, and the last run just keeps going to completion or its 360m timeout for a result nothing will ever read.

Measured this session: merging PRs #590-#609 in quick succession left 18 such runs alive for hours afterward, several still mid-build, some holding runners a genuinely-needed nightly full-family build then queued behind for over an hour.

A shorter timeout would only bound the waste, not remove it — and would risk false failures on legitimately slow builds (mozjs140, gnome-shell both ran well past an hour this session). The actual fix: add `closed` to `pull_request`'s trigger types, and make the `plan` job short-circuit to zero planned packages for a closed action instead of invoking the real planner. The new run does no work, but it queues against the identical `refs/pull/N/merge` concurrency group, so `cancel-in-progress` kills the stale real build for free — no manual `gh run cancel` needed going forward.

## Test plan
- [x] `actionlint` clean
- [x] Relevant pytest suites pass (workflow-shell-quoting, caller-grants-what-callee-asks tests)
- [x] Full `pytest tests/` — no new failures
- [ ] Verify on the next PR merge that its build run gets auto-cancelled

---
_Generated by [Claude Code](https://claude.ai/code)_