### PR TITLE
feat(publish): stage build-chain RPMs in ORAS so builds can fan out safely

### DIFF
--- a/.github/workflows/publish-build-chain-rpms.yml
+++ b/.github/workflows/publish-build-chain-rpms.yml
@@ -83,6 +83,9 @@ jobs:
 
   build:
     needs: plan
+    permissions:
+      contents: read
+      packages: write
     # The planner's matrix.runner is a GitHub-hosted label; on the runs-on
     # path it is translated to the equivalent AWS pool entry rather than
     # threaded through the planner (the planner's output is arch selection,
@@ -238,6 +241,41 @@ jobs:
           CHAIN_BUDGET_SECONDS: ${{ inputs.runner != 'runs-on' && 16200 || 34200 }}
         if: steps.verdict.outputs.hit != 'true'
         run: bash scripts/run-package-factory-cell.sh
+      # Stage whatever this leg banked in ORAS, so an independent one-off
+      # dispatch (built to fill a single missing package, say) doesn't have
+      # to become the one process serialized on the R2 bucket to be useful
+      # -- the publish job's own "pull-all" step picks this up before its
+      # normal sync. See scripts/oras-stage-artifacts.py's module docstring
+      # for why concurrent pushes here are safe where concurrent `rclone
+      # sync`s are not.
+      #
+      # always(), same reasoning as the partial-chain upload below: a leg
+      # that built 40 of 50 packages before its budget ran out banked 40
+      # real, already-verified RPMs, and staging them must not depend on
+      # the leg's own overall outcome.
+      - name: Install oras
+        if: always()
+        run: |
+          set -euo pipefail
+          arch="${{ matrix.architecture == 'aarch64' && 'arm64' || 'amd64' }}"
+          version=1.3.4
+          curl -fsSLO "https://github.com/oras-project/oras/releases/download/v${version}/oras_${version}_linux_${arch}.tar.gz"
+          case "$arch" in
+            amd64) echo "f27adb935022d94df8dc77719c322dda592c78a0d57a6f7dcdd8d900b248c454  oras_${version}_linux_${arch}.tar.gz" | sha256sum -c ;;
+            arm64) echo "15702c6e3a4a56a8bd8ac5c17efdbcab56d9bada661ccbcf017f5b10c1d89399  oras_${version}_linux_${arch}.tar.gz" | sha256sum -c ;;
+          esac
+          sudo tar -xzf "oras_${version}_linux_${arch}.tar.gz" -C /usr/local/bin oras
+          rm "oras_${version}_linux_${arch}.tar.gz"
+      - name: Log in to ghcr.io for ORAS
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "${GITHUB_TOKEN}" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
+      - name: Stage banked RPMs in ORAS
+        if: always()
+        env:
+          BUILD_CHAIN_ORAS_PUSH: "1"
+        run: python3 scripts/oras-stage-artifacts.py push ".factory/${{ matrix.id }}/artifacts"
       # always(): the wave is every RPM the chain banked, and a chain that
       # failed ONE package out of 674 still banked the rest. Without it this
       # upload skips on any build failure, the publish job starves, and the
@@ -294,6 +332,9 @@ jobs:
 
   publish:
     needs: [plan, build]
+    permissions:
+      contents: read
+      packages: read
     # Publish whatever the build banked, even when the build job itself is
     # red: one failed package must not hold the other built packages hostage,
     # or the chain can never accumulate across legs (#544). cancelled() still
@@ -378,6 +419,26 @@ jobs:
         with:
           name: publish-rpm-${{ matrix.id }}
           path: staged
+      # Pull in whatever ANY leg staged to ORAS -- not just this run's own
+      # `build` job above, but any independent one-off dispatch that pushed
+      # results in the meantime (scripts/oras-stage-artifacts.py's module
+      # docstring explains why those can run concurrently while only this
+      # publish job stays serialized). publish-rpm-wave.sh globs `staged/`
+      # recursively, so landing pulls in a subdirectory is picked up the
+      # same as the artifact download above.
+      - name: Install oras
+        run: |
+          set -euo pipefail
+          curl -fsSLO "https://github.com/oras-project/oras/releases/download/v1.3.4/oras_1.3.4_linux_amd64.tar.gz"
+          echo "f27adb935022d94df8dc77719c322dda592c78a0d57a6f7dcdd8d900b248c454  oras_1.3.4_linux_amd64.tar.gz" | sha256sum -c
+          sudo tar -xzf oras_1.3.4_linux_amd64.tar.gz -C /usr/local/bin oras
+          rm oras_1.3.4_linux_amd64.tar.gz
+      - name: Log in to ghcr.io for ORAS
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "${GITHUB_TOKEN}" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
+      - name: Pull everything staged in ORAS
+        run: python3 scripts/oras-stage-artifacts.py pull-all staged/oras
       - name: Sign and index
         run: |
           set -euo pipefail

--- a/scripts/oras-stage-artifacts.py
+++ b/scripts/oras-stage-artifacts.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Stage build-chain RPM artifacts in ORAS so independent builds don't race the publish repo.
+
+publish-build-chain-rpms.yml's `rclone sync` into R2 must be serialized --
+two of them running at once can delete each other's packages (#124 /
+INCIDENT-repo-wipe-gnome), which is why that workflow's concurrency group
+allows only one publisher at a time. Building has no such constraint: many
+independent package builds (a nightly run, a one-off dispatch for a single
+missing package, a manual retry) can run concurrently without conflict, as
+long as they don't all try to be the one process that syncs to R2.
+
+This module is the middle layer that lets them not have to be. Every build
+job pushes its own successfully-built RPMs here, as independent ORAS
+artifacts on ghcr.io -- concurrent pushes of different tags don't race each
+other the way `rclone sync` does. The single serialized publish job then
+pulls everything currently staged before its normal createrepo+sync, so
+publishing itself is exactly as serialized as before; only the building
+that feeds it is free to fan out.
+
+push <dir>: push every *.rpm in <dir> to the shared ORAS repo, tagged by a
+sanitized NVR. RPM release fields can carry `~` (prerelease, e.g. 51~beta)
+and `^` (snapshot/post-release), neither of which is a valid OCI tag
+character -- collapsed to `_` here. Nothing is actually lost by that: the
+pushed file keeps its real name via ORAS's own title annotation regardless
+of what the tag looks like, and the tag only needs to be unique and valid,
+not reversible. (Two distinct RPM names collapsing to the identical
+sanitized tag is possible in principle -- it would need two builds to
+differ ONLY in a character this collapses, in the same position -- but
+that is not a pattern real RPM naming produces, and see the module
+docstring's incident note for why the collision that actually matters,
+concurrent *publish*, is guarded elsewhere.)
+
+pull-all <dir>: list every tag currently staged and pull each one into
+<dir>, restoring original filenames. Best-effort per tag: one vanished or
+corrupt entry must not stop the publish job from picking up everything
+else that's staged.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ORAS_REPO = "ghcr.io/tuna-os/build-chain-artifacts"
+# Opt-in, like tideforge_cache.ORAS_PUSH_ENABLED: a staging push must never
+# be what makes a local or test run try to reach the network.
+ORAS_PUSH_ENABLED = os.environ.get("BUILD_CHAIN_ORAS_PUSH", "") == "1"
+
+_UNSAFE_TAG_CHARS = re.compile(r"[^a-zA-Z0-9._-]")
+
+
+def sanitize_tag(rpm_name: str) -> str:
+    """Map an RPM filename to a valid OCI tag (see module docstring)."""
+    stem = rpm_name.removesuffix(".rpm")
+    tag = _UNSAFE_TAG_CHARS.sub("_", stem)
+    if not tag or not (tag[0].isalnum() or tag[0] == "_"):
+        tag = f"x{tag}"
+    return tag
+
+
+def push(artifacts_dir: Path) -> int:
+    """Push every *.rpm in artifacts_dir to the shared ORAS repo.
+
+    Best-effort like tideforge_cache.oras_push: a staging push must never
+    fail the build that produced real, already-verified RPMs. Returns the
+    count of RPMs successfully staged.
+    """
+    if not ORAS_PUSH_ENABLED:
+        return 0
+    pushed = 0
+    for rpm in sorted(artifacts_dir.glob("*.rpm")):
+        tag = f"{ORAS_REPO}:{sanitize_tag(rpm.name)}"
+        try:
+            subprocess.run(
+                ["oras", "push", "--plain-http=false", tag, str(rpm)],
+                check=True, capture_output=True, text=True, timeout=120,
+            )
+            pushed += 1
+        except (subprocess.CalledProcessError, FileNotFoundError,
+                subprocess.TimeoutExpired, OSError) as exc:
+            print(f"oras-stage-artifacts: push failed for {rpm.name}: {exc}", file=sys.stderr)
+    return pushed
+
+
+def list_tags() -> list[str]:
+    """List every tag currently staged. Empty on any failure -- an
+    unreachable registry or an empty repo both mean "nothing to pull",
+    not an error the caller should propagate."""
+    try:
+        result = subprocess.run(
+            ["oras", "repo", "tags", "--plain-http=false", ORAS_REPO],
+            check=True, capture_output=True, text=True, timeout=60,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError,
+            subprocess.TimeoutExpired, OSError):
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def pull_all(output_dir: Path) -> int:
+    """Pull every currently-staged artifact into output_dir.
+
+    Returns the count of tags successfully pulled.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    pulled = 0
+    for tag in list_tags():
+        try:
+            subprocess.run(
+                ["oras", "pull", "--plain-http=false", f"{ORAS_REPO}:{tag}",
+                 "--output", str(output_dir)],
+                check=True, capture_output=True, text=True, timeout=120,
+            )
+            pulled += 1
+        except (subprocess.CalledProcessError, FileNotFoundError,
+                subprocess.TimeoutExpired, OSError) as exc:
+            print(f"oras-stage-artifacts: pull failed for tag {tag}: {exc}", file=sys.stderr)
+    return pulled
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    push_parser = subparsers.add_parser("push", help="stage every *.rpm in a directory")
+    push_parser.add_argument("artifacts_dir", type=Path)
+
+    pull_parser = subparsers.add_parser("pull-all", help="pull every currently-staged artifact")
+    pull_parser.add_argument("output_dir", type=Path)
+
+    args = parser.parse_args()
+    if args.command == "push":
+        count = push(args.artifacts_dir)
+        print(f"staged {count} RPM(s) to {ORAS_REPO}")
+    elif args.command == "pull-all":
+        count = pull_all(args.output_dir)
+        print(f"pulled {count} staged artifact(s) from {ORAS_REPO}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_oras_stage_artifacts.py
+++ b/tests/test_oras_stage_artifacts.py
@@ -1,0 +1,132 @@
+import importlib.util
+import subprocess
+from pathlib import Path
+
+
+def load_script(name):
+    path = Path(__file__).parent.parent / "scripts" / name
+    spec = importlib.util.spec_from_file_location(name.replace("-", "_").removesuffix(".py"), path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+oras_stage = load_script("oras-stage-artifacts.py")
+
+
+def test_sanitize_tag_strips_rpm_suffix():
+    assert oras_stage.sanitize_tag("vte291-0.84.1-1.bfin1.x86_64.rpm") == \
+        "vte291-0.84.1-1.bfin1.x86_64"
+
+
+def test_sanitize_tag_collapses_tilde():
+    tag = oras_stage.sanitize_tag("gnome-shell-51~beta-2.bfin1.x86_64.rpm")
+    assert "~" not in tag
+    assert tag == "gnome-shell-51_beta-2.bfin1.x86_64"
+
+
+def test_sanitize_tag_collapses_caret():
+    tag = oras_stage.sanitize_tag("quickshell-0.2.1^git20260209.dacfa9d.fc43.x86_64.rpm")
+    assert "^" not in tag
+
+
+def test_sanitize_tag_is_valid_oci_tag_charset():
+    import re
+    valid = re.compile(r"^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$")
+    for name in (
+        "gnome-shell-51~beta-2.bfin1.x86_64.rpm",
+        "mozjs140-140.13.0-3.bfin1.x86_64.rpm",
+        "~starts-with-tilde-1-1.bfin1.noarch.rpm",
+    ):
+        assert valid.match(oras_stage.sanitize_tag(name)), name
+
+
+def test_push_noop_when_disabled(tmp_path, monkeypatch):
+    monkeypatch.setattr(oras_stage, "ORAS_PUSH_ENABLED", False)
+    (tmp_path / "foo-1-1.bfin1.x86_64.rpm").write_bytes(b"rpm bytes")
+    assert oras_stage.push(tmp_path) == 0
+
+
+def test_push_calls_oras_once_per_rpm(tmp_path, monkeypatch):
+    monkeypatch.setattr(oras_stage, "ORAS_PUSH_ENABLED", True)
+    (tmp_path / "foo-1-1.bfin1.x86_64.rpm").write_bytes(b"a")
+    (tmp_path / "bar-2-1.bfin1.x86_64.rpm").write_bytes(b"b")
+    (tmp_path / "not-an-rpm.txt").write_text("ignore me")
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert oras_stage.push(tmp_path) == 2
+    assert len(calls) == 2
+    for cmd in calls:
+        assert cmd[:3] == ["oras", "push", "--plain-http=false"]
+        assert cmd[3].startswith(f"{oras_stage.ORAS_REPO}:")
+
+
+def test_push_continues_after_one_failure(tmp_path, monkeypatch):
+    monkeypatch.setattr(oras_stage, "ORAS_PUSH_ENABLED", True)
+    (tmp_path / "foo-1-1.bfin1.x86_64.rpm").write_bytes(b"a")
+    (tmp_path / "bar-2-1.bfin1.x86_64.rpm").write_bytes(b"b")
+
+    def fake_run(cmd, **kwargs):
+        if "foo" in cmd[3]:
+            raise subprocess.CalledProcessError(1, cmd)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert oras_stage.push(tmp_path) == 1
+
+
+def test_list_tags_parses_output(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(cmd, 0, stdout="tag-one\ntag-two\n\n")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert oras_stage.list_tags() == ["tag-one", "tag-two"]
+
+
+def test_list_tags_empty_on_failure(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        raise subprocess.CalledProcessError(1, cmd)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert oras_stage.list_tags() == []
+
+
+def test_pull_all_pulls_every_tag(tmp_path, monkeypatch):
+    monkeypatch.setattr(oras_stage, "list_tags", lambda: ["tag-one", "tag-two"])
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert oras_stage.pull_all(tmp_path) == 2
+    assert len(calls) == 2
+    assert calls[0][:3] == ["oras", "pull", "--plain-http=false"]
+    assert calls[0][3] == f"{oras_stage.ORAS_REPO}:tag-one"
+    assert str(tmp_path) in calls[0]
+
+
+def test_pull_all_continues_after_one_failure(tmp_path, monkeypatch):
+    monkeypatch.setattr(oras_stage, "list_tags", lambda: ["good", "bad"])
+
+    def fake_run(cmd, **kwargs):
+        if "bad" in cmd[3]:
+            raise subprocess.TimeoutExpired(cmd, 120)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert oras_stage.pull_all(tmp_path) == 1
+
+
+def test_pull_all_creates_output_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(oras_stage, "list_tags", lambda: [])
+    target = tmp_path / "nested" / "output"
+    assert oras_stage.pull_all(target) == 0
+    assert target.is_dir()


### PR DESCRIPTION
## Summary
`publish-build-chain-rpms.yml`'s `rclone sync` into R2 must stay serialized — two running at once can delete each other's packages (#124 / INCIDENT-repo-wipe-gnome), which is exactly why that workflow shares one concurrency group with `publish-tideforge-rpms.yml`. But building has no such constraint: many independent legs (the nightly, a one-off dispatch built to fill a single missing package, a manual retry) can build concurrently without conflict — they only conflict if they all try to be the process that syncs to R2.

Adds `scripts/oras-stage-artifacts.py` as the layer in between: every `build` leg pushes its own successfully-built RPMs to `ghcr.io/tuna-os/build-chain-artifacts` as independent ORAS artifacts (concurrent pushes of different tags don't race the way `rclone sync` does), tagged by a sanitized NVR since RPM releases can carry `~`/`^` which aren't valid OCI tag characters — the pushed file keeps its real name via ORAS's own title annotation regardless. The single serialized `publish` job now pulls everything currently staged before its normal sign+index+sync, so publishing itself stays exactly as serialized as before; only the building that feeds it is free to fan out.

This follows an existing pattern in the repo: `scripts/tideforge_cache.py` already does content-addressed ORAS push/pull against `ghcr.io/tuna-os/tideforge-sources` for source caching.

## Scope
- `build` job stages under `always()` (a leg that built 40 of 50 packages before its budget ran out banked 40 real RPMs — same reasoning as the existing partial-chain upload a few lines below it)
- `publish` job pulls everything into `staged/oras` before `publish-rpm-wave.sh` runs (it globs `staged/` recursively, so this needs no changes there)
- Job-level `packages: write`/`packages: read` added where each is actually used
- ORAS CLI installed from a checksum-verified release tarball (v1.3.4), matching the existing `rclone` install pattern in the same file rather than adding a third-party Action dependency

## Test plan
- [x] 12 new unit tests for `oras-stage-artifacts.py` (sanitization, push/pull best-effort semantics, failure isolation)
- [x] `actionlint` clean
- [x] Full `pytest tests/` — no new failures
- [ ] Verify a real dispatch stages to ORAS and the next publish run picks it up

---
_Generated by [Claude Code](https://claude.ai/code)_